### PR TITLE
Improve Renovate config validation workflow

### DIFF
--- a/.github/workflows/renovate-config-validation.yml
+++ b/.github/workflows/renovate-config-validation.yml
@@ -20,4 +20,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - run: npx --yes --package renovate -- renovate-config-validator
+      - name: Show Renovate version
+        run: npx --yes --package renovate@latest --min-release-age=3 renovate --version
+      - name: Validate Renovate Config
+        run: npx --yes --package renovate@latest --min-release-age=3 renovate-config-validator


### PR DESCRIPTION
## Summary
Enhanced the Renovate configuration validation GitHub Actions workflow to provide better visibility and use the latest stable version of Renovate.

## Key Changes
- Added a step to display the Renovate version being used for validation
- Updated the workflow to use `renovate@latest` with `--min-release-age=3` to ensure a stable, recently-released version is used
- Applied the same version pinning strategy to both the version check and config validation steps
- Added descriptive names to both workflow steps for improved clarity in action logs

## Implementation Details
The workflow now explicitly shows which version of Renovate is being used before running validation, making it easier to debug version-related issues. The `--min-release-age=3` flag ensures the workflow uses a release that's at least 3 days old, balancing between getting recent updates and avoiding bleeding-edge versions that may have undiscovered issues.

https://claude.ai/code/session_014qZCYAFvcfJZWWMuDdfvMb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * Renovate設定検証ワークフローを改善し、バージョン確認プロセスを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->