### PR TITLE
Add code coverage tracking with cargo-llvm-cov and codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,30 @@ jobs:
           docker network remove test-network
           exit 1
 
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+    env:
+      DATABASE_URL: postgres://bookshelf:password@localhost:5432/bookshelf
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: dtolnay/rust-toolchain@2ea1b3bdd0261867664fd125505456a7b9c3385c # 1.93.1
+        with:
+          components: llvm-tools-preview
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - uses: taiki-e/install-action@735e5933943122bc89878bce93fb2cb5ef870864 # cargo-llvm-cov
+        with:
+          tool: cargo-llvm-cov
+      - run: sudo systemctl start postgresql.service
+      - run: pg_isready
+      - run: sudo -u postgres psql --command="CREATE USER bookshelf WITH SUPERUSER PASSWORD 'password'" --command="\du" postgres
+      - run: sudo -u postgres createdb --owner=bookshelf bookshelf
+      - run: cargo llvm-cov --all-features --locked --lcov --output-path lcov.info
+      - uses: codecov/codecov-action@v5
+        with:
+          files: lcov.info
+          fail_ci_if_error: true
+
   fmt:
     name: Rustfmt
     runs-on: ubuntu-latest

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,14 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: auto
+        threshold: 1%
+comment:
+  layout: "reach,diff,flags,files"
+  behavior: default
+  require_changes: false


### PR DESCRIPTION
## Summary
This PR adds automated code coverage measurement and reporting to the CI/CD pipeline using `cargo-llvm-cov` and Codecov integration.

## Key Changes
- **New CI workflow job**: Added a `coverage` job to the GitHub Actions workflow that:
  - Sets up a PostgreSQL database (matching the existing test infrastructure)
  - Installs `cargo-llvm-cov` for Rust code coverage measurement
  - Generates LCOV coverage reports with all features enabled
  - Uploads coverage data to Codecov for tracking and reporting

- **Codecov configuration**: Added `codecov.yml` to configure coverage thresholds and reporting:
  - Sets minimum coverage targets at 1% for both project and patch coverage
  - Configures comment layout to show reach, diff, flags, and files
  - Enables default comment behavior without requiring changes

## Implementation Details
- The coverage job runs on `ubuntu-latest` and uses the same PostgreSQL setup as the existing integration tests
- Coverage is generated using `cargo llvm-cov` with `--all-features` and `--locked` flags to ensure comprehensive and reproducible results
- The generated LCOV report is uploaded to Codecov with strict error handling (`fail_ci_if_error: true`)

https://claude.ai/code/session_015MKvU3NFBJXob871FaFGme

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **テスト**
  * コードカバレッジの自動測定とレポート機能を追加しました。これにより、ソフトウェアの品質を継続的に監視できるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->