### PR TITLE
Replace panic with Result in production code

### DIFF
--- a/src/domain/entity/book.rs
+++ b/src/domain/entity/book.rs
@@ -56,7 +56,9 @@ pub struct BookTitle {
 
 impl_string_value_object!(BookTitle);
 
-static ISBN_REGEX: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(^$|^(\d-?){12}\d$)").unwrap());
+static ISBN_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(^$|^(\d-?){12}\d$)").expect("ISBN_REGEX is a hardcoded valid pattern")
+});
 
 #[derive(Debug, Clone, PartialEq, Eq, Validate)]
 pub struct Isbn {

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,8 @@ use tower_http::trace::{DefaultOnResponse, TraceLayer};
 use tower_http::{cors::CorsLayer, trace::DefaultOnRequest};
 use tracing::Level;
 
+use anyhow::Context as _;
+
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
     dotenvy::dotenv().ok();
@@ -50,7 +52,6 @@ async fn main() -> Result<(), anyhow::Error> {
     let allowed_origins = fetch_allowed_origins()?
         .into_iter()
         .map(|origin| {
-            use anyhow::Context as _;
             origin
                 .parse::<HeaderValue>()
                 .with_context(|| format!("invalid ALLOWED_ORIGINS value: \"{origin}\""))
@@ -91,7 +92,6 @@ async fn main() -> Result<(), anyhow::Error> {
 }
 
 fn fetch_port() -> Result<u16, anyhow::Error> {
-    use anyhow::Context as _;
     std::env::var("PORT")
         .context("environment variable PORT is required")?
         .parse()
@@ -99,12 +99,10 @@ fn fetch_port() -> Result<u16, anyhow::Error> {
 }
 
 fn fetch_database_url() -> Result<String, anyhow::Error> {
-    use anyhow::Context as _;
     std::env::var("DATABASE_URL").context("environment variable DATABASE_URL is required")
 }
 
 fn fetch_allowed_origins() -> Result<Vec<String>, anyhow::Error> {
-    use anyhow::Context as _;
     Ok(std::env::var("ALLOWED_ORIGINS")
         .context("environment variable ALLOWED_ORIGINS is required")?
         .split(',')

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use std::{net::SocketAddr, sync::Arc, time::Duration};
 
+use anyhow::anyhow;
 use axum::{
     Extension, Router,
     routing::{get, post},
@@ -21,27 +22,23 @@ use tower_http::{cors::CorsLayer, trace::DefaultOnRequest};
 use tracing::Level;
 
 #[tokio::main]
-async fn main() {
+async fn main() -> Result<(), anyhow::Error> {
     dotenvy::dotenv().ok();
 
     tracing_subscriber::fmt::init();
 
-    let db_url = fetch_database_url();
+    let db_url = fetch_database_url()?;
 
     let pool = PgPoolOptions::new()
         .max_connections(5)
         .connect(&db_url)
-        .await
-        .unwrap();
+        .await?;
 
-    sqlx::migrate!()
-        .run(&pool)
-        .await
-        .expect("Migration failed.");
+    sqlx::migrate!().run(&pool).await?;
 
     let (query_use_case, schema) = dependency_injection(pool);
 
-    let jwt_config = JwtConfig::default();
+    let jwt_config = JwtConfig::from_env()?;
     let jwks_cache = moka::future::Cache::builder()
         .max_capacity(1)
         .time_to_live(Duration::from_hours(1))
@@ -51,10 +48,14 @@ async fn main() {
         jwks_cache,
     });
 
-    let allowed_origins: Vec<_> = fetch_allowed_origins()
+    let allowed_origins = fetch_allowed_origins()?
         .into_iter()
-        .map(|origin| origin.parse::<HeaderValue>().unwrap())
-        .collect();
+        .map(|origin| {
+            origin
+                .parse::<HeaderValue>()
+                .map_err(|e| anyhow!("Invalid ALLOWED_ORIGINS value \"{origin}\": {e}"))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
     let cors_layer = CorsLayer::new()
         .allow_origin(allowed_origins)
         .allow_methods([Method::GET, Method::POST])
@@ -80,43 +81,49 @@ async fn main() {
                 .layer(cors_layer),
         );
 
-    let port = fetch_port();
+    let port = fetch_port()?;
     let addr = SocketAddr::from(([0, 0, 0, 0], port));
-    let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
+    let listener = tokio::net::TcpListener::bind(addr).await?;
     tracing::info!("Server started on port {}", port);
-    axum::serve(listener, app).await.unwrap();
+    axum::serve(listener, app).await?;
+
+    Ok(())
 }
 
-fn fetch_port() -> u16 {
+fn fetch_port() -> Result<u16, anyhow::Error> {
     use std::env::VarError;
 
     match std::env::var("PORT") {
         Ok(s) => s
             .parse()
-            .expect("Failed to parse environment variable PORT."),
-        Err(VarError::NotPresent) => panic!("Environment variable PORT is required."),
-        Err(VarError::NotUnicode(_)) => panic!("Environment variable PORT is not unicode."),
+            .map_err(|e| anyhow!("Failed to parse environment variable PORT: {e}")),
+        Err(VarError::NotPresent) => Err(anyhow!("Environment variable PORT is required.")),
+        Err(VarError::NotUnicode(_)) => Err(anyhow!("Environment variable PORT is not unicode.")),
     }
 }
 
-fn fetch_database_url() -> String {
+fn fetch_database_url() -> Result<String, anyhow::Error> {
     use std::env::VarError;
 
     match std::env::var("DATABASE_URL") {
-        Ok(s) => s,
-        Err(VarError::NotPresent) => panic!("Environment variable DATABASE_URL is required."),
-        Err(VarError::NotUnicode(_)) => panic!("Environment variable DATABASE_URL is not unicode."),
+        Ok(s) => Ok(s),
+        Err(VarError::NotPresent) => Err(anyhow!("Environment variable DATABASE_URL is required.")),
+        Err(VarError::NotUnicode(_)) => {
+            Err(anyhow!("Environment variable DATABASE_URL is not unicode."))
+        }
     }
 }
 
-fn fetch_allowed_origins() -> Vec<String> {
+fn fetch_allowed_origins() -> Result<Vec<String>, anyhow::Error> {
     use std::env::VarError;
 
     match std::env::var("ALLOWED_ORIGINS") {
-        Ok(s) => s.split(',').map(|s| s.to_owned()).collect(),
-        Err(VarError::NotPresent) => panic!("Environment variable ALLOWED_ORIGINS is required."),
-        Err(VarError::NotUnicode(_)) => {
-            panic!("Environment variable ALLOWED_ORIGINS is not unicode.")
+        Ok(s) => Ok(s.split(',').map(|s| s.to_owned()).collect()),
+        Err(VarError::NotPresent) => {
+            Err(anyhow!("Environment variable ALLOWED_ORIGINS is required."))
         }
+        Err(VarError::NotUnicode(_)) => Err(anyhow!(
+            "Environment variable ALLOWED_ORIGINS is not unicode."
+        )),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,5 @@
 use std::{net::SocketAddr, sync::Arc, time::Duration};
 
-use anyhow::anyhow;
 use axum::{
     Extension, Router,
     routing::{get, post},
@@ -51,9 +50,10 @@ async fn main() -> Result<(), anyhow::Error> {
     let allowed_origins = fetch_allowed_origins()?
         .into_iter()
         .map(|origin| {
+            use anyhow::Context as _;
             origin
                 .parse::<HeaderValue>()
-                .map_err(|e| anyhow!("Invalid ALLOWED_ORIGINS value \"{origin}\": {e}"))
+                .with_context(|| format!("invalid ALLOWED_ORIGINS value: \"{origin}\""))
         })
         .collect::<Result<Vec<_>, _>>()?;
     let cors_layer = CorsLayer::new()
@@ -91,39 +91,23 @@ async fn main() -> Result<(), anyhow::Error> {
 }
 
 fn fetch_port() -> Result<u16, anyhow::Error> {
-    use std::env::VarError;
-
-    match std::env::var("PORT") {
-        Ok(s) => s
-            .parse()
-            .map_err(|e| anyhow!("Failed to parse environment variable PORT: {e}")),
-        Err(VarError::NotPresent) => Err(anyhow!("Environment variable PORT is required.")),
-        Err(VarError::NotUnicode(_)) => Err(anyhow!("Environment variable PORT is not unicode.")),
-    }
+    use anyhow::Context as _;
+    std::env::var("PORT")
+        .context("environment variable PORT is required")?
+        .parse()
+        .context("failed to parse PORT as a port number")
 }
 
 fn fetch_database_url() -> Result<String, anyhow::Error> {
-    use std::env::VarError;
-
-    match std::env::var("DATABASE_URL") {
-        Ok(s) => Ok(s),
-        Err(VarError::NotPresent) => Err(anyhow!("Environment variable DATABASE_URL is required.")),
-        Err(VarError::NotUnicode(_)) => {
-            Err(anyhow!("Environment variable DATABASE_URL is not unicode."))
-        }
-    }
+    use anyhow::Context as _;
+    std::env::var("DATABASE_URL").context("environment variable DATABASE_URL is required")
 }
 
 fn fetch_allowed_origins() -> Result<Vec<String>, anyhow::Error> {
-    use std::env::VarError;
-
-    match std::env::var("ALLOWED_ORIGINS") {
-        Ok(s) => Ok(s.split(',').map(|s| s.to_owned()).collect()),
-        Err(VarError::NotPresent) => {
-            Err(anyhow!("Environment variable ALLOWED_ORIGINS is required."))
-        }
-        Err(VarError::NotUnicode(_)) => Err(anyhow!(
-            "Environment variable ALLOWED_ORIGINS is not unicode."
-        )),
-    }
+    use anyhow::Context as _;
+    Ok(std::env::var("ALLOWED_ORIGINS")
+        .context("environment variable ALLOWED_ORIGINS is required")?
+        .split(',')
+        .map(|s| s.to_owned())
+        .collect())
 }

--- a/src/presentation/extractor/claims.rs
+++ b/src/presentation/extractor/claims.rs
@@ -25,9 +25,10 @@ pub struct JwtConfig {
 
 impl JwtConfig {
     pub fn from_env() -> Result<Self, anyhow::Error> {
+        use anyhow::Context as _;
         envy::prefixed("JWT_")
             .from_env::<Self>()
-            .map_err(anyhow::Error::from)
+            .context("missing JWT environment variables (JWT_AUDIENCE, JWT_DOMAIN)")
     }
 }
 

--- a/src/presentation/extractor/claims.rs
+++ b/src/presentation/extractor/claims.rs
@@ -17,6 +17,8 @@ use serde::Deserialize;
 use serde_json::json;
 use std::{collections::HashSet, sync::Arc};
 
+use anyhow::Context as _;
+
 #[derive(Debug, Clone, Deserialize)]
 pub struct JwtConfig {
     pub(crate) audience: String,
@@ -25,7 +27,6 @@ pub struct JwtConfig {
 
 impl JwtConfig {
     pub fn from_env() -> Result<Self, anyhow::Error> {
-        use anyhow::Context as _;
         envy::prefixed("JWT_")
             .from_env::<Self>()
             .context("missing JWT environment variables (JWT_AUDIENCE, JWT_DOMAIN)")

--- a/src/presentation/extractor/claims.rs
+++ b/src/presentation/extractor/claims.rs
@@ -23,11 +23,11 @@ pub struct JwtConfig {
     pub(crate) domain: String,
 }
 
-impl Default for JwtConfig {
-    fn default() -> Self {
+impl JwtConfig {
+    pub fn from_env() -> Result<Self, anyhow::Error> {
         envy::prefixed("JWT_")
-            .from_env()
-            .expect("Provide missing environment variables for JWT (JWT_AUDIENCE, JWT_DOMAIN)")
+            .from_env::<Self>()
+            .map_err(anyhow::Error::from)
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -14,7 +14,8 @@ fn default_host() -> String {
 
 impl Config {
     pub fn from_env() -> Result<Self, anyhow::Error> {
-        envy::from_env::<Self>().map_err(anyhow::Error::from)
+        use anyhow::Context as _;
+        envy::from_env::<Self>().context("missing environment variables for Config")
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,3 +1,4 @@
+use anyhow::Context as _;
 use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize)]
@@ -14,7 +15,6 @@ fn default_host() -> String {
 
 impl Config {
     pub fn from_env() -> Result<Self, anyhow::Error> {
-        use anyhow::Context as _;
         envy::from_env::<Self>().context("missing environment variables for Config")
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -12,9 +12,9 @@ fn default_host() -> String {
     "127.0.0.1".to_string()
 }
 
-impl Default for Config {
-    fn default() -> Self {
-        envy::from_env::<Config>().expect("Provide missing environment variables for Config")
+impl Config {
+    pub fn from_env() -> Result<Self, anyhow::Error> {
+        envy::from_env::<Self>().map_err(anyhow::Error::from)
     }
 }
 


### PR DESCRIPTION
- main.rs: change main() to return Result<(), anyhow::Error>;
  convert fetch_port/fetch_database_url/fetch_allowed_origins to
  return Result and propagate errors with ? instead of panic!
- claims.rs: replace Default impl (which panicked) with a
  JwtConfig::from_env() -> Result<Self, anyhow::Error> method;
  update main.rs call site accordingly
- types.rs: replace Default impl (which panicked) with a
  Config::from_env() -> Result<Self, anyhow::Error> method
- book.rs: change .unwrap() on the static ISBN regex to .expect()
  with an explanatory message (static Lazy cannot return Result;
  the pattern is a hardcoded literal and can never be invalid)

https://claude.ai/code/session_01DE6M7ATn5o2YGnTsVGtzGf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **リファクタリング**
  * アプリケーションのスタートアップ処理を改善しました。データベース接続、認証設定、CORS設定、ポート番号の読み込み時に問題が発生した場合、より詳細なエラーメッセージが表示されるようになります。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->