### PR TITLE
Rename fileMatch to managerFilePatterns

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -6,7 +6,7 @@
   "customManagers": [
     {
       "customType": "regex",
-      "fileMatch": ["(^|/)rust-toolchain(\\.toml)?$"],
+      "managerFilePatterns": ["(^|/)rust-toolchain(\\.toml)?$"],
       "matchStrings": ["channel\\s*=\\s*\"(?<currentValue>\\d+\\.\\d+\\.\\d+)\""],
       "depNameTemplate": "rust",
       "packageNameTemplate": "rust-lang/rust",


### PR DESCRIPTION
https://github.com/hiterm/bookshelf-api/pull/176

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 依存関係管理ツール（Renovate）の設定ファイルを更新しました。カスタムマネージャーの設定を変更し、スキャン対象ファイルの指定方法を改善しています。これにより、プロジェクトの依存関係更新の検出がより効率的になります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->