### PR TITLE
Add author update and delete functionality

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,9 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(cargo test *)",
+      "Bash(cargo fmt *)",
+      "Bash(cargo clippy *)"
+    ]
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,7 +3,10 @@
     "allow": [
       "Bash(cargo test *)",
       "Bash(cargo fmt *)",
-      "Bash(cargo clippy *)"
+      "Bash(cargo clippy *)",
+      "Bash(git --no-pager status *)",
+      "Bash(git --no-pager diff *)",
+      "Bash(git --no-pager log *)"
     ]
   }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,13 +42,20 @@ Never commit or make file changes while on the `main` branch.
 
 ## Pre-commit Checks
 
-Before committing, run the following and ensure all pass:
+**MANDATORY — do not skip under any circumstances**, except:
+- The user explicitly grants permission to skip
+- The commit contains only documentation changes (e.g. `.md` files)
+
+Before EVERY commit, run ALL of the following in order and ensure ALL pass.
+If any command fails, fix the issue before committing. Do not commit with failures.
 
 ```bash
 cargo fmt --check
 cargo clippy
 cargo test
 ```
+
+If `cargo fmt --check` fails, run `cargo fmt` to fix formatting, then re-run the check.
 
 ## ExecPlans
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,15 @@ Never commit or make file changes while on the `main` branch.
 - Keep commits granular — commit at logical breakpoints rather than batching all changes together
 - Separate renames from edits: do not combine file renaming with content changes in the same commit
 
+## Testing
+
+When adding or modifying features, always include tests:
+
+- **Unit tests** — mandatory. Cover the logic being added or changed.
+- **E2E tests** — mandatory when a new API endpoint is added. For other
+  changes, assess whether E2E tests are needed, present your conclusion to
+  the user, and let the user make the final decision.
+
 ## Code Quality
 
 - Follow existing codebase conventions and reuse available libraries

--- a/e2e/tests/e2e.rs
+++ b/e2e/tests/e2e.rs
@@ -862,6 +862,46 @@ async fn e2e_graphql_update_author() -> Result<()> {
 
 #[tokio::test]
 #[serial]
+async fn e2e_graphql_update_nonexistent_author_returns_error() -> Result<()> {
+    let user_id = uuid::Uuid::new_v4().to_string();
+    let token = generate_test_token(&user_id)?;
+    ensure_user_registered(&token).await?;
+
+    let nonexistent_id = uuid::Uuid::new_v4().to_string();
+    let query = format!(
+        r#"mutation {{ updateAuthor(authorData: {{ id: "{}", name: "Ghost" }}) {{ id name }} }}"#,
+        nonexistent_id
+    );
+    let (_, response) = graphql_request(&query, Some(&token)).await?;
+    assert!(
+        response.get("errors").is_some(),
+        "updateAuthor should return errors for a non-existent author"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
+async fn e2e_graphql_delete_nonexistent_author_returns_error() -> Result<()> {
+    let user_id = uuid::Uuid::new_v4().to_string();
+    let token = generate_test_token(&user_id)?;
+    ensure_user_registered(&token).await?;
+
+    let nonexistent_id = uuid::Uuid::new_v4().to_string();
+    let query = format!(
+        r#"mutation {{ deleteAuthor(authorId: "{}") }}"#,
+        nonexistent_id
+    );
+    let (_, response) = graphql_request(&query, Some(&token)).await?;
+    assert!(
+        response.get("errors").is_some(),
+        "deleteAuthor should return errors for a non-existent author"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
 async fn e2e_graphql_create_book_without_auth() -> Result<()> {
     let query = r#"
         mutation {

--- a/e2e/tests/e2e.rs
+++ b/e2e/tests/e2e.rs
@@ -781,6 +781,87 @@ async fn e2e_graphql_delete_author_with_associated_books_fails() -> Result<()> {
 
 #[tokio::test]
 #[serial]
+async fn e2e_graphql_update_author() -> Result<()> {
+    let user_id = uuid::Uuid::new_v4().to_string();
+    let token = generate_test_token(&user_id)?;
+    ensure_user_registered(&token).await?;
+
+    // Create author
+    let original_name = format!("Author Before Update {}", uuid::Uuid::new_v4());
+    let create_query = format!(
+        r#"mutation {{ createAuthor(authorData: {{ name: "{}" }}) {{ id name }} }}"#,
+        original_name
+    );
+    let (_, response) = graphql_request(&create_query, Some(&token)).await?;
+    let author_id = response["data"]["createAuthor"]["id"]
+        .as_str()
+        .context("id should be string")?
+        .to_owned();
+
+    // Create book associated with the author
+    let create_book_query = format!(
+        r#"
+        mutation {{
+            createBook(bookData: {{
+                title: "Book For Author Update Test"
+                authorIds: ["{}"]
+                isbn: ""
+                read: false
+                owned: false
+                priority: 50
+                format: E_BOOK
+                store: KINDLE
+            }}) {{ id }}
+        }}
+        "#,
+        author_id
+    );
+    let (_, response) = graphql_request(&create_book_query, Some(&token)).await?;
+    let book_id = response["data"]["createBook"]["id"]
+        .as_str()
+        .context("id should be string")?
+        .to_owned();
+
+    // Update author name while the author has an associated book
+    let updated_name = format!("Author After Update {}", uuid::Uuid::new_v4());
+    let update_query = format!(
+        r#"mutation {{ updateAuthor(authorData: {{ id: "{}", name: "{}" }}) {{ id name }} }}"#,
+        author_id, updated_name
+    );
+    let (_, response) = graphql_request(&update_query, Some(&token)).await?;
+    assert!(
+        response.get("errors").is_none(),
+        "updateAuthor should not return errors"
+    );
+    let update_result = &response["data"]["updateAuthor"];
+    assert_eq!(
+        update_result["id"].as_str(),
+        Some(author_id.as_str()),
+        "updated author id should match"
+    );
+    assert_eq!(
+        update_result["name"].as_str(),
+        Some(updated_name.as_str()),
+        "updated author name should match"
+    );
+
+    // Verify update by fetching the author
+    let query = format!(r#"{{ author(id: "{}") {{ id name }} }}"#, author_id);
+    let (_, response) = graphql_request(&query, Some(&token)).await?;
+    assert_eq!(
+        response["data"]["author"]["name"].as_str(),
+        Some(updated_name.as_str()),
+        "author name should reflect the update"
+    );
+
+    // Clean up: delete book first, then author
+    delete_test_book(&book_id, &token).await?;
+    delete_test_author(&author_id, &token).await?;
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
 async fn e2e_graphql_create_book_without_auth() -> Result<()> {
     let query = r#"
         mutation {

--- a/e2e/tests/e2e.rs
+++ b/e2e/tests/e2e.rs
@@ -224,6 +224,21 @@ async fn graphql_request(query: &str, token: Option<&str>) -> Result<(u16, serde
     Ok((status, body))
 }
 
+async fn delete_test_author(author_id: &str, token: &str) -> Result<()> {
+    let query = format!(r#"mutation {{ deleteAuthor(authorId: "{}") }}"#, author_id);
+    let (status, response) = graphql_request(&query, Some(token)).await?;
+
+    if status != 200 {
+        anyhow::bail!("deleteAuthor should return 200, got {}", status);
+    }
+
+    if let Some(errors) = response.get("errors") {
+        anyhow::bail!("deleteAuthor has errors: {:?}", errors);
+    }
+
+    Ok(())
+}
+
 async fn delete_test_book(book_id: &str, token: &str) -> Result<()> {
     let query = format!(r#"mutation {{ deleteBook(bookId: "{}") }}"#, book_id);
     let (status, response) = graphql_request(&query, Some(token)).await?;
@@ -666,6 +681,101 @@ async fn e2e_graphql_book_with_invalid_id() -> Result<()> {
     let data = response.get("data").context("data field must exist")?;
     let book = data.get("book").context("book field must exist")?;
     assert!(book.is_null(), "book with invalid ID should be null");
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
+async fn e2e_graphql_delete_author_without_books_succeeds() -> Result<()> {
+    let user_id = uuid::Uuid::new_v4().to_string();
+    let token = generate_test_token(&user_id)?;
+    ensure_user_registered(&token).await?;
+
+    let random_name = format!("Author To Delete {}", uuid::Uuid::new_v4());
+    let create_query = format!(
+        r#"mutation {{ createAuthor(authorData: {{ name: "{}" }}) {{ id }} }}"#,
+        random_name
+    );
+    let (_, response) = graphql_request(&create_query, Some(&token)).await?;
+    let author_id = response["data"]["createAuthor"]["id"]
+        .as_str()
+        .context("id should be string")?
+        .to_owned();
+
+    delete_test_author(&author_id, &token).await?;
+
+    // Verify author no longer exists
+    let query = format!(r#"{{ author(id: "{}") {{ id }} }}"#, author_id);
+    let (_, response) = graphql_request(&query, Some(&token)).await?;
+    assert!(
+        response["data"]["author"].is_null(),
+        "author should be null after deletion"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
+async fn e2e_graphql_delete_author_with_associated_books_fails() -> Result<()> {
+    let user_id = uuid::Uuid::new_v4().to_string();
+    let token = generate_test_token(&user_id)?;
+    ensure_user_registered(&token).await?;
+
+    // Create author
+    let random_name = format!("Author With Book {}", uuid::Uuid::new_v4());
+    let create_author_query = format!(
+        r#"mutation {{ createAuthor(authorData: {{ name: "{}" }}) {{ id }} }}"#,
+        random_name
+    );
+    let (_, response) = graphql_request(&create_author_query, Some(&token)).await?;
+    let author_id = response["data"]["createAuthor"]["id"]
+        .as_str()
+        .context("id should be string")?
+        .to_owned();
+
+    // Create book associated with the author
+    let create_book_query = format!(
+        r#"
+        mutation {{
+            createBook(bookData: {{
+                title: "Book Blocking Author Delete"
+                authorIds: ["{}"]
+                isbn: ""
+                read: false
+                owned: false
+                priority: 50
+                format: E_BOOK
+                store: KINDLE
+            }}) {{ id }}
+        }}
+        "#,
+        author_id
+    );
+    let (_, response) = graphql_request(&create_book_query, Some(&token)).await?;
+    let book_id = response["data"]["createBook"]["id"]
+        .as_str()
+        .context("id should be string")?
+        .to_owned();
+
+    // Attempt to delete the author — must fail
+    let delete_author_query = format!(r#"mutation {{ deleteAuthor(authorId: "{}") }}"#, author_id);
+    let (_, response) = graphql_request(&delete_author_query, Some(&token)).await?;
+    assert!(
+        response.get("errors").is_some(),
+        "deleteAuthor should return errors when author has associated books"
+    );
+
+    // Verify the author still exists
+    let query = format!(r#"{{ author(id: "{}") {{ id }} }}"#, author_id);
+    let (_, response) = graphql_request(&query, Some(&token)).await?;
+    assert!(
+        !response["data"]["author"].is_null(),
+        "author should still exist after failed deletion"
+    );
+
+    // Clean up: delete book first, then author
+    delete_test_book(&book_id, &token).await?;
+    delete_test_author(&author_id, &token).await?;
     Ok(())
 }
 

--- a/e2e/tests/e2e.rs
+++ b/e2e/tests/e2e.rs
@@ -236,6 +236,20 @@ async fn delete_test_author(author_id: &str, token: &str) -> Result<()> {
         anyhow::bail!("deleteAuthor has errors: {:?}", errors);
     }
 
+    let data = response.get("data").context("data field must exist")?;
+    let delete_result = data
+        .get("deleteAuthor")
+        .context("deleteAuthor field must exist")?;
+
+    let delete_result_str = delete_result
+        .as_str()
+        .context("deleteAuthor result should be a string")?;
+
+    assert_eq!(
+        delete_result_str, author_id,
+        "deleted author id should match the requested author_id"
+    );
+
     Ok(())
 }
 

--- a/src/dependency_injection.rs
+++ b/src/dependency_injection.rs
@@ -8,7 +8,7 @@ use crate::{
     },
     presentation::graphql::{mutation::Mutation, query::Query, schema::build_schema},
     use_case::interactor::{
-        author::CreateAuthorInteractor,
+        author::{CreateAuthorInteractor, DeleteAuthorInteractor, UpdateAuthorInteractor},
         book::{CreateBookInteractor, DeleteBookInteractor, UpdateBookInteractor},
         mutation::MutationInteractor,
         query::QueryInteractor,
@@ -23,6 +23,8 @@ pub type MI = MutationInteractor<
     UpdateBookInteractor<PgBookRepository>,
     DeleteBookInteractor<PgBookRepository>,
     CreateAuthorInteractor<PgAuthorRepository>,
+    UpdateAuthorInteractor<PgAuthorRepository>,
+    DeleteAuthorInteractor<PgAuthorRepository>,
 >;
 
 pub fn dependency_injection(
@@ -41,13 +43,17 @@ pub fn dependency_injection(
     let create_book_use_case = CreateBookInteractor::new(book_repository.clone());
     let update_book_use_case = UpdateBookInteractor::new(book_repository.clone());
     let delete_book_use_case = DeleteBookInteractor::new(book_repository);
-    let create_author_use_case = CreateAuthorInteractor::new(author_repository);
+    let create_author_use_case = CreateAuthorInteractor::new(author_repository.clone());
+    let update_author_use_case = UpdateAuthorInteractor::new(author_repository.clone());
+    let delete_author_use_case = DeleteAuthorInteractor::new(author_repository);
     let mutation_use_case = MutationInteractor::new(
         register_user_use_case,
         create_book_use_case,
         update_book_use_case,
         delete_book_use_case,
         create_author_use_case,
+        update_author_use_case,
+        delete_author_use_case,
     );
 
     let query = Query::new(query_use_case.clone());

--- a/src/domain/entity/author.rs
+++ b/src/domain/entity/author.rs
@@ -74,10 +74,6 @@ impl Author {
         Ok(Author { id, name })
     }
 
-    pub fn set_name(&mut self, name: AuthorName) {
-        self.name = name;
-    }
-
     pub fn destructure(self) -> DestructureAuthor {
         DestructureAuthor {
             id: self.id,

--- a/src/domain/entity/author.rs
+++ b/src/domain/entity/author.rs
@@ -74,6 +74,10 @@ impl Author {
         Ok(Author { id, name })
     }
 
+    pub fn set_name(&mut self, name: AuthorName) {
+        self.name = name;
+    }
+
     pub fn destructure(self) -> DestructureAuthor {
         DestructureAuthor {
             id: self.id,

--- a/src/domain/error.rs
+++ b/src/domain/error.rs
@@ -13,6 +13,8 @@ pub enum DomainError {
         entity_id: String,
         user_id: String,
     },
+    #[error(r#"author "{author_id}" has associated books and cannot be deleted."#)]
+    HasAssociatedBooks { author_id: String, user_id: String },
     #[error(transparent)]
     InfrastructureError(anyhow::Error),
     #[error("{0}")]

--- a/src/domain/repository/author_repository.rs
+++ b/src/domain/repository/author_repository.rs
@@ -26,4 +26,6 @@ pub trait AuthorRepository: Send + Sync + 'static {
         user_id: &UserId,
         author_ids: &[AuthorId],
     ) -> Result<HashMap<AuthorId, Author>, DomainError>;
+    async fn update(&self, user_id: &UserId, author: &Author) -> Result<(), DomainError>;
+    async fn delete(&self, user_id: &UserId, author_id: &AuthorId) -> Result<(), DomainError>;
 }

--- a/src/infrastructure/author_repository.rs
+++ b/src/infrastructure/author_repository.rs
@@ -109,22 +109,6 @@ impl AuthorRepository for PgAuthorRepository {
     async fn delete(&self, user_id: &UserId, author_id: &AuthorId) -> Result<(), DomainError> {
         let mut tx = self.pool.begin().await?;
 
-        let exists: bool = sqlx::query_scalar(
-            "SELECT EXISTS(SELECT 1 FROM author WHERE id = $1 AND user_id = $2)",
-        )
-        .bind(author_id.to_uuid())
-        .bind(user_id.as_str())
-        .fetch_one(&mut *tx)
-        .await?;
-
-        if !exists {
-            return Err(DomainError::NotFound {
-                entity_type: "author",
-                entity_id: author_id.to_string(),
-                user_id: user_id.to_owned().into_string(),
-            });
-        }
-
         // book_author references author via FK with no CASCADE, so delete it first.
         sqlx::query("DELETE FROM book_author WHERE user_id = $1 AND author_id = $2")
             .bind(user_id.as_str())
@@ -140,9 +124,11 @@ impl AuthorRepository for PgAuthorRepository {
 
         match result.rows_affected() {
             0 => {
-                return Err(DomainError::Unexpected(String::from(
-                    "Author disappeared between existence check and delete.",
-                )));
+                return Err(DomainError::NotFound {
+                    entity_type: "author",
+                    entity_id: author_id.to_string(),
+                    user_id: user_id.to_owned().into_string(),
+                });
             }
             1 => {}
             _ => {
@@ -425,11 +411,9 @@ mod tests {
 
         // book_author row must be gone — find_by_id returns the book with no authors
         let book_after = book_repository.find_by_id(&user_id, book.id()).await?;
-        assert!(
-            book_after
-                .map(|b| b.author_ids().is_empty())
-                .unwrap_or(true)
-        );
+        assert!(book_after.is_some());
+        let book_after = book_after.unwrap();
+        assert!(book_after.author_ids().is_empty());
 
         Ok(())
     }

--- a/src/infrastructure/author_repository.rs
+++ b/src/infrastructure/author_repository.rs
@@ -84,13 +84,14 @@ impl AuthorRepository for PgAuthorRepository {
     }
 
     async fn update(&self, user_id: &UserId, author: &Author) -> Result<(), DomainError> {
-        let result =
-            sqlx::query("UPDATE author SET name = $1, updated_at = now() WHERE id = $2 AND user_id = $3")
-                .bind(author.name().as_str())
-                .bind(author.id().to_uuid())
-                .bind(user_id.as_str())
-                .execute(&self.pool)
-                .await?;
+        let result = sqlx::query(
+            "UPDATE author SET name = $1, updated_at = now() WHERE id = $2 AND user_id = $3",
+        )
+        .bind(author.name().as_str())
+        .bind(author.id().to_uuid())
+        .bind(user_id.as_str())
+        .execute(&self.pool)
+        .await?;
 
         match result.rows_affected() {
             0 => Err(DomainError::NotFound {

--- a/src/infrastructure/author_repository.rs
+++ b/src/infrastructure/author_repository.rs
@@ -109,7 +109,23 @@ impl AuthorRepository for PgAuthorRepository {
     async fn delete(&self, user_id: &UserId, author_id: &AuthorId) -> Result<(), DomainError> {
         let mut tx = self.pool.begin().await?;
 
-        // Delete book_author rows first to satisfy the FK constraint on author.
+        let exists: bool = sqlx::query_scalar(
+            "SELECT EXISTS(SELECT 1 FROM author WHERE id = $1 AND user_id = $2)",
+        )
+        .bind(author_id.to_uuid())
+        .bind(user_id.as_str())
+        .fetch_one(&mut *tx)
+        .await?;
+
+        if !exists {
+            return Err(DomainError::NotFound {
+                entity_type: "author",
+                entity_id: author_id.to_string(),
+                user_id: user_id.to_owned().into_string(),
+            });
+        }
+
+        // book_author references author via FK with no CASCADE, so delete it first.
         sqlx::query("DELETE FROM book_author WHERE user_id = $1 AND author_id = $2")
             .bind(user_id.as_str())
             .bind(author_id.to_uuid())
@@ -124,11 +140,9 @@ impl AuthorRepository for PgAuthorRepository {
 
         match result.rows_affected() {
             0 => {
-                return Err(DomainError::NotFound {
-                    entity_type: "author",
-                    entity_id: author_id.to_string(),
-                    user_id: user_id.to_owned().into_string(),
-                });
+                return Err(DomainError::Unexpected(String::from(
+                    "Author disappeared between existence check and delete.",
+                )));
             }
             1 => {}
             _ => {

--- a/src/infrastructure/author_repository.rs
+++ b/src/infrastructure/author_repository.rs
@@ -83,6 +83,54 @@ impl AuthorRepository for PgAuthorRepository {
         authors
     }
 
+    async fn update(&self, user_id: &UserId, author: &Author) -> Result<(), DomainError> {
+        let result =
+            sqlx::query("UPDATE author SET name = $1, updated_at = now() WHERE id = $2 AND user_id = $3")
+                .bind(author.name().as_str())
+                .bind(author.id().to_uuid())
+                .bind(user_id.as_str())
+                .execute(&self.pool)
+                .await?;
+
+        match result.rows_affected() {
+            0 => Err(DomainError::NotFound {
+                entity_type: "author",
+                entity_id: author.id().to_string(),
+                user_id: user_id.to_owned().into_string(),
+            }),
+            1 => Ok(()),
+            _ => Err(DomainError::Unexpected(String::from(
+                "rows_affected is greater than 1.",
+            ))),
+        }
+    }
+
+    async fn delete(&self, user_id: &UserId, author_id: &AuthorId) -> Result<(), DomainError> {
+        sqlx::query("DELETE FROM book_author WHERE user_id = $1 AND author_id = $2")
+            .bind(user_id.as_str())
+            .bind(author_id.to_uuid())
+            .execute(&self.pool)
+            .await?;
+
+        let result = sqlx::query("DELETE FROM author WHERE id = $1 AND user_id = $2")
+            .bind(author_id.to_uuid())
+            .bind(user_id.as_str())
+            .execute(&self.pool)
+            .await?;
+
+        match result.rows_affected() {
+            0 => Err(DomainError::NotFound {
+                entity_type: "author",
+                entity_id: author_id.to_string(),
+                user_id: user_id.to_owned().into_string(),
+            }),
+            1 => Ok(()),
+            _ => Err(DomainError::Unexpected(String::from(
+                "rows_affected is greater than 1.",
+            ))),
+        }
+    }
+
     async fn find_by_ids_as_hash_map(
         &self,
         user_id: &UserId,

--- a/src/infrastructure/author_repository.rs
+++ b/src/infrastructure/author_repository.rs
@@ -109,6 +109,22 @@ impl AuthorRepository for PgAuthorRepository {
     async fn delete(&self, user_id: &UserId, author_id: &AuthorId) -> Result<(), DomainError> {
         let mut tx = self.pool.begin().await?;
 
+        // Lock the author row to prevent concurrent inserts into book_author after the count check.
+        let locked: Option<(Uuid,)> =
+            sqlx::query_as("SELECT id FROM author WHERE id = $1 AND user_id = $2 FOR UPDATE")
+                .bind(author_id.to_uuid())
+                .bind(user_id.as_str())
+                .fetch_optional(&mut *tx)
+                .await?;
+
+        if locked.is_none() {
+            return Err(DomainError::NotFound {
+                entity_type: "author",
+                entity_id: author_id.to_string(),
+                user_id: user_id.to_owned().into_string(),
+            });
+        }
+
         let (count,): (i64,) = sqlx::query_as(
             "SELECT COUNT(*) FROM book_author WHERE user_id = $1 AND author_id = $2",
         )

--- a/src/infrastructure/author_repository.rs
+++ b/src/infrastructure/author_repository.rs
@@ -109,12 +109,20 @@ impl AuthorRepository for PgAuthorRepository {
     async fn delete(&self, user_id: &UserId, author_id: &AuthorId) -> Result<(), DomainError> {
         let mut tx = self.pool.begin().await?;
 
-        // book_author references author via FK with no CASCADE, so delete it first.
-        sqlx::query("DELETE FROM book_author WHERE user_id = $1 AND author_id = $2")
-            .bind(user_id.as_str())
-            .bind(author_id.to_uuid())
-            .execute(&mut *tx)
-            .await?;
+        let (count,): (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM book_author WHERE user_id = $1 AND author_id = $2",
+        )
+        .bind(user_id.as_str())
+        .bind(author_id.to_uuid())
+        .fetch_one(&mut *tx)
+        .await?;
+
+        if count > 0 {
+            return Err(DomainError::HasAssociatedBooks {
+                author_id: author_id.to_string(),
+                user_id: user_id.to_owned().into_string(),
+            });
+        }
 
         let result = sqlx::query("DELETE FROM author WHERE id = $1 AND user_id = $2")
             .bind(author_id.to_uuid())
@@ -390,7 +398,7 @@ mod tests {
     }
 
     #[sqlx::test]
-    async fn delete_removes_author_and_book_author_rows(pool: PgPool) -> anyhow::Result<()> {
+    async fn delete_fails_when_author_has_associated_books(pool: PgPool) -> anyhow::Result<()> {
         let user_repository = PgUserRepository::new(pool.clone());
         let author_repository = PgAuthorRepository::new(pool.clone());
         let book_repository = PgBookRepository::new(pool.clone());
@@ -404,16 +412,36 @@ mod tests {
         let book = make_book("675bc8d9-3155-42fb-87b0-0a82cb162848", &[author_id.clone()])?;
         book_repository.create(&user_id, &book).await?;
 
+        let result = author_repository.delete(&user_id, &author_id).await;
+        assert!(matches!(
+            result,
+            Err(DomainError::HasAssociatedBooks { .. })
+        ));
+
+        // author and book_author must still exist
+        let found = author_repository.find_by_id(&user_id, &author_id).await?;
+        assert!(found.is_some());
+
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn delete_succeeds_when_author_has_no_associated_books(
+        pool: PgPool,
+    ) -> anyhow::Result<()> {
+        let user_repository = PgUserRepository::new(pool.clone());
+        let author_repository = PgAuthorRepository::new(pool.clone());
+
+        let user_id = prepare_user(&user_repository, "user1").await?;
+
+        let author_id = AuthorId::try_from("e324be11-5b77-4ba6-8423-9f27e2d228f1")?;
+        let author = Author::new(author_id.clone(), AuthorName::new("author1".to_string())?)?;
+        author_repository.create(&user_id, &author).await?;
+
         author_repository.delete(&user_id, &author_id).await?;
 
         let found = author_repository.find_by_id(&user_id, &author_id).await?;
         assert_eq!(found, None);
-
-        // book_author row must be gone — find_by_id returns the book with no authors
-        let book_after = book_repository.find_by_id(&user_id, book.id()).await?;
-        assert!(book_after.is_some());
-        let book_after = book_after.unwrap();
-        assert!(book_after.author_ids().is_empty());
 
         Ok(())
     }
@@ -433,7 +461,9 @@ mod tests {
     }
 
     #[sqlx::test]
-    async fn delete_does_not_touch_other_users_book_author(pool: PgPool) -> anyhow::Result<()> {
+    async fn delete_does_not_affect_other_users_when_book_association_blocks(
+        pool: PgPool,
+    ) -> anyhow::Result<()> {
         let user_repository = PgUserRepository::new(pool.clone());
         let author_repository = PgAuthorRepository::new(pool.clone());
         let book_repository = PgBookRepository::new(pool.clone());
@@ -453,9 +483,14 @@ mod tests {
         let book2 = make_book("675bc8d9-3155-42fb-87b0-0a82cb162848", &[author_id.clone()])?;
         book_repository.create(&user2_id, &book2).await?;
 
-        // user2 deletes their copy of the author — must not affect user1's book_author
-        author_repository.delete(&user2_id, &author_id).await?;
+        // user2 has an associated book, so delete must fail
+        let result = author_repository.delete(&user2_id, &author_id).await;
+        assert!(matches!(
+            result,
+            Err(DomainError::HasAssociatedBooks { .. })
+        ));
 
+        // user1's book_author row must be intact
         let user1_book = book_repository
             .find_by_id(&user1_id, book1.id())
             .await?

--- a/src/infrastructure/author_repository.rs
+++ b/src/infrastructure/author_repository.rs
@@ -107,29 +107,39 @@ impl AuthorRepository for PgAuthorRepository {
     }
 
     async fn delete(&self, user_id: &UserId, author_id: &AuthorId) -> Result<(), DomainError> {
-        sqlx::query("DELETE FROM book_author WHERE user_id = $1 AND author_id = $2")
-            .bind(user_id.as_str())
-            .bind(author_id.to_uuid())
-            .execute(&self.pool)
-            .await?;
+        let mut tx = self.pool.begin().await?;
 
         let result = sqlx::query("DELETE FROM author WHERE id = $1 AND user_id = $2")
             .bind(author_id.to_uuid())
             .bind(user_id.as_str())
-            .execute(&self.pool)
+            .execute(&mut *tx)
             .await?;
 
         match result.rows_affected() {
-            0 => Err(DomainError::NotFound {
-                entity_type: "author",
-                entity_id: author_id.to_string(),
-                user_id: user_id.to_owned().into_string(),
-            }),
-            1 => Ok(()),
-            _ => Err(DomainError::Unexpected(String::from(
-                "rows_affected is greater than 1.",
-            ))),
+            0 => {
+                return Err(DomainError::NotFound {
+                    entity_type: "author",
+                    entity_id: author_id.to_string(),
+                    user_id: user_id.to_owned().into_string(),
+                });
+            }
+            1 => {}
+            _ => {
+                return Err(DomainError::Unexpected(String::from(
+                    "rows_affected is greater than 1.",
+                )));
+            }
         }
+
+        sqlx::query("DELETE FROM book_author WHERE user_id = $1 AND author_id = $2")
+            .bind(user_id.as_str())
+            .bind(author_id.to_uuid())
+            .execute(&mut *tx)
+            .await?;
+
+        tx.commit().await?;
+
+        Ok(())
     }
 
     async fn find_by_ids_as_hash_map(
@@ -169,8 +179,20 @@ impl AuthorRepository for PgAuthorRepository {
 mod tests {
 
     use crate::{
-        domain::{entity::user::User, repository::user_repository::UserRepository},
-        infrastructure::user_repository::PgUserRepository,
+        common::types::{BookFormat, BookStore},
+        domain::{
+            entity::{
+                book::{Book, BookId, BookTitle, Isbn, OwnedFlag, Priority, ReadFlag},
+                user::User,
+            },
+            error::DomainError,
+            repository::{book_repository::BookRepository, user_repository::UserRepository},
+        },
+        infrastructure::{book_repository::PgBookRepository, user_repository::PgUserRepository},
+    };
+    use time::{
+        PrimitiveDateTime,
+        macros::{date, time},
     };
 
     use super::*;
@@ -306,6 +328,171 @@ mod tests {
         assert_eq!(result.len(), 0);
 
         Ok(())
+    }
+
+    #[sqlx::test]
+    async fn update_changes_name(pool: PgPool) -> anyhow::Result<()> {
+        let user_repository = PgUserRepository::new(pool.clone());
+        let author_repository = PgAuthorRepository::new(pool.clone());
+
+        let user_id = prepare_user(&user_repository, "user1").await?;
+
+        let author_id = AuthorId::try_from("e324be11-5b77-4ba6-8423-9f27e2d228f1")?;
+        let author = Author::new(author_id.clone(), AuthorName::new("original".to_string())?)?;
+        author_repository.create(&user_id, &author).await?;
+
+        let updated = Author::new(author_id.clone(), AuthorName::new("updated".to_string())?)?;
+        author_repository.update(&user_id, &updated).await?;
+
+        let actual = author_repository.find_by_id(&user_id, &author_id).await?;
+        assert_eq!(
+            actual.map(|a| a.name().as_str().to_string()),
+            Some("updated".to_string())
+        );
+
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn update_returns_not_found_for_nonexistent_author(pool: PgPool) -> anyhow::Result<()> {
+        let user_repository = PgUserRepository::new(pool.clone());
+        let author_repository = PgAuthorRepository::new(pool.clone());
+
+        let user_id = prepare_user(&user_repository, "user1").await?;
+
+        let author_id = AuthorId::try_from("e324be11-5b77-4ba6-8423-9f27e2d228f1")?;
+        let author = Author::new(author_id, AuthorName::new("name".to_string())?)?;
+
+        let result = author_repository.update(&user_id, &author).await;
+        assert!(matches!(result, Err(DomainError::NotFound { .. })));
+
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn update_returns_not_found_for_other_users_author(pool: PgPool) -> anyhow::Result<()> {
+        let user_repository = PgUserRepository::new(pool.clone());
+        let author_repository = PgAuthorRepository::new(pool.clone());
+
+        let user1_id = prepare_user(&user_repository, "user1").await?;
+        let user2_id = prepare_user(&user_repository, "user2").await?;
+
+        let author_id = AuthorId::try_from("e324be11-5b77-4ba6-8423-9f27e2d228f1")?;
+        let author = Author::new(author_id.clone(), AuthorName::new("name".to_string())?)?;
+        author_repository.create(&user1_id, &author).await?;
+
+        let updated = Author::new(author_id, AuthorName::new("hacked".to_string())?)?;
+        let result = author_repository.update(&user2_id, &updated).await;
+        assert!(matches!(result, Err(DomainError::NotFound { .. })));
+
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn delete_removes_author_and_book_author_rows(pool: PgPool) -> anyhow::Result<()> {
+        let user_repository = PgUserRepository::new(pool.clone());
+        let author_repository = PgAuthorRepository::new(pool.clone());
+        let book_repository = PgBookRepository::new(pool.clone());
+
+        let user_id = prepare_user(&user_repository, "user1").await?;
+
+        let author_id = AuthorId::try_from("e324be11-5b77-4ba6-8423-9f27e2d228f1")?;
+        let author = Author::new(author_id.clone(), AuthorName::new("author1".to_string())?)?;
+        author_repository.create(&user_id, &author).await?;
+
+        let book = make_book("675bc8d9-3155-42fb-87b0-0a82cb162848", &[author_id.clone()])?;
+        book_repository.create(&user_id, &book).await?;
+
+        author_repository.delete(&user_id, &author_id).await?;
+
+        let found = author_repository.find_by_id(&user_id, &author_id).await?;
+        assert_eq!(found, None);
+
+        // book_author row must be gone — find_by_id returns the book with no authors
+        let book_after = book_repository.find_by_id(&user_id, book.id()).await?;
+        assert!(
+            book_after
+                .map(|b| b.author_ids().is_empty())
+                .unwrap_or(true)
+        );
+
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn delete_returns_not_found_for_nonexistent_author(pool: PgPool) -> anyhow::Result<()> {
+        let user_repository = PgUserRepository::new(pool.clone());
+        let author_repository = PgAuthorRepository::new(pool.clone());
+
+        let user_id = prepare_user(&user_repository, "user1").await?;
+
+        let author_id = AuthorId::try_from("e324be11-5b77-4ba6-8423-9f27e2d228f1")?;
+        let result = author_repository.delete(&user_id, &author_id).await;
+        assert!(matches!(result, Err(DomainError::NotFound { .. })));
+
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn delete_does_not_touch_other_users_book_author(pool: PgPool) -> anyhow::Result<()> {
+        let user_repository = PgUserRepository::new(pool.clone());
+        let author_repository = PgAuthorRepository::new(pool.clone());
+        let book_repository = PgBookRepository::new(pool.clone());
+
+        let user1_id = prepare_user(&user_repository, "user1").await?;
+        let user2_id = prepare_user(&user_repository, "user2").await?;
+
+        // Both users have the same author UUID — allowed by composite PK (id, user_id)
+        let author_id = AuthorId::try_from("e324be11-5b77-4ba6-8423-9f27e2d228f1")?;
+        let author1 = Author::new(author_id.clone(), AuthorName::new("author1".to_string())?)?;
+        let author2 = Author::new(author_id.clone(), AuthorName::new("author1".to_string())?)?;
+        author_repository.create(&user1_id, &author1).await?;
+        author_repository.create(&user2_id, &author2).await?;
+
+        let book1 = make_book("675bc8d9-3155-42fb-87b0-0a82cb162848", &[author_id.clone()])?;
+        book_repository.create(&user1_id, &book1).await?;
+        let book2 = make_book("675bc8d9-3155-42fb-87b0-0a82cb162848", &[author_id.clone()])?;
+        book_repository.create(&user2_id, &book2).await?;
+
+        // user2 deletes their copy of the author — must not affect user1's book_author
+        author_repository.delete(&user2_id, &author_id).await?;
+
+        let user1_book = book_repository
+            .find_by_id(&user1_id, book1.id())
+            .await?
+            .expect("user1's book must still exist");
+        assert!(
+            user1_book.author_ids().contains(&author_id),
+            "user1's book_author row must be intact"
+        );
+
+        Ok(())
+    }
+
+    fn make_book(book_id_str: &str, author_ids: &[AuthorId]) -> Result<Book, DomainError> {
+        let book_id = BookId::try_from(book_id_str)?;
+        let title = BookTitle::new("title1".to_owned())?;
+        let isbn = Isbn::new("1111111111116".to_owned())?;
+        let read = ReadFlag::new(false);
+        let owned = OwnedFlag::new(false);
+        let priority = Priority::new(50)?;
+        let format = BookFormat::EBook;
+        let store = BookStore::Kindle;
+        let created_at = PrimitiveDateTime::new(date!(2022 - 05 - 05), time!(0:00)).assume_utc();
+        let updated_at = PrimitiveDateTime::new(date!(2022 - 05 - 05), time!(0:00)).assume_utc();
+        Book::new(
+            book_id,
+            title,
+            author_ids.to_vec(),
+            isbn,
+            read,
+            owned,
+            priority,
+            format,
+            store,
+            created_at,
+            updated_at,
+        )
     }
 
     async fn prepare_user(repository: &PgUserRepository, id: &str) -> Result<UserId, DomainError> {

--- a/src/infrastructure/author_repository.rs
+++ b/src/infrastructure/author_repository.rs
@@ -109,6 +109,13 @@ impl AuthorRepository for PgAuthorRepository {
     async fn delete(&self, user_id: &UserId, author_id: &AuthorId) -> Result<(), DomainError> {
         let mut tx = self.pool.begin().await?;
 
+        // Delete book_author rows first to satisfy the FK constraint on author.
+        sqlx::query("DELETE FROM book_author WHERE user_id = $1 AND author_id = $2")
+            .bind(user_id.as_str())
+            .bind(author_id.to_uuid())
+            .execute(&mut *tx)
+            .await?;
+
         let result = sqlx::query("DELETE FROM author WHERE id = $1 AND user_id = $2")
             .bind(author_id.to_uuid())
             .bind(user_id.as_str())
@@ -130,12 +137,6 @@ impl AuthorRepository for PgAuthorRepository {
                 )));
             }
         }
-
-        sqlx::query("DELETE FROM book_author WHERE user_id = $1 AND author_id = $2")
-            .bind(user_id.as_str())
-            .bind(author_id.to_uuid())
-            .execute(&mut *tx)
-            .await?;
 
         tx.commit().await?;
 

--- a/src/presentation/error.rs
+++ b/src/presentation/error.rs
@@ -10,6 +10,8 @@ pub enum PresentationalError {
     NotFound(String),
     #[error("{0}")]
     Validation(String),
+    #[error("{0}")]
+    Conflict(String),
     #[error(transparent)]
     OtherError(Arc<anyhow::Error>),
     #[error("{0}")]
@@ -21,6 +23,7 @@ impl From<UseCaseError> for PresentationalError {
         match err {
             UseCaseError::NotFound { .. } => PresentationalError::NotFound(err.to_string()),
             UseCaseError::Validation(_) => PresentationalError::Validation(err.to_string()),
+            UseCaseError::Conflict(_) => PresentationalError::Conflict(err.to_string()),
             UseCaseError::Other(_) => {
                 PresentationalError::OtherError(Arc::new(anyhow::Error::new(err)))
             }

--- a/src/presentation/graphql/mutation.rs
+++ b/src/presentation/graphql/mutation.rs
@@ -7,7 +7,9 @@ use crate::{
     use_case::traits::mutation::MutationUseCase,
 };
 
-use super::object::{Author, Book, CreateAuthorInput, CreateBookInput, UpdateBookInput, User};
+use super::object::{
+    Author, Book, CreateAuthorInput, CreateBookInput, UpdateAuthorInput, UpdateBookInput, User,
+};
 
 pub struct Mutation<MUC> {
     mutation_use_case: MUC,
@@ -82,6 +84,31 @@ where
             .create_author(&claims.sub, author_data.into())
             .await?;
         Ok(author.into())
+    }
+
+    async fn update_author(
+        &self,
+        ctx: &Context<'_>,
+        author_data: UpdateAuthorInput,
+    ) -> Result<Author, PresentationalError> {
+        let claims = get_claims(ctx)?;
+        let author = self
+            .mutation_use_case
+            .update_author(&claims.sub, author_data.into())
+            .await?;
+        Ok(author.into())
+    }
+
+    async fn delete_author(
+        &self,
+        ctx: &Context<'_>,
+        author_id: ID,
+    ) -> Result<String, PresentationalError> {
+        let claims = get_claims(ctx)?;
+        self.mutation_use_case
+            .delete_author(&claims.sub, author_id.as_str())
+            .await?;
+        Ok(author_id.to_string())
     }
 }
 

--- a/src/presentation/graphql/object.rs
+++ b/src/presentation/graphql/object.rs
@@ -4,8 +4,7 @@ use async_graphql::{ID, InputObject, SimpleObject};
 
 use crate::common::types::{BookFormat as CommonBookFormat, BookStore as CommonBookStore};
 use crate::dependency_injection::QI;
-use crate::use_case::dto::author::AuthorDto;
-use crate::use_case::dto::author::CreateAuthorDto;
+use crate::use_case::dto::author::{AuthorDto, CreateAuthorDto, UpdateAuthorDto};
 use crate::use_case::dto::book::{BookDto, CreateBookDto, UpdateBookDto};
 
 use super::loader::AuthorLoader;
@@ -265,5 +264,17 @@ impl CreateAuthorInput {
 impl From<CreateAuthorInput> for CreateAuthorDto {
     fn from(val: CreateAuthorInput) -> Self {
         CreateAuthorDto::new(val.name)
+    }
+}
+
+#[derive(InputObject)]
+pub struct UpdateAuthorInput {
+    pub id: ID,
+    pub name: String,
+}
+
+impl From<UpdateAuthorInput> for UpdateAuthorDto {
+    fn from(val: UpdateAuthorInput) -> Self {
+        UpdateAuthorDto::new(val.id.to_string(), val.name)
     }
 }

--- a/src/use_case/dto/author.rs
+++ b/src/use_case/dto/author.rs
@@ -26,6 +26,17 @@ impl CreateAuthorDto {
     }
 }
 
+pub struct UpdateAuthorDto {
+    pub id: String,
+    pub name: String,
+}
+
+impl UpdateAuthorDto {
+    pub fn new(id: String, name: String) -> Self {
+        Self { id, name }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::domain::entity::author::{Author, AuthorId, AuthorName};

--- a/src/use_case/error.rs
+++ b/src/use_case/error.rs
@@ -12,6 +12,8 @@ pub enum UseCaseError {
         entity_id: String,
         user_id: String,
     },
+    #[error("{0}")]
+    Conflict(String),
     #[error(transparent)]
     Other(anyhow::Error),
     #[error("{0}")]
@@ -31,6 +33,7 @@ impl From<DomainError> for UseCaseError {
                 entity_id,
                 user_id,
             },
+            DomainError::HasAssociatedBooks { .. } => UseCaseError::Conflict(err.to_string()),
             DomainError::InfrastructureError(_) => UseCaseError::Other(anyhow::Error::new(err)),
             DomainError::Unexpected(message) => UseCaseError::Unexpected(message),
         }
@@ -59,6 +62,16 @@ mod tests {
         };
         let use_case_err = UseCaseError::from(domain_err);
         assert!(matches!(use_case_err, UseCaseError::NotFound { .. }));
+    }
+
+    #[test]
+    fn domain_has_associated_books_becomes_use_case_conflict_error() {
+        let domain_err = DomainError::HasAssociatedBooks {
+            author_id: "author1".to_string(),
+            user_id: "user1".to_string(),
+        };
+        let use_case_err = UseCaseError::from(domain_err);
+        assert!(matches!(use_case_err, UseCaseError::Conflict(_)));
     }
 
     #[test]

--- a/src/use_case/interactor/author.rs
+++ b/src/use_case/interactor/author.rs
@@ -70,17 +70,6 @@ where
         let user_id = UserId::new(user_id.to_string())?;
         let author_id = AuthorId::try_from(author_data.id.as_str())?;
         let author_name = AuthorName::new(author_data.name)?;
-        let existing = self
-            .author_repository
-            .find_by_id(&user_id, &author_id)
-            .await?;
-        if existing.is_none() {
-            return Err(UseCaseError::NotFound {
-                entity_type: "author",
-                entity_id: author_id.to_string(),
-                user_id: user_id.into_string(),
-            });
-        }
         let author = Author::new(author_id, author_name)?;
         self.author_repository.update(&user_id, &author).await?;
         Ok(author.into())
@@ -116,7 +105,7 @@ mod tests {
 
     use crate::{
         domain::{
-            entity::author::{Author, AuthorId, AuthorName},
+            entity::author::{AuthorId, AuthorName},
             error::DomainError,
             repository::author_repository::MockAuthorRepository,
         },
@@ -183,17 +172,8 @@ mod tests {
     async fn update_author_success() {
         // Given
         let author_id_str = "006099b4-6c42-4ec4-8645-f6bd5b63eddc";
-        let existing = Author::new(
-            AuthorId::try_from(author_id_str).unwrap(),
-            AuthorName::new("Old Name".to_string()).unwrap(),
-        )
-        .unwrap();
 
         let mut author_repository = MockAuthorRepository::new();
-        author_repository
-            .expect_find_by_id()
-            .with(always(), always())
-            .returning(move |_, _| Ok(Some(existing.clone())));
         author_repository
             .expect_update()
             .with(always(), always())
@@ -217,9 +197,15 @@ mod tests {
 
         let mut author_repository = MockAuthorRepository::new();
         author_repository
-            .expect_find_by_id()
+            .expect_update()
             .with(always(), always())
-            .returning(|_, _| Ok(None));
+            .returning(|_, _| {
+                Err(DomainError::NotFound {
+                    entity_type: "author",
+                    entity_id: "006099b4-6c42-4ec4-8645-f6bd5b63eddc".to_string(),
+                    user_id: "user1".to_string(),
+                })
+            });
 
         let interactor = UpdateAuthorInteractor::new(author_repository);
         let author_data = UpdateAuthorDto::new(author_id_str.to_string(), "New Name".to_string());

--- a/src/use_case/interactor/author.rs
+++ b/src/use_case/interactor/author.rs
@@ -289,6 +289,31 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn delete_author_propagates_has_associated_books() {
+        // Given
+        let author_id_str = "006099b4-6c42-4ec4-8645-f6bd5b63eddc";
+
+        let mut author_repository = MockAuthorRepository::new();
+        author_repository
+            .expect_delete()
+            .with(always(), always())
+            .returning(|_, _| {
+                Err(DomainError::HasAssociatedBooks {
+                    author_id: "006099b4-6c42-4ec4-8645-f6bd5b63eddc".to_string(),
+                    user_id: "user1".to_string(),
+                })
+            });
+
+        let interactor = DeleteAuthorInteractor::new(author_repository);
+
+        // When
+        let result = interactor.delete("user1", author_id_str).await;
+
+        // Then
+        assert!(matches!(result, Err(UseCaseError::Conflict(_))));
+    }
+
+    #[tokio::test]
     async fn delete_author_fails_with_invalid_author_id() {
         // Given
         let author_repository = MockAuthorRepository::new();

--- a/src/use_case/interactor/author.rs
+++ b/src/use_case/interactor/author.rs
@@ -10,9 +10,9 @@ use crate::{
         repository::author_repository::AuthorRepository,
     },
     use_case::{
-        dto::author::{AuthorDto, CreateAuthorDto},
+        dto::author::{AuthorDto, CreateAuthorDto, UpdateAuthorDto},
         error::UseCaseError,
-        traits::author::CreateAuthorUseCase,
+        traits::author::{CreateAuthorUseCase, DeleteAuthorUseCase, UpdateAuthorUseCase},
     },
 };
 
@@ -44,6 +44,69 @@ where
         self.author_repository.create(&user_id, &author).await?;
 
         Ok(author.into())
+    }
+}
+
+pub struct UpdateAuthorInteractor<AR> {
+    author_repository: AR,
+}
+
+impl<AR> UpdateAuthorInteractor<AR> {
+    pub fn new(author_repository: AR) -> Self {
+        Self { author_repository }
+    }
+}
+
+#[async_trait]
+impl<AR> UpdateAuthorUseCase for UpdateAuthorInteractor<AR>
+where
+    AR: AuthorRepository,
+{
+    async fn update(
+        &self,
+        user_id: &str,
+        author_data: UpdateAuthorDto,
+    ) -> Result<AuthorDto, UseCaseError> {
+        let user_id = UserId::new(user_id.to_string())?;
+        let author_id = AuthorId::try_from(author_data.id.as_str())?;
+        let existing = self
+            .author_repository
+            .find_by_id(&user_id, &author_id)
+            .await?;
+        if existing.is_none() {
+            return Err(UseCaseError::NotFound {
+                entity_type: "author",
+                entity_id: author_data.id,
+                user_id: user_id.into_string(),
+            });
+        }
+        let author_name = AuthorName::new(author_data.name)?;
+        let author = Author::new(author_id, author_name)?;
+        self.author_repository.update(&user_id, &author).await?;
+        Ok(author.into())
+    }
+}
+
+pub struct DeleteAuthorInteractor<AR> {
+    author_repository: AR,
+}
+
+impl<AR> DeleteAuthorInteractor<AR> {
+    pub fn new(author_repository: AR) -> Self {
+        Self { author_repository }
+    }
+}
+
+#[async_trait]
+impl<AR> DeleteAuthorUseCase for DeleteAuthorInteractor<AR>
+where
+    AR: AuthorRepository,
+{
+    async fn delete(&self, user_id: &str, author_id: &str) -> Result<(), UseCaseError> {
+        let user_id = UserId::new(user_id.to_string())?;
+        let author_id = AuthorId::try_from(author_id)?;
+        self.author_repository.delete(&user_id, &author_id).await?;
+        Ok(())
     }
 }
 

--- a/src/use_case/interactor/author.rs
+++ b/src/use_case/interactor/author.rs
@@ -69,6 +69,7 @@ where
     ) -> Result<AuthorDto, UseCaseError> {
         let user_id = UserId::new(user_id.to_string())?;
         let author_id = AuthorId::try_from(author_data.id.as_str())?;
+        let author_name = AuthorName::new(author_data.name)?;
         let existing = self
             .author_repository
             .find_by_id(&user_id, &author_id)
@@ -76,11 +77,10 @@ where
         if existing.is_none() {
             return Err(UseCaseError::NotFound {
                 entity_type: "author",
-                entity_id: author_data.id,
+                entity_id: author_id.to_string(),
                 user_id: user_id.into_string(),
             });
         }
-        let author_name = AuthorName::new(author_data.name)?;
         let author = Author::new(author_id, author_name)?;
         self.author_repository.update(&user_id, &author).await?;
         Ok(author.into())
@@ -115,10 +115,18 @@ mod tests {
     use mockall::predicate::always;
 
     use crate::{
-        domain::repository::author_repository::MockAuthorRepository,
+        domain::{
+            entity::author::{Author, AuthorId, AuthorName},
+            error::DomainError,
+            repository::author_repository::MockAuthorRepository,
+        },
         use_case::{
-            dto::author::CreateAuthorDto, error::UseCaseError,
-            interactor::author::CreateAuthorInteractor, traits::author::CreateAuthorUseCase,
+            dto::author::{CreateAuthorDto, UpdateAuthorDto},
+            error::UseCaseError,
+            interactor::author::{
+                CreateAuthorInteractor, DeleteAuthorInteractor, UpdateAuthorInteractor,
+            },
+            traits::author::{CreateAuthorUseCase, DeleteAuthorUseCase, UpdateAuthorUseCase},
         },
     };
 
@@ -166,6 +174,146 @@ mod tests {
 
         // When
         let result = interactor.create("", author_data).await;
+
+        // Then
+        assert!(matches!(result, Err(UseCaseError::Validation(_))));
+    }
+
+    #[tokio::test]
+    async fn update_author_success() {
+        // Given
+        let author_id_str = "006099b4-6c42-4ec4-8645-f6bd5b63eddc";
+        let existing = Author::new(
+            AuthorId::try_from(author_id_str).unwrap(),
+            AuthorName::new("Old Name".to_string()).unwrap(),
+        )
+        .unwrap();
+
+        let mut author_repository = MockAuthorRepository::new();
+        author_repository
+            .expect_find_by_id()
+            .with(always(), always())
+            .returning(move |_, _| Ok(Some(existing.clone())));
+        author_repository
+            .expect_update()
+            .with(always(), always())
+            .returning(|_, _| Ok(()));
+
+        let interactor = UpdateAuthorInteractor::new(author_repository);
+        let author_data = UpdateAuthorDto::new(author_id_str.to_string(), "New Name".to_string());
+
+        // When
+        let result = interactor.update("user1", author_data).await;
+
+        // Then
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().name, "New Name");
+    }
+
+    #[tokio::test]
+    async fn update_author_not_found() {
+        // Given
+        let author_id_str = "006099b4-6c42-4ec4-8645-f6bd5b63eddc";
+
+        let mut author_repository = MockAuthorRepository::new();
+        author_repository
+            .expect_find_by_id()
+            .with(always(), always())
+            .returning(|_, _| Ok(None));
+
+        let interactor = UpdateAuthorInteractor::new(author_repository);
+        let author_data = UpdateAuthorDto::new(author_id_str.to_string(), "New Name".to_string());
+
+        // When
+        let result = interactor.update("user1", author_data).await;
+
+        // Then
+        assert!(matches!(result, Err(UseCaseError::NotFound { .. })));
+    }
+
+    #[tokio::test]
+    async fn update_author_fails_with_invalid_author_id() {
+        // Given
+        let author_repository = MockAuthorRepository::new();
+        let interactor = UpdateAuthorInteractor::new(author_repository);
+        let author_data = UpdateAuthorDto::new("not-a-uuid".to_string(), "New Name".to_string());
+
+        // When
+        let result = interactor.update("user1", author_data).await;
+
+        // Then
+        assert!(matches!(result, Err(UseCaseError::Validation(_))));
+    }
+
+    #[tokio::test]
+    async fn update_author_fails_with_empty_name() {
+        // Given
+        let author_id_str = "006099b4-6c42-4ec4-8645-f6bd5b63eddc";
+        let author_repository = MockAuthorRepository::new();
+        let interactor = UpdateAuthorInteractor::new(author_repository);
+        let author_data = UpdateAuthorDto::new(author_id_str.to_string(), "".to_string());
+
+        // When
+        let result = interactor.update("user1", author_data).await;
+
+        // Then
+        assert!(matches!(result, Err(UseCaseError::Validation(_))));
+    }
+
+    #[tokio::test]
+    async fn delete_author_success() {
+        // Given
+        let author_id_str = "006099b4-6c42-4ec4-8645-f6bd5b63eddc";
+
+        let mut author_repository = MockAuthorRepository::new();
+        author_repository
+            .expect_delete()
+            .with(always(), always())
+            .returning(|_, _| Ok(()));
+
+        let interactor = DeleteAuthorInteractor::new(author_repository);
+
+        // When
+        let result = interactor.delete("user1", author_id_str).await;
+
+        // Then
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn delete_author_propagates_not_found() {
+        // Given
+        let author_id_str = "006099b4-6c42-4ec4-8645-f6bd5b63eddc";
+
+        let mut author_repository = MockAuthorRepository::new();
+        author_repository
+            .expect_delete()
+            .with(always(), always())
+            .returning(|_, _| {
+                Err(DomainError::NotFound {
+                    entity_type: "author",
+                    entity_id: "006099b4-6c42-4ec4-8645-f6bd5b63eddc".to_string(),
+                    user_id: "user1".to_string(),
+                })
+            });
+
+        let interactor = DeleteAuthorInteractor::new(author_repository);
+
+        // When
+        let result = interactor.delete("user1", author_id_str).await;
+
+        // Then
+        assert!(matches!(result, Err(UseCaseError::NotFound { .. })));
+    }
+
+    #[tokio::test]
+    async fn delete_author_fails_with_invalid_author_id() {
+        // Given
+        let author_repository = MockAuthorRepository::new();
+        let interactor = DeleteAuthorInteractor::new(author_repository);
+
+        // When
+        let result = interactor.delete("user1", "not-a-uuid").await;
 
         // Then
         assert!(matches!(result, Err(UseCaseError::Validation(_))));

--- a/src/use_case/interactor/author.rs
+++ b/src/use_case/interactor/author.rs
@@ -243,6 +243,21 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn update_author_fails_with_invalid_user_id() {
+        // Given
+        let author_id_str = "006099b4-6c42-4ec4-8645-f6bd5b63eddc";
+        let author_repository = MockAuthorRepository::new();
+        let interactor = UpdateAuthorInteractor::new(author_repository);
+        let author_data = UpdateAuthorDto::new(author_id_str.to_string(), "New Name".to_string());
+
+        // When
+        let result = interactor.update("", author_data).await;
+
+        // Then
+        assert!(matches!(result, Err(UseCaseError::Validation(_))));
+    }
+
+    #[tokio::test]
     async fn delete_author_success() {
         // Given
         let author_id_str = "006099b4-6c42-4ec4-8645-f6bd5b63eddc";
@@ -321,6 +336,20 @@ mod tests {
 
         // When
         let result = interactor.delete("user1", "not-a-uuid").await;
+
+        // Then
+        assert!(matches!(result, Err(UseCaseError::Validation(_))));
+    }
+
+    #[tokio::test]
+    async fn delete_author_fails_with_invalid_user_id() {
+        // Given
+        let author_id_str = "006099b4-6c42-4ec4-8645-f6bd5b63eddc";
+        let author_repository = MockAuthorRepository::new();
+        let interactor = DeleteAuthorInteractor::new(author_repository);
+
+        // When
+        let result = interactor.delete("", author_id_str).await;
 
         // Then
         assert!(matches!(result, Err(UseCaseError::Validation(_))));

--- a/src/use_case/interactor/author.rs
+++ b/src/use_case/interactor/author.rs
@@ -104,11 +104,7 @@ mod tests {
     use mockall::predicate::always;
 
     use crate::{
-        domain::{
-            entity::author::{AuthorId, AuthorName},
-            error::DomainError,
-            repository::author_repository::MockAuthorRepository,
-        },
+        domain::{error::DomainError, repository::author_repository::MockAuthorRepository},
         use_case::{
             dto::author::{CreateAuthorDto, UpdateAuthorDto},
             error::UseCaseError,

--- a/src/use_case/interactor/author.rs
+++ b/src/use_case/interactor/author.rs
@@ -69,24 +69,8 @@ where
     ) -> Result<AuthorDto, UseCaseError> {
         let user_id = UserId::new(user_id.to_string())?;
         let author_id = AuthorId::try_from(author_data.id.as_str())?;
-
-        let mut author = match self
-            .author_repository
-            .find_by_id(&user_id, &author_id)
-            .await?
-        {
-            Some(author) => author,
-            None => {
-                return Err(UseCaseError::NotFound {
-                    entity_type: "author",
-                    entity_id: author_data.id,
-                    user_id: user_id.into_string(),
-                });
-            }
-        };
-
         let author_name = AuthorName::new(author_data.name)?;
-        author.set_name(author_name);
+        let author = Author::new(author_id, author_name)?;
         self.author_repository.update(&user_id, &author).await?;
         Ok(author.into())
     }
@@ -120,11 +104,7 @@ mod tests {
     use mockall::predicate::always;
 
     use crate::{
-        domain::{
-            entity::author::{Author, AuthorId, AuthorName},
-            error::DomainError,
-            repository::author_repository::MockAuthorRepository,
-        },
+        domain::{error::DomainError, repository::author_repository::MockAuthorRepository},
         use_case::{
             dto::author::{CreateAuthorDto, UpdateAuthorDto},
             error::UseCaseError,
@@ -188,17 +168,8 @@ mod tests {
     async fn update_author_success() {
         // Given
         let author_id_str = "006099b4-6c42-4ec4-8645-f6bd5b63eddc";
-        let existing_author = Author::new(
-            AuthorId::try_from(author_id_str).unwrap(),
-            AuthorName::new("Old Name".to_string()).unwrap(),
-        )
-        .unwrap();
 
         let mut author_repository = MockAuthorRepository::new();
-        author_repository
-            .expect_find_by_id()
-            .with(always(), always())
-            .returning(move |_, _| Ok(Some(existing_author.clone())));
         author_repository
             .expect_update()
             .with(always(), always())
@@ -222,9 +193,15 @@ mod tests {
 
         let mut author_repository = MockAuthorRepository::new();
         author_repository
-            .expect_find_by_id()
+            .expect_update()
             .with(always(), always())
-            .returning(|_, _| Ok(None));
+            .returning(|_, _| {
+                Err(DomainError::NotFound {
+                    entity_type: "author",
+                    entity_id: "006099b4-6c42-4ec4-8645-f6bd5b63eddc".to_string(),
+                    user_id: "user1".to_string(),
+                })
+            });
 
         let interactor = UpdateAuthorInteractor::new(author_repository);
         let author_data = UpdateAuthorDto::new(author_id_str.to_string(), "New Name".to_string());
@@ -254,18 +231,7 @@ mod tests {
     async fn update_author_fails_with_empty_name() {
         // Given
         let author_id_str = "006099b4-6c42-4ec4-8645-f6bd5b63eddc";
-        let existing_author = Author::new(
-            AuthorId::try_from(author_id_str).unwrap(),
-            AuthorName::new("Old Name".to_string()).unwrap(),
-        )
-        .unwrap();
-
-        let mut author_repository = MockAuthorRepository::new();
-        author_repository
-            .expect_find_by_id()
-            .with(always(), always())
-            .returning(move |_, _| Ok(Some(existing_author.clone())));
-
+        let author_repository = MockAuthorRepository::new();
         let interactor = UpdateAuthorInteractor::new(author_repository);
         let author_data = UpdateAuthorDto::new(author_id_str.to_string(), "".to_string());
 

--- a/src/use_case/interactor/author.rs
+++ b/src/use_case/interactor/author.rs
@@ -69,8 +69,24 @@ where
     ) -> Result<AuthorDto, UseCaseError> {
         let user_id = UserId::new(user_id.to_string())?;
         let author_id = AuthorId::try_from(author_data.id.as_str())?;
+
+        let mut author = match self
+            .author_repository
+            .find_by_id(&user_id, &author_id)
+            .await?
+        {
+            Some(author) => author,
+            None => {
+                return Err(UseCaseError::NotFound {
+                    entity_type: "author",
+                    entity_id: author_data.id,
+                    user_id: user_id.into_string(),
+                });
+            }
+        };
+
         let author_name = AuthorName::new(author_data.name)?;
-        let author = Author::new(author_id, author_name)?;
+        author.set_name(author_name);
         self.author_repository.update(&user_id, &author).await?;
         Ok(author.into())
     }
@@ -104,7 +120,11 @@ mod tests {
     use mockall::predicate::always;
 
     use crate::{
-        domain::{error::DomainError, repository::author_repository::MockAuthorRepository},
+        domain::{
+            entity::author::{Author, AuthorId, AuthorName},
+            error::DomainError,
+            repository::author_repository::MockAuthorRepository,
+        },
         use_case::{
             dto::author::{CreateAuthorDto, UpdateAuthorDto},
             error::UseCaseError,
@@ -168,8 +188,17 @@ mod tests {
     async fn update_author_success() {
         // Given
         let author_id_str = "006099b4-6c42-4ec4-8645-f6bd5b63eddc";
+        let existing_author = Author::new(
+            AuthorId::try_from(author_id_str).unwrap(),
+            AuthorName::new("Old Name".to_string()).unwrap(),
+        )
+        .unwrap();
 
         let mut author_repository = MockAuthorRepository::new();
+        author_repository
+            .expect_find_by_id()
+            .with(always(), always())
+            .returning(move |_, _| Ok(Some(existing_author.clone())));
         author_repository
             .expect_update()
             .with(always(), always())
@@ -193,15 +222,9 @@ mod tests {
 
         let mut author_repository = MockAuthorRepository::new();
         author_repository
-            .expect_update()
+            .expect_find_by_id()
             .with(always(), always())
-            .returning(|_, _| {
-                Err(DomainError::NotFound {
-                    entity_type: "author",
-                    entity_id: "006099b4-6c42-4ec4-8645-f6bd5b63eddc".to_string(),
-                    user_id: "user1".to_string(),
-                })
-            });
+            .returning(|_, _| Ok(None));
 
         let interactor = UpdateAuthorInteractor::new(author_repository);
         let author_data = UpdateAuthorDto::new(author_id_str.to_string(), "New Name".to_string());
@@ -231,7 +254,18 @@ mod tests {
     async fn update_author_fails_with_empty_name() {
         // Given
         let author_id_str = "006099b4-6c42-4ec4-8645-f6bd5b63eddc";
-        let author_repository = MockAuthorRepository::new();
+        let existing_author = Author::new(
+            AuthorId::try_from(author_id_str).unwrap(),
+            AuthorName::new("Old Name".to_string()).unwrap(),
+        )
+        .unwrap();
+
+        let mut author_repository = MockAuthorRepository::new();
+        author_repository
+            .expect_find_by_id()
+            .with(always(), always())
+            .returning(move |_, _| Ok(Some(existing_author.clone())));
+
         let interactor = UpdateAuthorInteractor::new(author_repository);
         let author_data = UpdateAuthorDto::new(author_id_str.to_string(), "".to_string());
 

--- a/src/use_case/interactor/mutation.rs
+++ b/src/use_case/interactor/mutation.rs
@@ -143,6 +143,87 @@ mod tests {
     use time::OffsetDateTime;
     use uuid::Uuid;
 
+    type DefaultInteractor = MutationInteractor<
+        MockRegisterUserUseCase,
+        MockCreateBookUseCase,
+        MockUpdateBookUseCase,
+        MockDeleteBookUseCase,
+        MockCreateAuthorUseCase,
+        MockUpdateAuthorUseCase,
+        MockDeleteAuthorUseCase,
+    >;
+
+    struct InteractorBuilder {
+        register_user: MockRegisterUserUseCase,
+        create_book: MockCreateBookUseCase,
+        update_book: MockUpdateBookUseCase,
+        delete_book: MockDeleteBookUseCase,
+        create_author: MockCreateAuthorUseCase,
+        update_author: MockUpdateAuthorUseCase,
+        delete_author: MockDeleteAuthorUseCase,
+    }
+
+    impl InteractorBuilder {
+        fn new() -> Self {
+            Self {
+                register_user: MockRegisterUserUseCase::new(),
+                create_book: MockCreateBookUseCase::new(),
+                update_book: MockUpdateBookUseCase::new(),
+                delete_book: MockDeleteBookUseCase::new(),
+                create_author: MockCreateAuthorUseCase::new(),
+                update_author: MockUpdateAuthorUseCase::new(),
+                delete_author: MockDeleteAuthorUseCase::new(),
+            }
+        }
+
+        fn with_register_user(mut self, mock: MockRegisterUserUseCase) -> Self {
+            self.register_user = mock;
+            self
+        }
+
+        fn with_create_book(mut self, mock: MockCreateBookUseCase) -> Self {
+            self.create_book = mock;
+            self
+        }
+
+        fn with_update_book(mut self, mock: MockUpdateBookUseCase) -> Self {
+            self.update_book = mock;
+            self
+        }
+
+        fn with_delete_book(mut self, mock: MockDeleteBookUseCase) -> Self {
+            self.delete_book = mock;
+            self
+        }
+
+        fn with_create_author(mut self, mock: MockCreateAuthorUseCase) -> Self {
+            self.create_author = mock;
+            self
+        }
+
+        fn with_update_author(mut self, mock: MockUpdateAuthorUseCase) -> Self {
+            self.update_author = mock;
+            self
+        }
+
+        fn with_delete_author(mut self, mock: MockDeleteAuthorUseCase) -> Self {
+            self.delete_author = mock;
+            self
+        }
+
+        fn build(self) -> DefaultInteractor {
+            MutationInteractor::new(
+                self.register_user,
+                self.create_book,
+                self.update_book,
+                self.delete_book,
+                self.create_author,
+                self.update_author,
+                self.delete_author,
+            )
+        }
+    }
+
     fn make_book_dto(id: &str) -> BookDto {
         BookDto {
             id: id.to_string(),
@@ -168,15 +249,9 @@ mod tests {
             .with(always())
             .returning(|id| Ok(UserDto::new(id.to_string())));
 
-        let interactor = MutationInteractor::new(
-            mock_register_user,
-            MockCreateBookUseCase::new(),
-            MockUpdateBookUseCase::new(),
-            MockDeleteBookUseCase::new(),
-            MockCreateAuthorUseCase::new(),
-            MockUpdateAuthorUseCase::new(),
-            MockDeleteAuthorUseCase::new(),
-        );
+        let interactor = InteractorBuilder::new()
+            .with_register_user(mock_register_user)
+            .build();
 
         // When
         let result = interactor.register_user("user1").await;
@@ -198,15 +273,9 @@ mod tests {
             .with(always(), always())
             .returning(move |_, _| Ok(make_book_dto(&book_id)));
 
-        let interactor = MutationInteractor::new(
-            MockRegisterUserUseCase::new(),
-            mock_create_book,
-            MockUpdateBookUseCase::new(),
-            MockDeleteBookUseCase::new(),
-            MockCreateAuthorUseCase::new(),
-            MockUpdateAuthorUseCase::new(),
-            MockDeleteAuthorUseCase::new(),
-        );
+        let interactor = InteractorBuilder::new()
+            .with_create_book(mock_create_book)
+            .build();
 
         let book_data = CreateBookDto::new(
             "New Book".to_string(),
@@ -239,15 +308,9 @@ mod tests {
             .with(always(), always())
             .returning(move |_, _| Ok(make_book_dto(&book_id)));
 
-        let interactor = MutationInteractor::new(
-            MockRegisterUserUseCase::new(),
-            MockCreateBookUseCase::new(),
-            mock_update_book,
-            MockDeleteBookUseCase::new(),
-            MockCreateAuthorUseCase::new(),
-            MockUpdateAuthorUseCase::new(),
-            MockDeleteAuthorUseCase::new(),
-        );
+        let interactor = InteractorBuilder::new()
+            .with_update_book(mock_update_book)
+            .build();
 
         let book_data = UpdateBookDto::new(
             expected_dto.id.clone(),
@@ -278,15 +341,9 @@ mod tests {
             .with(always(), always())
             .returning(|_, _| Ok(()));
 
-        let interactor = MutationInteractor::new(
-            MockRegisterUserUseCase::new(),
-            MockCreateBookUseCase::new(),
-            MockUpdateBookUseCase::new(),
-            mock_delete_book,
-            MockCreateAuthorUseCase::new(),
-            MockUpdateAuthorUseCase::new(),
-            MockDeleteAuthorUseCase::new(),
-        );
+        let interactor = InteractorBuilder::new()
+            .with_delete_book(mock_delete_book)
+            .build();
 
         // When
         let result = interactor
@@ -311,15 +368,9 @@ mod tests {
                 })
             });
 
-        let interactor = MutationInteractor::new(
-            MockRegisterUserUseCase::new(),
-            MockCreateBookUseCase::new(),
-            MockUpdateBookUseCase::new(),
-            MockDeleteBookUseCase::new(),
-            mock_create_author,
-            MockUpdateAuthorUseCase::new(),
-            MockDeleteAuthorUseCase::new(),
-        );
+        let interactor = InteractorBuilder::new()
+            .with_create_author(mock_create_author)
+            .build();
 
         let author_data = CreateAuthorDto::new("New Author".to_string());
 
@@ -345,15 +396,9 @@ mod tests {
                 })
             });
 
-        let interactor = MutationInteractor::new(
-            MockRegisterUserUseCase::new(),
-            MockCreateBookUseCase::new(),
-            MockUpdateBookUseCase::new(),
-            MockDeleteBookUseCase::new(),
-            MockCreateAuthorUseCase::new(),
-            mock_update_author,
-            MockDeleteAuthorUseCase::new(),
-        );
+        let interactor = InteractorBuilder::new()
+            .with_update_author(mock_update_author)
+            .build();
 
         let author_data = UpdateAuthorDto::new(
             "006099b4-6c42-4ec4-8645-f6bd5b63eddc".to_string(),
@@ -377,15 +422,9 @@ mod tests {
             .with(always(), always())
             .returning(|_, _| Ok(()));
 
-        let interactor = MutationInteractor::new(
-            MockRegisterUserUseCase::new(),
-            MockCreateBookUseCase::new(),
-            MockUpdateBookUseCase::new(),
-            MockDeleteBookUseCase::new(),
-            MockCreateAuthorUseCase::new(),
-            MockUpdateAuthorUseCase::new(),
-            mock_delete_author,
-        );
+        let interactor = InteractorBuilder::new()
+            .with_delete_author(mock_delete_author)
+            .build();
 
         // When
         let result = interactor

--- a/src/use_case/interactor/mutation.rs
+++ b/src/use_case/interactor/mutation.rs
@@ -128,7 +128,7 @@ mod tests {
     use crate::common::types::{BookFormat, BookStore};
     use crate::use_case::{
         dto::{
-            author::{AuthorDto, CreateAuthorDto},
+            author::{AuthorDto, CreateAuthorDto, UpdateAuthorDto},
             book::{BookDto, CreateBookDto, UpdateBookDto},
             user::UserDto,
         },
@@ -355,7 +355,6 @@ mod tests {
             MockDeleteAuthorUseCase::new(),
         );
 
-        use crate::use_case::dto::author::UpdateAuthorDto;
         let author_data = UpdateAuthorDto::new(
             "006099b4-6c42-4ec4-8645-f6bd5b63eddc".to_string(),
             "Updated Author".to_string(),

--- a/src/use_case/interactor/mutation.rs
+++ b/src/use_case/interactor/mutation.rs
@@ -330,4 +330,70 @@ mod tests {
         assert!(result.is_ok());
         assert_eq!(result.unwrap().name, "New Author");
     }
+
+    #[tokio::test]
+    async fn update_author_delegates_to_sub_use_case() {
+        // Given
+        let mut mock_update_author = MockUpdateAuthorUseCase::new();
+        mock_update_author
+            .expect_update()
+            .with(always(), always())
+            .returning(|_, data| {
+                Ok(AuthorDto {
+                    id: "006099b4-6c42-4ec4-8645-f6bd5b63eddc".to_string(),
+                    name: data.name.clone(),
+                })
+            });
+
+        let interactor = MutationInteractor::new(
+            MockRegisterUserUseCase::new(),
+            MockCreateBookUseCase::new(),
+            MockUpdateBookUseCase::new(),
+            MockDeleteBookUseCase::new(),
+            MockCreateAuthorUseCase::new(),
+            mock_update_author,
+            MockDeleteAuthorUseCase::new(),
+        );
+
+        use crate::use_case::dto::author::UpdateAuthorDto;
+        let author_data = UpdateAuthorDto::new(
+            "006099b4-6c42-4ec4-8645-f6bd5b63eddc".to_string(),
+            "Updated Author".to_string(),
+        );
+
+        // When
+        let result = interactor.update_author("user1", author_data).await;
+
+        // Then
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().name, "Updated Author");
+    }
+
+    #[tokio::test]
+    async fn delete_author_delegates_to_sub_use_case() {
+        // Given
+        let mut mock_delete_author = MockDeleteAuthorUseCase::new();
+        mock_delete_author
+            .expect_delete()
+            .with(always(), always())
+            .returning(|_, _| Ok(()));
+
+        let interactor = MutationInteractor::new(
+            MockRegisterUserUseCase::new(),
+            MockCreateBookUseCase::new(),
+            MockUpdateBookUseCase::new(),
+            MockDeleteBookUseCase::new(),
+            MockCreateAuthorUseCase::new(),
+            MockUpdateAuthorUseCase::new(),
+            mock_delete_author,
+        );
+
+        // When
+        let result = interactor
+            .delete_author("user1", "006099b4-6c42-4ec4-8645-f6bd5b63eddc")
+            .await;
+
+        // Then
+        assert!(result.is_ok());
+    }
 }

--- a/src/use_case/interactor/mutation.rs
+++ b/src/use_case/interactor/mutation.rs
@@ -114,7 +114,9 @@ where
     }
 
     async fn delete_author(&self, user_id: &str, author_id: &str) -> Result<(), UseCaseError> {
-        self.delete_author_use_case.delete(user_id, author_id).await?;
+        self.delete_author_use_case
+            .delete(user_id, author_id)
+            .await?;
         Ok(())
     }
 }

--- a/src/use_case/interactor/mutation.rs
+++ b/src/use_case/interactor/mutation.rs
@@ -2,34 +2,40 @@ use async_trait::async_trait;
 
 use crate::use_case::{
     dto::{
-        author::{AuthorDto, CreateAuthorDto},
+        author::{AuthorDto, CreateAuthorDto, UpdateAuthorDto},
         book::{BookDto, CreateBookDto, UpdateBookDto},
         user::UserDto,
     },
     error::UseCaseError,
     traits::{
-        author::CreateAuthorUseCase,
+        author::{CreateAuthorUseCase, DeleteAuthorUseCase, UpdateAuthorUseCase},
         book::{CreateBookUseCase, DeleteBookUseCase, UpdateBookUseCase},
         mutation::MutationUseCase,
         user::RegisterUserUseCase,
     },
 };
 
-pub struct MutationInteractor<RUUC, CBUC, UBUC, DBUC, CAUC> {
+pub struct MutationInteractor<RUUC, CBUC, UBUC, DBUC, CAUC, UAUC, DAUC> {
     register_user_use_case: RUUC,
     create_book_use_case: CBUC,
     update_book_use_case: UBUC,
     delete_book_use_case: DBUC,
     create_author_use_case: CAUC,
+    update_author_use_case: UAUC,
+    delete_author_use_case: DAUC,
 }
 
-impl<RUUC, CBUC, UBUC, DBUC, CAUC> MutationInteractor<RUUC, CBUC, UBUC, DBUC, CAUC> {
+impl<RUUC, CBUC, UBUC, DBUC, CAUC, UAUC, DAUC>
+    MutationInteractor<RUUC, CBUC, UBUC, DBUC, CAUC, UAUC, DAUC>
+{
     pub fn new(
         register_user_use_case: RUUC,
         create_book_use_case: CBUC,
         update_book_use_case: UBUC,
         delete_book_use_case: DBUC,
         create_author_use_case: CAUC,
+        update_author_use_case: UAUC,
+        delete_author_use_case: DAUC,
     ) -> Self {
         Self {
             register_user_use_case,
@@ -37,19 +43,23 @@ impl<RUUC, CBUC, UBUC, DBUC, CAUC> MutationInteractor<RUUC, CBUC, UBUC, DBUC, CA
             update_book_use_case,
             delete_book_use_case,
             create_author_use_case,
+            update_author_use_case,
+            delete_author_use_case,
         }
     }
 }
 
 #[async_trait]
-impl<RUUC, CBUC, UBUC, DBUC, CAUC> MutationUseCase
-    for MutationInteractor<RUUC, CBUC, UBUC, DBUC, CAUC>
+impl<RUUC, CBUC, UBUC, DBUC, CAUC, UAUC, DAUC> MutationUseCase
+    for MutationInteractor<RUUC, CBUC, UBUC, DBUC, CAUC, UAUC, DAUC>
 where
     RUUC: RegisterUserUseCase,
     CBUC: CreateBookUseCase,
     UBUC: UpdateBookUseCase,
     DBUC: DeleteBookUseCase,
     CAUC: CreateAuthorUseCase,
+    UAUC: UpdateAuthorUseCase,
+    DAUC: DeleteAuthorUseCase,
 {
     async fn register_user(&self, user_id: &str) -> Result<UserDto, UseCaseError> {
         let user = self.register_user_use_case.register_user(user_id).await?;
@@ -90,6 +100,23 @@ where
             .await?;
         Ok(author)
     }
+
+    async fn update_author(
+        &self,
+        user_id: &str,
+        author_data: UpdateAuthorDto,
+    ) -> Result<AuthorDto, UseCaseError> {
+        let author = self
+            .update_author_use_case
+            .update(user_id, author_data)
+            .await?;
+        Ok(author)
+    }
+
+    async fn delete_author(&self, user_id: &str, author_id: &str) -> Result<(), UseCaseError> {
+        self.delete_author_use_case.delete(user_id, author_id).await?;
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -105,7 +132,7 @@ mod tests {
         },
         interactor::mutation::MutationInteractor,
         traits::{
-            author::MockCreateAuthorUseCase,
+            author::{MockCreateAuthorUseCase, MockDeleteAuthorUseCase, MockUpdateAuthorUseCase},
             book::{MockCreateBookUseCase, MockDeleteBookUseCase, MockUpdateBookUseCase},
             mutation::MutationUseCase,
             user::MockRegisterUserUseCase,
@@ -145,6 +172,8 @@ mod tests {
             MockUpdateBookUseCase::new(),
             MockDeleteBookUseCase::new(),
             MockCreateAuthorUseCase::new(),
+            MockUpdateAuthorUseCase::new(),
+            MockDeleteAuthorUseCase::new(),
         );
 
         // When
@@ -173,6 +202,8 @@ mod tests {
             MockUpdateBookUseCase::new(),
             MockDeleteBookUseCase::new(),
             MockCreateAuthorUseCase::new(),
+            MockUpdateAuthorUseCase::new(),
+            MockDeleteAuthorUseCase::new(),
         );
 
         let book_data = CreateBookDto::new(
@@ -212,6 +243,8 @@ mod tests {
             mock_update_book,
             MockDeleteBookUseCase::new(),
             MockCreateAuthorUseCase::new(),
+            MockUpdateAuthorUseCase::new(),
+            MockDeleteAuthorUseCase::new(),
         );
 
         let book_data = UpdateBookDto::new(
@@ -249,6 +282,8 @@ mod tests {
             MockUpdateBookUseCase::new(),
             mock_delete_book,
             MockCreateAuthorUseCase::new(),
+            MockUpdateAuthorUseCase::new(),
+            MockDeleteAuthorUseCase::new(),
         );
 
         // When
@@ -280,6 +315,8 @@ mod tests {
             MockUpdateBookUseCase::new(),
             MockDeleteBookUseCase::new(),
             mock_create_author,
+            MockUpdateAuthorUseCase::new(),
+            MockDeleteAuthorUseCase::new(),
         );
 
         let author_data = CreateAuthorDto::new("New Author".to_string());

--- a/src/use_case/traits/author.rs
+++ b/src/use_case/traits/author.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use mockall::automock;
 
 use crate::use_case::{
-    dto::author::{AuthorDto, CreateAuthorDto},
+    dto::author::{AuthorDto, CreateAuthorDto, UpdateAuthorDto},
     error::UseCaseError,
 };
 
@@ -14,4 +14,20 @@ pub trait CreateAuthorUseCase: Send + Sync + 'static {
         user_id: &str,
         author_data: CreateAuthorDto,
     ) -> Result<AuthorDto, UseCaseError>;
+}
+
+#[automock]
+#[async_trait]
+pub trait UpdateAuthorUseCase: Send + Sync + 'static {
+    async fn update(
+        &self,
+        user_id: &str,
+        author_data: UpdateAuthorDto,
+    ) -> Result<AuthorDto, UseCaseError>;
+}
+
+#[automock]
+#[async_trait]
+pub trait DeleteAuthorUseCase: Send + Sync + 'static {
+    async fn delete(&self, user_id: &str, author_id: &str) -> Result<(), UseCaseError>;
 }

--- a/src/use_case/traits/mutation.rs
+++ b/src/use_case/traits/mutation.rs
@@ -3,7 +3,7 @@ use mockall::automock;
 
 use crate::use_case::{
     dto::{
-        author::{AuthorDto, CreateAuthorDto},
+        author::{AuthorDto, CreateAuthorDto, UpdateAuthorDto},
         book::{BookDto, CreateBookDto, UpdateBookDto},
         user::UserDto,
     },
@@ -30,4 +30,10 @@ pub trait MutationUseCase: Send + Sync + 'static {
         user_id: &str,
         author_data: CreateAuthorDto,
     ) -> Result<AuthorDto, UseCaseError>;
+    async fn update_author(
+        &self,
+        user_id: &str,
+        author_data: UpdateAuthorDto,
+    ) -> Result<AuthorDto, UseCaseError>;
+    async fn delete_author(&self, user_id: &str, author_id: &str) -> Result<(), UseCaseError>;
 }


### PR DESCRIPTION
Implement edit and delete mutations for authors following the same
Clean Architecture pattern used for books. Each layer is extended:

- AuthorRepository trait: add update and delete methods
- PgAuthorRepository: implement SQL UPDATE/DELETE with rows_affected
  NotFound detection; delete removes book_author rows first
- UpdateAuthorDto, UpdateAuthorUseCase, DeleteAuthorUseCase: new
  use-case layer types
- UpdateAuthorInteractor, DeleteAuthorInteractor: implementations
  with find-first-then-update pattern
- MutationUseCase / MutationInteractor: wire update_author and
  delete_author through the facade, adding two new generic params
- GraphQL: UpdateAuthorInput, updateAuthor and deleteAuthor mutations

https://claude.ai/code/session_015pSotMxcKyZr1ffEBFvPSq

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 著者の更新（名前編集）と削除が利用可能に。ID指定で更新・削除を実行できます。削除は関連する書籍がある場合は拒否されます。
* **テスト**
  * 単体／データベース／E2Eテストを追加・拡張し、更新・削除の成功・未検出・競合・検証失敗などを検証。
* **ドキュメント**
  * コミット前のチェック手順を明確化し必須化（整形／静的解析／テスト）。
* **雑務**
  * ツール設定とプレコンフリクト対処のための設定を追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->