### PR TITLE
Replace once_cell with std::sync::LazyLock and dotenv with dotenvy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -358,7 +358,7 @@ dependencies = [
  "axum-extra",
  "axum-macros",
  "derive_more",
- "dotenv",
+ "dotenvy",
  "envy",
  "futures-util",
  "getset",
@@ -367,7 +367,6 @@ dependencies = [
  "log",
  "mockall",
  "moka",
- "once_cell",
  "regex",
  "reqwest",
  "serde",
@@ -758,12 +757,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "dotenv"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 
 [[package]]
 name = "dotenvy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ axum = { version = "0.8" }
 axum-extra = { version = "0.12", features = ["typed-header"] }
 axum-macros = "0.5.0"
 derive_more = { version = "2.0", features = ["display", "error"] }
-dotenv = "0.15.0"
+dotenvy = "0.15.7"
 envy = "0.4.2"
 futures-util = "0.3.31"
 getset = "0.1.3"
@@ -27,7 +27,6 @@ jsonwebtoken = { version = "10.3.0", features = ["aws_lc_rs"] }
 log = "0.4.22"
 mockall = "0.14.0"
 moka = { version = "0.12", features = ["future"] }
-once_cell = "1.20.2"
 regex = "1.11.0"
 reqwest = { version = "0.13", features = [ "json" ] }
 serde = { version = "1.0", features = ["derive"] }

--- a/src/bin/gen_schema.rs
+++ b/src/bin/gen_schema.rs
@@ -5,7 +5,7 @@ use bookshelf_api::{
 
 #[tokio::main]
 async fn main() {
-    dotenv::dotenv().ok();
+    dotenvy::dotenv().ok();
 
     let query_use_case = MockQueryUseCase::new();
     let query = Query::new(query_use_case);

--- a/src/domain/entity/book.rs
+++ b/src/domain/entity/book.rs
@@ -1,5 +1,5 @@
 use getset::{Getters, Setters};
-use once_cell::sync::Lazy;
+use std::sync::LazyLock;
 use regex::Regex;
 use time::OffsetDateTime;
 use uuid::Uuid;
@@ -56,7 +56,7 @@ pub struct BookTitle {
 
 impl_string_value_object!(BookTitle);
 
-static ISBN_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"(^$|^(\d-?){12}\d$)").unwrap());
+static ISBN_REGEX: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(^$|^(\d-?){12}\d$)").unwrap());
 
 #[derive(Debug, Clone, PartialEq, Eq, Validate)]
 pub struct Isbn {

--- a/src/domain/entity/book.rs
+++ b/src/domain/entity/book.rs
@@ -1,6 +1,6 @@
 use getset::{Getters, Setters};
-use std::sync::LazyLock;
 use regex::Regex;
+use std::sync::LazyLock;
 use time::OffsetDateTime;
 use uuid::Uuid;
 use validator::Validate;

--- a/src/infrastructure/user_repository.rs
+++ b/src/infrastructure/user_repository.rs
@@ -51,7 +51,7 @@ mod tests {
 
     #[sqlx::test]
     async fn test_user_repository(pool: PgPool) -> anyhow::Result<()> {
-        dotenv::dotenv().ok();
+        dotenvy::dotenv().ok();
 
         let repository = PgUserRepository::new(pool);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,7 @@ use tracing::Level;
 
 #[tokio::main]
 async fn main() {
-    dotenv::dotenv().ok();
+    dotenvy::dotenv().ok();
 
     tracing_subscriber::fmt::init();
 


### PR DESCRIPTION
## Summary
This PR modernizes the codebase by replacing deprecated/unmaintained dependencies with their standard library equivalents and maintained alternatives.

## Key Changes
- **Lazy initialization**: Replaced `once_cell::sync::Lazy` with `std::sync::LazyLock` (stabilized in Rust 1.80.0)
  - Updated `ISBN_REGEX` static in `src/domain/entity/book.rs` to use `LazyLock`
  - Removed `once_cell` dependency from `Cargo.toml`

- **Environment variable loading**: Replaced `dotenv` crate with `dotenvy` (maintained fork)
  - Updated all `dotenv::dotenv()` calls to `dotenvy::dotenv()` in:
    - `src/main.rs`
    - `src/bin/gen_schema.rs`
    - `src/infrastructure/user_repository.rs`
  - Updated dependency in `Cargo.toml` from `dotenv = "0.15.0"` to `dotenvy = "0.15.7"`

## Implementation Details
- `LazyLock` provides the same functionality as `Lazy` with better performance and no external dependency
- `dotenvy` is a maintained community fork of the unmaintained `dotenv` crate with identical API compatibility
- All changes are drop-in replacements with no behavioral modifications

https://claude.ai/code/session_01Q2RnWJ7u9z6Myet3hzQQGH

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * 依存関係を更新しました。環境変数の読み込みライブラリと静的初期化の実装を最新のバージョンに置き換えました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->