### PR TITLE
Add TLS/HTTPS connectivity regression test for CA certificates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,12 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - name: Verify HTTPS connectivity via reqwest
+        run: |
+          docker build --target tls-check -t bookshelf-api:tls-check \
+            --cache-from type=gha .
+          docker run --rm bookshelf-api:tls-check
+
       - name: Run container and health check
         run: |
           docker network create test-network

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,11 +67,15 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - name: Build tls-check image
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
+        with:
+          push: false
+          load: true
+          tags: bookshelf-api:tls-check
+          target: tls-check
       - name: Verify HTTPS connectivity via reqwest
-        run: |
-          docker build --target tls-check -t bookshelf-api:tls-check \
-            --cache-from type=gha .
-          docker run --rm bookshelf-api:tls-check
+        run: docker run --rm bookshelf-api:tls-check
 
       - name: Run container and health check
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN --mount=type=bind,source=src,target=src \
 set -e
 cargo build --locked --release
 cp ./target/release/$APP_NAME /bin/server
+cp ./target/release/check_tls /bin/check_tls
 EOF
 
 
@@ -44,3 +45,21 @@ USER appuser
 COPY --from=build-stage /bin/server /bin/
 
 CMD ["/bin/server"]
+
+
+# Regression test image for CA certificate fix (PR #187).
+# Verifies that reqwest can make HTTPS connections using the system trust store.
+# Usage: docker build --target tls-check -t bookshelf-api:tls-check . && docker run --rm bookshelf-api:tls-check
+FROM debian:trixie-slim@sha256:26f98ccd92fd0a44d6928ce8ff8f4921b4d2f535bfa07555ee5d18f61429cf0c AS tls-check
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
+ARG UID=10001
+RUN useradd -l -M -u "${UID}" -d "/nonexistent" -s "/sbin/nologin" appuser
+USER appuser
+
+COPY --from=build-stage /bin/check_tls /bin/
+
+CMD ["/bin/check_tls"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,11 @@ cp ./target/release/check_tls /bin/check_tls
 EOF
 
 
-FROM debian:trixie-slim@sha256:26f98ccd92fd0a44d6928ce8ff8f4921b4d2f535bfa07555ee5d18f61429cf0c
+# Shared base for the production image and the TLS regression-test image.
+# Both stages inherit ca-certificates from here, ensuring that the regression
+# test (tls-check) exercises the exact same certificate environment as
+# production. Removing ca-certificates from this stage breaks both.
+FROM debian:trixie-slim@sha256:26f98ccd92fd0a44d6928ce8ff8f4921b4d2f535bfa07555ee5d18f61429cf0c AS base
 
 # https://ianwwagner.com/reqwest-0-13-upgrade-and-webpki.html
 RUN apt-get update \
@@ -42,24 +46,23 @@ ARG UID=10001
 RUN useradd -l -M -u "${UID}" -d "/nonexistent" -s "/sbin/nologin" appuser
 USER appuser
 
-COPY --from=build-stage /bin/server /bin/
 
-CMD ["/bin/server"]
-
-
-# Regression test image for CA certificate fix (PR #187).
-# Verifies that reqwest can make HTTPS connections using the system trust store.
-# Usage: docker build --target tls-check -t bookshelf-api:tls-check . && docker run --rm bookshelf-api:tls-check
-FROM debian:trixie-slim@sha256:26f98ccd92fd0a44d6928ce8ff8f4921b4d2f535bfa07555ee5d18f61429cf0c AS tls-check
-
-RUN apt-get update \
- && apt-get install -y --no-install-recommends ca-certificates \
- && rm -rf /var/lib/apt/lists/*
-
-ARG UID=10001
-RUN useradd -l -M -u "${UID}" -d "/nonexistent" -s "/sbin/nologin" appuser
-USER appuser
+# Regression test image for the CA certificate fix (PR #187).
+# Verifies that reqwest can establish an HTTPS connection using the system
+# trust store inherited from the base stage. Placed before the production
+# stage so that the production image remains the default build target.
+# Usage: docker build --target tls-check -t bookshelf-api:tls-check .
+#        docker run --rm bookshelf-api:tls-check
+FROM base AS tls-check
 
 COPY --from=build-stage /bin/check_tls /bin/
 
 CMD ["/bin/check_tls"]
+
+
+# Production image — default build target (must be the last stage).
+FROM base
+
+COPY --from=build-stage /bin/server /bin/
+
+CMD ["/bin/server"]

--- a/src/bin/check_tls.rs
+++ b/src/bin/check_tls.rs
@@ -1,9 +1,15 @@
 // Regression check for the CA-certificate fix (PR #187).
-// Verifies that reqwest can establish an HTTPS connection using the system trust store.
+// Verifies that the HTTP client used in production can establish an HTTPS
+// connection using the system trust store.
 // Run inside the production container image to confirm ca-certificates is installed.
+use bookshelf_api::common::http::build_http_client;
+
 #[tokio::main]
 async fn main() {
-    reqwest::get("https://example.com")
+    build_http_client()
+        .expect("failed to build HTTP client")
+        .get("https://example.com")
+        .send()
         .await
         .expect("HTTPS check failed: CA certificates may not be installed");
     println!("TLS OK");

--- a/src/bin/check_tls.rs
+++ b/src/bin/check_tls.rs
@@ -1,0 +1,10 @@
+// Regression check for the CA-certificate fix (PR #187).
+// Verifies that reqwest can establish an HTTPS connection using the system trust store.
+// Run inside the production container image to confirm ca-certificates is installed.
+#[tokio::main]
+async fn main() {
+    reqwest::get("https://example.com")
+        .await
+        .expect("HTTPS check failed: CA certificates may not be installed");
+    println!("TLS OK");
+}

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,1 +1,2 @@
+pub mod http;
 pub mod types;

--- a/src/common/http.rs
+++ b/src/common/http.rs
@@ -1,0 +1,7 @@
+use std::time::Duration;
+
+pub fn build_http_client() -> reqwest::Result<reqwest::Client> {
+    reqwest::ClientBuilder::new()
+        .timeout(Duration::from_secs(10))
+        .build()
+}

--- a/src/presentation/extractor/claims.rs
+++ b/src/presentation/extractor/claims.rs
@@ -1,3 +1,4 @@
+use crate::common::http::build_http_client;
 use crate::presentation::app_state::AppState;
 use axum::extract::FromRequestParts;
 use axum::http::request::Parts;
@@ -14,7 +15,6 @@ use jsonwebtoken::{
 };
 use serde::Deserialize;
 use serde_json::json;
-use std::time::Duration;
 use std::{collections::HashSet, sync::Arc};
 
 #[derive(Debug, Clone, Deserialize)]
@@ -165,9 +165,7 @@ async fn fetch_jwks(domain: &str) -> Result<JwkSet, ClientError> {
     let uri = std::env::var("JWKS_URL")
         .unwrap_or_else(|_| format!("https://{}/.well-known/jwks.json", domain));
     validate_jwks_url(&uri)?;
-    let client = reqwest::ClientBuilder::new()
-        .timeout(Duration::from_secs(10))
-        .build()
+    let client = build_http_client()
         .map_err(|e| ClientError::JwksFetch(format!("failed to build HTTP client: {e}")))?;
     let response = client
         .get(&uri)


### PR DESCRIPTION
## Summary
This PR adds a regression test to verify that HTTPS connections work correctly using the system trust store, specifically to prevent regressions of the CA certificate fix from PR #187.

## Key Changes
- **New binary `check_tls`**: Added `src/bin/check_tls.rs` that performs a simple HTTPS request to example.com to verify reqwest can establish TLS connections using system CA certificates
- **Docker build updates**: Modified Dockerfile to:
  - Build and copy the new `check_tls` binary during the build stage
  - Add a new `tls-check` target image based on debian:trixie-slim with ca-certificates installed
  - Configure the tls-check image to run the check_tls binary as its entrypoint
- **CI workflow enhancement**: Added a new step in `.github/workflows/ci.yml` to build and run the tls-check container image as part of the CI pipeline

## Implementation Details
- The `check_tls` binary is a minimal async Rust program using tokio and reqwest that makes a GET request to https://example.com
- The tls-check Docker image is a lightweight verification container that can be built and run independently with `docker build --target tls-check` and `docker run`
- The regression test runs in CI after the main build to catch any issues with CA certificate installation in the production container image

https://claude.ai/code/session_01FCjNJt8xbmTQFxcH8fFBg4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * HTTPS接続の自動検証機能を追加しました。

* **その他**
  * ビルドプロセスにTLS接続確認テストを統合し、デプロイ前に接続性を検証できるようにしました。
  * HTTP クライアント構築ロジックを共有モジュール化し、コード保守性を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->