### PR TITLE
feat(renovate): group rust-toolchain.toml and Dockerfile rust version updates

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -38,7 +38,7 @@
     },
     {
       // Keep rust-toolchain.toml and Dockerfile rust base image in sync
-      "matchPackageNames": ["rust"],
+      "matchDepNames": ["rust"],
       "matchManagers": ["custom.regex", "dockerfile"],
       "groupName": "rust version"
     },


### PR DESCRIPTION
Add a customManagers regex entry to track Rust toolchain version in
rust-toolchain.toml via github-releases datasource. Enable Dockerfile
rust image updates and group both under a single "rust version" PR so
all Rust versions stay in sync across files.

https://claude.ai/code/session_01KgyW4YoF4Tp1rbDGSc9gSf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * Rust ツールチェーン設定ファイルからのバージョン検出機能を追加しました。
  * Rust 関連のアップデートを一括してグループ化し、管理を効率化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->