### PR TITLE
Add schema.graphql and CI check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,3 +149,17 @@ jobs:
           components: clippy
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - run: cargo clippy --all-targets --locked -- -D warnings
+
+  check-schema:
+    name: Check Schema
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-rust-toolchain
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - name: Generate schema
+        run: cargo run --bin gen_schema --locked > /tmp/schema.graphql.generated
+      - name: Check schema is up to date
+        run: diff schema.graphql /tmp/schema.graphql.generated

--- a/schema.graphql
+++ b/schema.graphql
@@ -1,0 +1,97 @@
+type Author {
+	id: ID!
+	name: String!
+}
+
+type Book {
+	id: String!
+	title: String!
+	isbn: String!
+	read: Boolean!
+	owned: Boolean!
+	priority: Int!
+	format: BookFormat!
+	store: BookStore!
+	createdAt: Int!
+	updatedAt: Int!
+	authors: [Author!]!
+}
+
+enum BookFormat {
+	E_BOOK
+	PRINTED
+	UNKNOWN
+}
+
+enum BookStore {
+	KINDLE
+	UNKNOWN
+}
+
+input CreateAuthorInput {
+	name: String!
+}
+
+input CreateBookInput {
+	title: String!
+	authorIds: [String!]!
+	isbn: String!
+	read: Boolean!
+	owned: Boolean!
+	priority: Int!
+	format: BookFormat!
+	store: BookStore!
+}
+
+type Mutation {
+	registerUser: User!
+	createBook(bookData: CreateBookInput!): Book!
+	updateBook(bookData: UpdateBookInput!): Book!
+	deleteBook(bookId: ID!): String!
+	createAuthor(authorData: CreateAuthorInput!): Author!
+	updateAuthor(authorData: UpdateAuthorInput!): Author!
+	deleteAuthor(authorId: ID!): String!
+}
+
+type Query {
+	loggedInUser: User
+	book(id: ID!): Book
+	books: [Book!]!
+	author(id: ID!): Author
+	authors: [Author!]!
+}
+
+input UpdateAuthorInput {
+	id: ID!
+	name: String!
+}
+
+input UpdateBookInput {
+	id: String!
+	title: String!
+	authorIds: [String!]!
+	isbn: String!
+	read: Boolean!
+	owned: Boolean!
+	priority: Int!
+	format: BookFormat!
+	store: BookStore!
+}
+
+type User {
+	id: ID!
+}
+
+"""
+Directs the executor to include this field or fragment only when the `if` argument is true.
+"""
+directive @include(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+"""
+Directs the executor to skip this field or fragment when the `if` argument is true.
+"""
+directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+schema {
+	query: Query
+	mutation: Mutation
+}
+


### PR DESCRIPTION
## Summary

- Add `schema.graphql` to the repository root, generated from the existing `gen_schema` binary
- Add `check-schema` CI job that regenerates the schema and diffs it against the committed file, failing if they diverge

## How to update the schema

When changing the GraphQL schema, regenerate and commit the file:

```bash
cargo run --bin gen_schema --locked > schema.graphql
```

## Test plan

- [ ] `Check Schema` CI job passes on this PR
- [ ] Verify staleness detection: modify `schema.graphql` locally and confirm `diff schema.graphql /tmp/schema.graphql.generated` exits non-zero

🤖 Generated with [Claude Code](https://claude.com/claude-code)