### PR TITLE
Fix renovate config validation command

### DIFF
--- a/.github/workflows/renovate-config-validation.yml
+++ b/.github/workflows/renovate-config-validation.yml
@@ -20,4 +20,4 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - run: npx --yes renovate-config-validator renovate.json5
+      - run: npx --yes --package renovate -- renovate-config-validator


### PR DESCRIPTION
Replace non-existent renovate-config-validator package with the
correct invocation: npx --yes --package renovate -- renovate-config-validator

https://claude.ai/code/session_01AB3bJGziwVgZwypgNT9d6F

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * CI/CD ワークフローの構成検証コマンドを更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->