### PR TITLE
Add minimumReleaseAge for cargo updates in renovate config

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -18,6 +18,10 @@
       "matchUpdateTypes": ["patch"],
       "matchCurrentVersion": "/^0\\./",
       "groupName": "{{manager}} non-major"
+    },
+    {
+      "matchManagers": ["cargo"],
+      "minimumReleaseAge": "3 days"
     }
   ],
   "reviewers": ["hiterm"],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **その他**
  * Cargoで管理されるパッケージ更新に対し、リリースから3日間の最小待機期間を設定し、アップデートの安定性向上を図りました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->