### PR TITLE
Upgrade debian

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN touch src/main.rs
 RUN cargo build --release
 
 
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 COPY --from=build-stage /bookshelf-api/target/release/bookshelf-api /
 
 RUN apt update


### PR DESCRIPTION
Fix libssl issue

```
/bookshelf-api: error while loading shared libraries: libssl.so.3: cannot open shared object file: No such file or directory
```