### PR TITLE
Update Rust edition from 2021 to 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bookshelf-api"
 version = "2.2.0"
-edition = "2021"
+edition = "2024"
 default-run = "bookshelf-api"
 
 [features]

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bookshelf-e2e"
 version = "2.2.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 anyhow = "1.0"

--- a/src/infrastructure/book_repository.rs
+++ b/src/infrastructure/book_repository.rs
@@ -278,7 +278,7 @@ impl BookRepository for PgBookRepository {
             _ => {
                 return Err(DomainError::Unexpected(String::from(
                     "rows_affected is greater than 1.",
-                )))
+                )));
             }
         }
 
@@ -336,7 +336,7 @@ impl BookRepository for PgBookRepository {
             _ => {
                 return Err(DomainError::Unexpected(String::from(
                     "rows_affected is greater than 1.",
-                )))
+                )));
             }
         }
 
@@ -363,8 +363,8 @@ mod tests {
 
     use super::*;
     use time::{
-        macros::{date, time},
         PrimitiveDateTime,
+        macros::{date, time},
     };
 
     #[sqlx::test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,18 +1,18 @@
 use std::{net::SocketAddr, sync::Arc};
 
 use axum::{
-    routing::{get, post},
     Extension, Router,
+    routing::{get, post},
 };
 use bookshelf_api::{
-    dependency_injection::{dependency_injection, MI, QI},
+    dependency_injection::{MI, QI, dependency_injection},
     presentation::handler::graphql::{graphql_handler, graphql_playground_handler},
     presentation::handler::user::me_handler,
     presentation::{app_state::AppState, extractor::claims::Auth0Config},
 };
 use http::{
-    header::{ACCEPT, AUTHORIZATION, CONTENT_TYPE},
     HeaderValue, Method,
+    header::{ACCEPT, AUTHORIZATION, CONTENT_TYPE},
 };
 use sqlx::postgres::PgPoolOptions;
 use tower::ServiceBuilder;

--- a/src/presentation/extractor/claims.rs
+++ b/src/presentation/extractor/claims.rs
@@ -3,15 +3,14 @@ use axum::extract::FromRequestParts;
 use axum::http::request::Parts;
 use axum::response::{IntoResponse, Response};
 use axum::{Json, RequestPartsExt};
-use axum_extra::headers::authorization::Bearer;
-use axum_extra::headers::Authorization;
 use axum_extra::TypedHeader;
+use axum_extra::headers::Authorization;
+use axum_extra::headers::authorization::Bearer;
 use derive_more::Display;
 use http::{StatusCode, Uri};
 use jsonwebtoken::{
-    decode, decode_header,
+    Algorithm, DecodingKey, Validation, decode, decode_header,
     jwk::{AlgorithmParameters, JwkSet},
-    Algorithm, DecodingKey, Validation,
 };
 use serde::Deserialize;
 use serde_json::json;
@@ -153,7 +152,7 @@ async fn fetch_jwks(domain: &str) -> Result<JwkSet, MyError> {
         Err(e) => {
             return Err(MyError {
                 message: format!("TODO1: {}", e),
-            })
+            });
         }
     };
     match response.json().await {

--- a/src/presentation/graphql/mutation.rs
+++ b/src/presentation/graphql/mutation.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use async_graphql::{Context, Object, ID};
+use async_graphql::{Context, ID, Object};
 
 use crate::{
     presentation::{error::PresentationalError, extractor::claims::Claims},

--- a/src/presentation/graphql/object.rs
+++ b/src/presentation/graphql/object.rs
@@ -1,6 +1,6 @@
 use async_graphql::dataloader::DataLoader;
 use async_graphql::{ComplexObject, Context, Enum, Result};
-use async_graphql::{InputObject, SimpleObject, ID};
+use async_graphql::{ID, InputObject, SimpleObject};
 
 use crate::common::types::{BookFormat as CommonBookFormat, BookStore as CommonBookStore};
 use crate::dependency_injection::QI;

--- a/src/presentation/graphql/query.rs
+++ b/src/presentation/graphql/query.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use async_graphql::{Context, Object, ID};
+use async_graphql::{Context, ID, Object};
 
 use crate::{
     presentation::{error::PresentationalError, extractor::claims::Claims},

--- a/src/presentation/handler/graphql.rs
+++ b/src/presentation/handler/graphql.rs
@@ -1,12 +1,12 @@
 use async_graphql::{
-    dataloader::DataLoader,
-    http::{playground_source, GraphQLPlaygroundConfig},
     EmptySubscription, Schema,
+    dataloader::DataLoader,
+    http::{GraphQLPlaygroundConfig, playground_source},
 };
 use async_graphql_axum::{GraphQLRequest, GraphQLResponse};
 use axum::{
-    response::{Html, IntoResponse},
     Extension,
+    response::{Html, IntoResponse},
 };
 
 use crate::{

--- a/src/presentation/handler/user.rs
+++ b/src/presentation/handler/user.rs
@@ -3,7 +3,7 @@
 //! This module provides the handler for retrieving the current authenticated
 //! user's information from JWT claims.
 
-use axum::{extract::State, Json};
+use axum::{Json, extract::State};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 

--- a/src/use_case/interactor/book.rs
+++ b/src/use_case/interactor/book.rs
@@ -80,7 +80,7 @@ where
                     entity_type: "book",
                     entity_id: book_data.id,
                     user_id: user_id.into_string(),
-                })
+                });
             }
         };
 


### PR DESCRIPTION
Apply edition 2024 import sorting and trailing semicolon formatting
required by rustfmt under the new edition. All 33 tests pass.

https://claude.ai/code/session_01Y7SWRagbs6dLdxoUe3W85U

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * Rustエディションを2021から2024に更新しました。

* **Style**
  * コード内の複数のインポートと書式を整理しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->