### PR TITLE
chore: exclude self-image and Rust dockerfile from renovate

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -21,7 +21,16 @@
     {
       "matchManagers": ["cargo"],
       "minimumReleaseAge": "3 days"
-    }
+    },
+    {
+      "matchPackageNames": ["ghcr.io/hiterm/bookshelf-api"],
+      "enabled": false
+    },
+    {
+      "matchPackageNames": ["rust"],
+      "matchManagers": ["dockerfile"],
+      "enabled": false
+    },
   ],
   "reviewers": ["hiterm"],
 }


### PR DESCRIPTION
## Summary

- Disable renovate for `ghcr.io/hiterm/bookshelf-api` (own app image referenced in `rendercom/Dockerfile`) — closes #134
- Disable renovate for `rust` dockerfile image (managed manually) — closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * 自動更新管理の設定を更新しました。特定のコンテナイメージとDockerfile環境の依存関係について、自動更新を無効化する新しいルールを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->