### PR TITLE
fix: add workflows permission to update-rust workflow

### DIFF
--- a/.github/workflows/update-rust.yml
+++ b/.github/workflows/update-rust.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  workflows: write
 
 jobs:
   update-rust:


### PR DESCRIPTION
The workflow modifies .github/workflows/*.yml files but lacked the
`workflows: write` permission required to push such changes.

https://claude.ai/code/session_01U9JUHRgmZLsC9G9jkwwYZ8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **チャージ**
  * 自動化されたシステムプロセスの権限設定を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->