### PR TITLE
Fix user isolation bug and add isolation tests

### DIFF
--- a/src/infrastructure/author_repository.rs
+++ b/src/infrastructure/author_repository.rs
@@ -131,7 +131,7 @@ mod tests {
         let user_repository = PgUserRepository::new(pool.clone());
         let author_repository = PgAuthorRepository::new(pool.clone());
 
-        let user_id = prepare_user(&user_repository).await?;
+        let user_id = prepare_user(&user_repository, "user1").await?;
 
         let author_id = AuthorId::try_from("e324be11-5b77-4ba6-8423-9f27e2d228f1")?;
         let author_name = AuthorName::new(String::from("author1"))?;
@@ -150,7 +150,7 @@ mod tests {
         let user_repository = PgUserRepository::new(pool.clone());
         let author_repository = PgAuthorRepository::new(pool.clone());
 
-        let user_id = prepare_user(&user_repository).await?;
+        let user_id = prepare_user(&user_repository, "user1").await?;
 
         let author_id = AuthorId::try_from("e324be11-5b77-4ba6-8423-9f27e2d228f1")?;
         let author_name = AuthorName::new(String::from("author1"))?;
@@ -175,7 +175,7 @@ mod tests {
         let user_repository = PgUserRepository::new(pool.clone());
         let author_repository = PgAuthorRepository::new(pool.clone());
 
-        let user_id = prepare_user(&user_repository).await?;
+        let user_id = prepare_user(&user_repository, "user1").await?;
 
         let author_id1 = AuthorId::try_from("e324be11-5b77-4ba6-8423-9f27e2d228f1")?;
         let author_name = AuthorName::new(String::from("author1"))?;
@@ -201,8 +201,66 @@ mod tests {
         Ok(())
     }
 
-    async fn prepare_user(repository: &PgUserRepository) -> Result<UserId, DomainError> {
-        let user_id = UserId::new(String::from("user1"))?;
+    #[sqlx::test]
+    async fn find_by_id_does_not_return_other_users_author(pool: PgPool) -> anyhow::Result<()> {
+        let user_repository = PgUserRepository::new(pool.clone());
+        let author_repository = PgAuthorRepository::new(pool.clone());
+
+        let user1_id = prepare_user(&user_repository, "user1").await?;
+        let user2_id = prepare_user(&user_repository, "user2").await?;
+
+        let author_id = AuthorId::try_from("e324be11-5b77-4ba6-8423-9f27e2d228f1")?;
+        let author = Author::new(author_id.clone(), AuthorName::new("author1".to_string())?)?;
+        author_repository.create(&user1_id, &author).await?;
+
+        let result = author_repository.find_by_id(&user2_id, &author_id).await?;
+        assert_eq!(result, None);
+
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn find_all_does_not_return_other_users_authors(pool: PgPool) -> anyhow::Result<()> {
+        let user_repository = PgUserRepository::new(pool.clone());
+        let author_repository = PgAuthorRepository::new(pool.clone());
+
+        let user1_id = prepare_user(&user_repository, "user1").await?;
+        let user2_id = prepare_user(&user_repository, "user2").await?;
+
+        let author_id = AuthorId::try_from("e324be11-5b77-4ba6-8423-9f27e2d228f1")?;
+        let author = Author::new(author_id, AuthorName::new("author1".to_string())?)?;
+        author_repository.create(&user1_id, &author).await?;
+
+        let result = author_repository.find_all(&user2_id).await?;
+        assert_eq!(result.len(), 0);
+
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn find_by_ids_as_hash_map_does_not_return_other_users_authors(
+        pool: PgPool,
+    ) -> anyhow::Result<()> {
+        let user_repository = PgUserRepository::new(pool.clone());
+        let author_repository = PgAuthorRepository::new(pool.clone());
+
+        let user1_id = prepare_user(&user_repository, "user1").await?;
+        let user2_id = prepare_user(&user_repository, "user2").await?;
+
+        let author_id = AuthorId::try_from("e324be11-5b77-4ba6-8423-9f27e2d228f1")?;
+        let author = Author::new(author_id.clone(), AuthorName::new("author1".to_string())?)?;
+        author_repository.create(&user1_id, &author).await?;
+
+        let result = author_repository
+            .find_by_ids_as_hash_map(&user2_id, &[author_id])
+            .await?;
+        assert_eq!(result.len(), 0);
+
+        Ok(())
+    }
+
+    async fn prepare_user(repository: &PgUserRepository, id: &str) -> Result<UserId, DomainError> {
+        let user_id = UserId::new(String::from(id))?;
         let user = User::new(user_id.clone());
         repository.create(&user).await?;
 

--- a/src/infrastructure/book_repository.rs
+++ b/src/infrastructure/book_repository.rs
@@ -524,18 +524,36 @@ mod tests {
         let user1_id = prepare_user(&user_repository, "user1").await?;
         let user2_id = prepare_user(&user_repository, "user2").await?;
 
-        let author_ids = prepare_authors1(&user1_id, &author_repository).await?;
-        let mut book = book_entity1(&author_ids)?;
+        // user1 owns book X with authors [A, B]
+        let user1_author_ids = prepare_authors1(&user1_id, &author_repository).await?;
+        let book = book_entity1(&user1_author_ids)?;
         book_repository.create(&user1_id, &book).await?;
 
-        book.set_title(BookTitle::new("tampered title".to_owned())?);
-        let result = book_repository.update(&user2_id, &book).await;
-        assert!(result.is_err());
-        assert!(matches!(result, Err(DomainError::NotFound { .. })));
+        // user2 also owns book X (same UUID; composite PK (id, user_id) allows this)
+        // with their own author rows [A, B]
+        let user2_author_ids = prepare_authors1(&user2_id, &author_repository).await?;
+        let book_copy = book_entity1(&user2_author_ids)?;
+        book_repository.create(&user2_id, &book_copy).await?;
 
-        // user1's book must remain unchanged
-        let original = book_repository.find_by_id(&user1_id, book.id()).await?;
-        assert_eq!(original.unwrap().title().as_str(), "title1");
+        // user2 updates their book keeping only author A (drops B).
+        // The resulting DELETE FROM book_author must not touch user1's rows.
+        // With the old buggy guard (no user_id check) this would delete user1's B row.
+        let book_for_update = book_entity1(&user2_author_ids[..1])?;
+        let result = book_repository.update(&user2_id, &book_for_update).await;
+        assert!(result.is_ok()); // user2 owns this book, so update succeeds
+
+        // user1's book must remain fully intact: title and both authors [A, B]
+        let user1_book = book_repository
+            .find_by_id(&user1_id, book.id())
+            .await?
+            .unwrap();
+        assert_eq!(user1_book.title().as_str(), "title1");
+        assert_eq!(user1_book.author_ids().len(), user1_author_ids.len());
+        assert!(
+            user1_author_ids
+                .iter()
+                .all(|id| user1_book.author_ids().contains(id))
+        );
 
         Ok(())
     }

--- a/src/infrastructure/book_repository.rs
+++ b/src/infrastructure/book_repository.rs
@@ -237,6 +237,8 @@ impl BookRepository for PgBookRepository {
     }
 
     async fn update(&self, user_id: &UserId, book: &Book) -> Result<(), DomainError> {
+        let mut tx = self.pool.begin().await?;
+
         let result = sqlx::query(
             "UPDATE book SET
                user_id = $1,
@@ -262,7 +264,7 @@ impl BookRepository for PgBookRepository {
         .bind(book.created_at())
         .bind(book.updated_at())
         .bind(book.id().to_uuid())
-        .execute(&self.pool)
+        .execute(&mut *tx)
         .await?;
 
         let rows_affected = result.rows_affected();
@@ -295,7 +297,7 @@ impl BookRepository for PgBookRepository {
         .bind(user_id.as_str())
         .bind(book.id().to_uuid())
         .bind(&author_ids)
-        .execute(&self.pool)
+        .execute(&mut *tx)
         .await?;
 
         // https://github.com/launchbadge/sqlx/blob/fa5c436918664de112677519d73cf6939c938cb0/FAQ.md#how-can-i-bind-an-array-to-a-values-clause-how-can-i-do-bulk-inserts
@@ -307,8 +309,10 @@ impl BookRepository for PgBookRepository {
         .bind(user_id.as_str())
         .bind(book.id().to_uuid())
         .bind(&author_ids)
-        .execute(&self.pool)
+        .execute(&mut *tx)
         .await?;
+
+        tx.commit().await?;
 
         Ok(())
     }
@@ -505,12 +509,47 @@ mod tests {
         let user1_id = prepare_user(&user_repository, "user1").await?;
         let user2_id = prepare_user(&user_repository, "user2").await?;
 
-        let author_ids = prepare_authors1(&user1_id, &author_repository).await?;
-        let book = book_entity1(&author_ids)?;
-        book_repository.create(&user1_id, &book).await?;
+        // Both users own the same book UUID but with distinct author associations.
+        // This exercises the book_author.user_id filter inside the
+        // authors_of_book_and_user CTE: if that CTE ignored user_id, one user's
+        // find_all would return the other user's author_ids.
+        let user1_author_ids = prepare_authors1(&user1_id, &author_repository).await?;
+        let book1 = book_entity1(&user1_author_ids)?;
+        book_repository.create(&user1_id, &book1).await?;
 
-        let result = book_repository.find_all(&user2_id).await?;
-        assert_eq!(result.len(), 0);
+        let user2_author_ids = prepare_authors2(&user2_id, &author_repository).await?;
+        let book2 = book_entity1(&user2_author_ids)?;
+        book_repository.create(&user2_id, &book2).await?;
+
+        // user1's find_all must contain only user1's authors
+        let user1_books = book_repository.find_all(&user1_id).await?;
+        assert_eq!(user1_books.len(), 1);
+        assert!(
+            user1_author_ids
+                .iter()
+                .all(|id| user1_books[0].author_ids().contains(id))
+        );
+        assert!(
+            !user1_books[0]
+                .author_ids()
+                .iter()
+                .any(|id| user2_author_ids.contains(id))
+        );
+
+        // user2's find_all must contain only user2's authors
+        let user2_books = book_repository.find_all(&user2_id).await?;
+        assert_eq!(user2_books.len(), 1);
+        assert!(
+            user2_author_ids
+                .iter()
+                .all(|id| user2_books[0].author_ids().contains(id))
+        );
+        assert!(
+            !user2_books[0]
+                .author_ids()
+                .iter()
+                .any(|id| user1_author_ids.contains(id))
+        );
 
         Ok(())
     }
@@ -575,9 +614,17 @@ mod tests {
         assert!(result.is_err());
         assert!(matches!(result, Err(DomainError::NotFound { .. })));
 
-        // user1's book must still exist
+        // user1's book row must still exist
         let still_exists = book_repository.find_by_id(&user1_id, book.id()).await?;
-        assert!(still_exists.is_some());
+        let existing_book = still_exists.unwrap();
+
+        // user1's book_author rows must also be intact: a buggy delete that
+        // omits the user_id guard would have wiped them for all users.
+        assert!(
+            author_ids
+                .iter()
+                .all(|id| existing_book.author_ids().contains(id))
+        );
 
         Ok(())
     }

--- a/src/infrastructure/book_repository.rs
+++ b/src/infrastructure/book_repository.rs
@@ -490,12 +490,47 @@ mod tests {
         let user1_id = prepare_user(&user_repository, "user1").await?;
         let user2_id = prepare_user(&user_repository, "user2").await?;
 
-        let author_ids = prepare_authors1(&user1_id, &author_repository).await?;
-        let book = book_entity1(&author_ids)?;
-        book_repository.create(&user1_id, &book).await?;
+        // Both users own the same book UUID but with distinct author associations.
+        // This exercises the book_author.user_id filter inside the
+        // authors_of_book_and_user CTE in find_by_id: if that CTE ignored user_id,
+        // one user's find_by_id would return the other user's author_ids.
+        let user1_author_ids = prepare_authors1(&user1_id, &author_repository).await?;
+        let book1 = book_entity1(&user1_author_ids)?;
+        book_repository.create(&user1_id, &book1).await?;
 
-        let result = book_repository.find_by_id(&user2_id, book.id()).await?;
-        assert_eq!(result, None);
+        let user2_author_ids = prepare_authors2(&user2_id, &author_repository).await?;
+        let book2 = book_entity1(&user2_author_ids)?;
+        book_repository.create(&user2_id, &book2).await?;
+
+        // user1's find_by_id must return only user1's authors
+        let user1_result = book_repository.find_by_id(&user1_id, book1.id()).await?;
+        let user1_book = user1_result.unwrap();
+        assert!(
+            user1_author_ids
+                .iter()
+                .all(|id| user1_book.author_ids().contains(id))
+        );
+        assert!(
+            !user1_book
+                .author_ids()
+                .iter()
+                .any(|id| user2_author_ids.contains(id))
+        );
+
+        // user2's find_by_id must return only user2's authors
+        let user2_result = book_repository.find_by_id(&user2_id, book2.id()).await?;
+        let user2_book = user2_result.unwrap();
+        assert!(
+            user2_author_ids
+                .iter()
+                .all(|id| user2_book.author_ids().contains(id))
+        );
+        assert!(
+            !user2_book
+                .author_ids()
+                .iter()
+                .any(|id| user1_author_ids.contains(id))
+        );
 
         Ok(())
     }

--- a/src/infrastructure/book_repository.rs
+++ b/src/infrastructure/book_repository.rs
@@ -249,7 +249,7 @@ impl BookRepository for PgBookRepository {
                store = $8,
                created_at = $9,
                updated_at = $10
-            WHERE id = $11",
+            WHERE id = $11 AND user_id = $1",
         )
         .bind(user_id.as_str())
         .bind(book.title().as_str())
@@ -289,11 +289,14 @@ impl BookRepository for PgBookRepository {
             .collect();
 
         // https://github.com/launchbadge/sqlx/blob/fa5c436918664de112677519d73cf6939c938cb0/FAQ.md#how-can-i-do-a-select--where-foo-in--query
-        sqlx::query("DELETE FROM book_author WHERE book_id = $1 AND author_id != ALL($2)")
-            .bind(book.id().to_uuid())
-            .bind(&author_ids)
-            .execute(&self.pool)
-            .await?;
+        sqlx::query(
+            "DELETE FROM book_author WHERE user_id = $1 AND book_id = $2 AND author_id != ALL($3)",
+        )
+        .bind(user_id.as_str())
+        .bind(book.id().to_uuid())
+        .bind(&author_ids)
+        .execute(&self.pool)
+        .await?;
 
         // https://github.com/launchbadge/sqlx/blob/fa5c436918664de112677519d73cf6939c938cb0/FAQ.md#how-can-i-bind-an-array-to-a-values-clause-how-can-i-do-bulk-inserts
         sqlx::query(
@@ -354,6 +357,7 @@ mod tests {
                 author::{Author, AuthorName},
                 user::User,
             },
+            error::DomainError,
             repository::{author_repository::AuthorRepository, user_repository::UserRepository},
         },
         infrastructure::{
@@ -373,7 +377,7 @@ mod tests {
         let author_repository = PgAuthorRepository::new(pool.clone());
         let book_repository = PgBookRepository::new(pool.clone());
 
-        let user_id = prepare_user(&user_repository).await?;
+        let user_id = prepare_user(&user_repository, "user1").await?;
         let author_ids = prepare_authors1(&user_id, &author_repository).await?;
 
         let all_books = book_repository.find_all(&user_id).await?;
@@ -394,7 +398,7 @@ mod tests {
         let author_repository = PgAuthorRepository::new(pool.clone());
         let book_repository = PgBookRepository::new(pool.clone());
 
-        let user_id = prepare_user(&user_repository).await?;
+        let user_id = prepare_user(&user_repository, "user1").await?;
 
         let author_ids1 = prepare_authors1(&user_id, &author_repository).await?;
         let author_ids2 = prepare_authors2(&user_id, &author_repository).await?;
@@ -427,7 +431,7 @@ mod tests {
         let author_repository = PgAuthorRepository::new(pool.clone());
         let book_repository = PgBookRepository::new(pool.clone());
 
-        let user_id = prepare_user(&user_repository).await?;
+        let user_id = prepare_user(&user_repository, "user1").await?;
         let mut author_ids = prepare_authors1(&user_id, &author_repository).await?;
         let mut book = book_entity1(&author_ids)?;
         book_repository.create(&user_id, &book).await?;
@@ -459,7 +463,7 @@ mod tests {
         let author_repository = PgAuthorRepository::new(pool.clone());
         let book_repository = PgBookRepository::new(pool.clone());
 
-        let user_id = prepare_user(&user_repository).await?;
+        let user_id = prepare_user(&user_repository, "user1").await?;
         let author_ids = prepare_authors1(&user_id, &author_repository).await?;
         let book = book_entity1(&author_ids)?;
         book_repository.create(&user_id, &book).await?;
@@ -473,8 +477,95 @@ mod tests {
         Ok(())
     }
 
-    async fn prepare_user(repository: &PgUserRepository) -> Result<UserId, DomainError> {
-        let user_id = UserId::new(String::from("user1"))?;
+    #[sqlx::test]
+    async fn test_find_by_id_does_not_return_other_users_book(pool: PgPool) -> anyhow::Result<()> {
+        let user_repository = PgUserRepository::new(pool.clone());
+        let author_repository = PgAuthorRepository::new(pool.clone());
+        let book_repository = PgBookRepository::new(pool.clone());
+
+        let user1_id = prepare_user(&user_repository, "user1").await?;
+        let user2_id = prepare_user(&user_repository, "user2").await?;
+
+        let author_ids = prepare_authors1(&user1_id, &author_repository).await?;
+        let book = book_entity1(&author_ids)?;
+        book_repository.create(&user1_id, &book).await?;
+
+        let result = book_repository.find_by_id(&user2_id, book.id()).await?;
+        assert_eq!(result, None);
+
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn test_find_all_does_not_return_other_users_books(pool: PgPool) -> anyhow::Result<()> {
+        let user_repository = PgUserRepository::new(pool.clone());
+        let author_repository = PgAuthorRepository::new(pool.clone());
+        let book_repository = PgBookRepository::new(pool.clone());
+
+        let user1_id = prepare_user(&user_repository, "user1").await?;
+        let user2_id = prepare_user(&user_repository, "user2").await?;
+
+        let author_ids = prepare_authors1(&user1_id, &author_repository).await?;
+        let book = book_entity1(&author_ids)?;
+        book_repository.create(&user1_id, &book).await?;
+
+        let result = book_repository.find_all(&user2_id).await?;
+        assert_eq!(result.len(), 0);
+
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn test_update_does_not_affect_other_users_book(pool: PgPool) -> anyhow::Result<()> {
+        let user_repository = PgUserRepository::new(pool.clone());
+        let author_repository = PgAuthorRepository::new(pool.clone());
+        let book_repository = PgBookRepository::new(pool.clone());
+
+        let user1_id = prepare_user(&user_repository, "user1").await?;
+        let user2_id = prepare_user(&user_repository, "user2").await?;
+
+        let author_ids = prepare_authors1(&user1_id, &author_repository).await?;
+        let mut book = book_entity1(&author_ids)?;
+        book_repository.create(&user1_id, &book).await?;
+
+        book.set_title(BookTitle::new("tampered title".to_owned())?);
+        let result = book_repository.update(&user2_id, &book).await;
+        assert!(result.is_err());
+        assert!(matches!(result, Err(DomainError::NotFound { .. })));
+
+        // user1's book must remain unchanged
+        let original = book_repository.find_by_id(&user1_id, book.id()).await?;
+        assert_eq!(original.unwrap().title().as_str(), "title1");
+
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn test_delete_does_not_affect_other_users_book(pool: PgPool) -> anyhow::Result<()> {
+        let user_repository = PgUserRepository::new(pool.clone());
+        let author_repository = PgAuthorRepository::new(pool.clone());
+        let book_repository = PgBookRepository::new(pool.clone());
+
+        let user1_id = prepare_user(&user_repository, "user1").await?;
+        let user2_id = prepare_user(&user_repository, "user2").await?;
+
+        let author_ids = prepare_authors1(&user1_id, &author_repository).await?;
+        let book = book_entity1(&author_ids)?;
+        book_repository.create(&user1_id, &book).await?;
+
+        let result = book_repository.delete(&user2_id, book.id()).await;
+        assert!(result.is_err());
+        assert!(matches!(result, Err(DomainError::NotFound { .. })));
+
+        // user1's book must still exist
+        let still_exists = book_repository.find_by_id(&user1_id, book.id()).await?;
+        assert!(still_exists.is_some());
+
+        Ok(())
+    }
+
+    async fn prepare_user(repository: &PgUserRepository, id: &str) -> Result<UserId, DomainError> {
+        let user_id = UserId::new(String::from(id))?;
         let user = User::new(user_id.clone());
         repository.create(&user).await?;
 

--- a/src/infrastructure/book_repository.rs
+++ b/src/infrastructure/book_repository.rs
@@ -598,6 +598,36 @@ mod tests {
     }
 
     #[sqlx::test]
+    async fn test_update_returns_not_found_for_other_users_book(
+        pool: PgPool,
+    ) -> anyhow::Result<()> {
+        let user_repository = PgUserRepository::new(pool.clone());
+        let author_repository = PgAuthorRepository::new(pool.clone());
+        let book_repository = PgBookRepository::new(pool.clone());
+
+        let user1_id = prepare_user(&user_repository, "user1").await?;
+        let user2_id = prepare_user(&user_repository, "user2").await?;
+
+        // Only user1 owns book X; user2 does not.
+        let author_ids = prepare_authors1(&user1_id, &author_repository).await?;
+        let book = book_entity1(&author_ids)?;
+        book_repository.create(&user1_id, &book).await?;
+
+        // user2 attempts to update user1's book.
+        // The WHERE id = $11 AND user_id = $1 guard must return NotFound.
+        // Without the AND user_id = $1 clause the UPDATE would silently mutate
+        // user1's row and return Ok(()).
+        let result = book_repository.update(&user2_id, &book).await;
+        assert!(matches!(result, Err(DomainError::NotFound { .. })));
+
+        // user1's book must be untouched
+        let still_exists = book_repository.find_by_id(&user1_id, book.id()).await?;
+        assert!(still_exists.is_some());
+
+        Ok(())
+    }
+
+    #[sqlx::test]
     async fn test_delete_does_not_affect_other_users_book(pool: PgPool) -> anyhow::Result<()> {
         let user_repository = PgUserRepository::new(pool.clone());
         let author_repository = PgAuthorRepository::new(pool.clone());

--- a/src/use_case/interactor/query.rs
+++ b/src/use_case/interactor/query.rs
@@ -159,6 +159,152 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn find_book_by_id_passes_correct_user_id_to_repository() {
+        // Given
+        let user_repository = MockUserRepository::new();
+        let mut book_repository = MockBookRepository::new();
+        let author_repository = MockAuthorRepository::new();
+
+        let expected_user_id = "user1";
+        let book_id_str = "a1b2c3d4-e5f6-4890-abcd-ef1234567890";
+        let book = make_book(book_id_str);
+
+        book_repository
+            .expect_find_by_id()
+            .withf(move |uid, _| uid.as_str() == expected_user_id)
+            .returning(move |_, _| Ok(Some(book.clone())));
+
+        let query_interactor = QueryInteractor {
+            user_repository,
+            book_repository,
+            author_repository,
+        };
+
+        // When
+        let result = query_interactor.find_book_by_id("user1", book_id_str).await;
+
+        // Then
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn find_all_books_passes_correct_user_id_to_repository() {
+        // Given
+        let user_repository = MockUserRepository::new();
+        let mut book_repository = MockBookRepository::new();
+        let author_repository = MockAuthorRepository::new();
+
+        let expected_user_id = "user1";
+
+        book_repository
+            .expect_find_all()
+            .withf(move |uid| uid.as_str() == expected_user_id)
+            .returning(|_| Ok(vec![]));
+
+        let query_interactor = QueryInteractor {
+            user_repository,
+            book_repository,
+            author_repository,
+        };
+
+        // When
+        let result = query_interactor.find_all_books("user1").await;
+
+        // Then
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn find_author_by_id_passes_correct_user_id_to_repository() {
+        // Given
+        let user_repository = MockUserRepository::new();
+        let book_repository = MockBookRepository::new();
+        let mut author_repository = MockAuthorRepository::new();
+
+        let expected_user_id = "user1";
+        let author_id_str = "006099b4-6c42-4ec4-8645-f6bd5b63eddc";
+
+        author_repository
+            .expect_find_by_id()
+            .withf(move |uid, _| uid.as_str() == expected_user_id)
+            .returning(|_, _| Ok(None));
+
+        let query_interactor = QueryInteractor {
+            user_repository,
+            book_repository,
+            author_repository,
+        };
+
+        // When
+        let result = query_interactor
+            .find_author_by_id("user1", author_id_str)
+            .await;
+
+        // Then
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn find_all_authors_passes_correct_user_id_to_repository() {
+        // Given
+        let user_repository = MockUserRepository::new();
+        let book_repository = MockBookRepository::new();
+        let mut author_repository = MockAuthorRepository::new();
+
+        let expected_user_id = "user1";
+
+        author_repository
+            .expect_find_all()
+            .withf(move |uid| uid.as_str() == expected_user_id)
+            .returning(|_| Ok(vec![]));
+
+        let query_interactor = QueryInteractor {
+            user_repository,
+            book_repository,
+            author_repository,
+        };
+
+        // When
+        let result = query_interactor.find_all_authors("user1").await;
+
+        // Then
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn find_author_by_ids_as_hash_map_passes_correct_user_id_to_repository() {
+        // Given
+        let user_repository = MockUserRepository::new();
+        let book_repository = MockBookRepository::new();
+        let mut author_repository = MockAuthorRepository::new();
+
+        let expected_user_id = "user1";
+
+        author_repository
+            .expect_find_by_ids_as_hash_map()
+            .withf(move |uid, _| uid.as_str() == expected_user_id)
+            .returning(|_, _| Ok(HashMap::new()));
+
+        let query_interactor = QueryInteractor {
+            user_repository,
+            book_repository,
+            author_repository,
+        };
+
+        // When
+        let result = query_interactor
+            .find_author_by_ids_as_hash_map(
+                "user1",
+                &["006099b4-6c42-4ec4-8645-f6bd5b63eddc".to_string()],
+            )
+            .await;
+
+        // Then
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
     async fn find_author_by_id() {
         let user_repository = MockUserRepository::new();
         let book_repository = MockBookRepository::new();


### PR DESCRIPTION
- Fix book_repository.update() WHERE clause to include user_id,
  preventing cross-user book modification
- Fix book_author DELETE in update() to scope by user_id
- Add DB isolation tests for book and author repositories
- Add unit tests verifying correct user_id propagation in QueryInteractor

https://claude.ai/code/session_01DrgJBpHn3SdMB5Pfsjo21Q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 更新・削除処理を単一トランザクションにまとめ、クエリ条件をユーザー単位で厳格化。別ユーザーの行が誤って更新・削除されないようにしました。

* **Tests**
  * 他ユーザー隔離を検証する統合テストを追加（作成・取得・更新・削除が他ユーザーへ影響しないことを確認）。
  * 単体テストを追加・調整し、使用するユーザー識別子がリポジトリ／インタラクタへ正しく伝播されることを検証。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->