### PR TITLE
Add --all-targets to check and clippy CI steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,9 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/setup-rust-toolchain
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-      - run: cargo check --locked
+      - run: cargo check --all-targets --locked
+        env:
+          RUSTFLAGS: "-D warnings"
 
   test:
     name: Test Suite
@@ -146,4 +148,4 @@ jobs:
         with:
           components: clippy
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-      - run: cargo clippy --locked -- -D warnings
+      - run: cargo clippy --all-targets --locked -- -D warnings

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,7 @@ If any command fails, fix the issue before committing. Do not commit with failur
 
 ```bash
 cargo fmt --check
-cargo clippy
+cargo clippy --fix --all-targets -- -D warnings
 cargo test
 ```
 

--- a/src/domain/entity/author.rs
+++ b/src/domain/entity/author.rs
@@ -98,7 +98,7 @@ mod tests {
 
     #[test]
     fn validation_success() {
-        assert!(matches!(AuthorName::new(String::from("author1")), Ok(_)));
+        assert!(AuthorName::new(String::from("author1")).is_ok());
     }
 
     #[test]

--- a/src/domain/entity/book.rs
+++ b/src/domain/entity/book.rs
@@ -212,48 +212,48 @@ mod test {
     #[test]
     fn valid_isbn_with_hyphen() {
         let isbn = Isbn::new("978-4062758574".to_owned());
-        assert!(matches!(isbn, Ok(_)));
+        assert!(isbn.is_ok());
     }
 
     #[test]
     fn valid_isbn_without_hyphen() {
         let isbn = Isbn::new("9784062758574".to_owned());
-        assert!(matches!(isbn, Ok(_)));
+        assert!(isbn.is_ok());
     }
 
     #[test]
     fn empty_isbn_is_valid() {
         let isbn = Isbn::new("".to_owned());
-        assert!(matches!(isbn, Ok(_)));
+        assert!(isbn.is_ok());
     }
 
     #[test]
     fn isbn_too_short() {
         let isbn = Isbn::new("1".to_owned());
-        assert!(matches!(isbn, Err(_)));
+        assert!(isbn.is_err());
     }
 
     #[test]
     fn priority_0_is_valid() {
         let priority = Priority::new(0);
-        assert!(matches!(priority, Ok(_)));
+        assert!(priority.is_ok());
     }
 
     #[test]
     fn priority_100_is_valid() {
         let priority = Priority::new(100);
-        assert!(matches!(priority, Ok(_)));
+        assert!(priority.is_ok());
     }
 
     #[test]
     fn priority_negative1_is_invalid() {
         let priority = Priority::new(-1);
-        assert!(matches!(priority, Err(_)));
+        assert!(priority.is_err());
     }
 
     #[test]
     fn priority_101_is_invalid() {
         let priority = Priority::new(101);
-        assert!(matches!(priority, Err(_)));
+        assert!(priority.is_err());
     }
 }

--- a/src/domain/entity/user.rs
+++ b/src/domain/entity/user.rs
@@ -29,7 +29,7 @@ mod tests {
 
     #[test]
     fn validation_success() {
-        assert!(matches!(UserId::new(String::from("user1")), Ok(_)));
+        assert!(UserId::new(String::from("user1")).is_ok());
     }
 
     #[test]

--- a/src/presentation/extractor/claims.rs
+++ b/src/presentation/extractor/claims.rs
@@ -207,6 +207,24 @@ fn validate_jwks_url(url: &str) -> Result<(), ClientError> {
     Ok(())
 }
 
+async fn fetch_jwks(domain: &str) -> Result<Arc<JwkSet>, ClientError> {
+    let url = std::env::var("JWKS_URL")
+        .unwrap_or_else(|_| format!("https://{}/.well-known/jwks.json", domain));
+    validate_jwks_url(&url)?;
+    let client = build_http_client()
+        .map_err(|e| ClientError::JwksFetch(format!("failed to build HTTP client: {e}")))?;
+    let response = client
+        .get(&url)
+        .send()
+        .await
+        .map_err(|e| ClientError::JwksFetch(format!("request failed: {e}")))?;
+    let jwks = response
+        .json::<JwkSet>()
+        .await
+        .map_err(|e| ClientError::JwksFetch(format!("invalid JWKS response: {e}")))?;
+    Ok(Arc::new(jwks))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -250,22 +268,4 @@ mod tests {
     fn invalid_url_is_rejected() {
         assert!(validate_jwks_url("not a url").is_err());
     }
-}
-
-async fn fetch_jwks(domain: &str) -> Result<Arc<JwkSet>, ClientError> {
-    let url = std::env::var("JWKS_URL")
-        .unwrap_or_else(|_| format!("https://{}/.well-known/jwks.json", domain));
-    validate_jwks_url(&url)?;
-    let client = build_http_client()
-        .map_err(|e| ClientError::JwksFetch(format!("failed to build HTTP client: {e}")))?;
-    let response = client
-        .get(&url)
-        .send()
-        .await
-        .map_err(|e| ClientError::JwksFetch(format!("request failed: {e}")))?;
-    let jwks = response
-        .json::<JwkSet>()
-        .await
-        .map_err(|e| ClientError::JwksFetch(format!("invalid JWKS response: {e}")))?;
-    Ok(Arc::new(jwks))
 }


### PR DESCRIPTION
## Summary

- Add `--all-targets` flag to `cargo check` and `cargo clippy` in CI so test code and examples are also linted
- Enable `-D warnings` for `cargo check` via `RUSTFLAGS` to treat warnings as errors
- Fix clippy warnings in test code (replace `assert!(matches!(x, Ok(_)))` with `assert!(x.is_ok())`)
- Move `fetch_jwks` function before the `#[cfg(test)]` module to resolve dead-code warning
- Update AGENTS.md pre-commit check to use `cargo clippy --fix --all-targets -- -D warnings`

## Test plan

- [ ] CI passes on this branch (check, test, clippy jobs all green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)