### PR TITLE
Add importBooks mutation

### DIFF
--- a/.agent/plans/20260501-add-bulk-book-creation.md
+++ b/.agent/plans/20260501-add-bulk-book-creation.md
@@ -1,0 +1,911 @@
+# Add Import Books Mutation
+
+This ExecPlan is a living document. The sections `Progress`, `Surprises &
+Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must be kept up
+to date as work proceeds.
+
+This document must be maintained in accordance with `.agent/PLANS.md`.
+
+**Plan update rule**: Update this document continuously as work proceeds —
+mark each task done the moment it is completed, record discoveries immediately
+when found, and log decisions as soon as they are made. Do NOT batch updates
+and apply them all at the end.
+
+**Commit granularity rule**: Commit at each logical breakpoint — completing a
+migration file, adding a new domain trait, implementing a repository method,
+adding a test suite, and so on. Do not batch unrelated changes into one
+commit. Each commit message must describe what specifically changed and why.
+
+
+## Purpose / Big Picture
+
+Before this change, registering multiple books requires issuing N separate
+`createBook` GraphQL mutations, each in its own HTTP round-trip and its own
+database transaction. Clients that import large reading lists must sequence
+every request and handle partial failures themselves.
+
+After this change, clients can import many books in a single `importBooks`
+GraphQL mutation. All books and any author records that need to be created
+are inserted inside **one database transaction**, and the entire batch is
+recorded under a **single `event_set`** in the event log so that the whole
+import is traceable as one logical operation.
+
+This mutation is designed for a specific use case: bringing in a list of books
+from an external source (such as a reading-list export or a CSV file) where
+authors are identified by name, not by pre-existing IDs. Author names are
+supplied per book as strings. The server resolves each name via a
+**find-or-create** strategy: if an author with that name already exists for
+the authenticated user it is reused; otherwise a new author row is inserted.
+A `UNIQUE(user_id, name)` constraint on the `author` table enforces this
+invariant at the database level.
+
+To see it working after implementation: call `importBooks` with two or more
+books whose author lists overlap, then query `bookHistory` for each returned
+book. All events should share the same `eventSetId`, confirming they were
+recorded as a single batch.
+
+
+## Progress
+
+- [ ] Milestone 1: Database migrations — unique constraint + new event_set_operation value
+  - [ ] plan updated
+- [ ] Milestone 2: Domain layer — ImportBookInput struct + ImportBooksRepository trait
+  - [ ] plan updated
+- [ ] Milestone 3: Infrastructure layer — PgImportBooksRepository (find-or-create + single tx)
+  - [ ] plan updated
+- [ ] Milestone 4: Use case layer — ImportBookEntryDto, ImportBooksUseCase, ImportBooksInteractor,
+  update MutationInteractor
+  - [ ] plan updated
+- [ ] Milestone 5: Presentation layer and DI — GraphQL input/resolver, wire everything up
+  - [ ] plan updated
+- [ ] Milestone 6: Tests — unit tests and E2E tests
+  - [ ] plan updated
+
+
+## Surprises & Discoveries
+
+*(Record unexpected behaviors, bugs, or insights here as they occur.)*
+
+
+## Decision Log
+
+- Decision: The mutation is named `importBooks` rather than `createBulkBooks`
+  or a generic "bulk create" variant.
+  Rationale: This mutation embeds specific semantics — author names instead
+  of IDs, find-or-create author resolution, a single event_set for the whole
+  batch — that make it a purpose-built import operation, not a generic
+  multi-item create. The name `importBooks` communicates that intent clearly
+  to API clients.
+  Date/Author: 2026-05-01 / hiterm
+
+- Decision: Author input uses `authorNames: [String!]!` (name strings) rather
+  than `authorIds`. The server resolves names to IDs via find-or-create in the
+  infrastructure layer.
+  Rationale: Clients doing an import typically have author names from an
+  external source, not pre-existing author IDs. Requiring IDs would force the
+  client to do N `createAuthor` calls before the import, defeating the purpose.
+  Date/Author: 2026-05-01 / hiterm
+
+- Decision: A single `event_set` row (operation = `import_books`) covers all
+  author events and book events produced by one `importBooks` call.
+  Rationale: The `event_set` table was designed to group related events from
+  one logical user action. An import is exactly such an action; grouping
+  everything under one `event_set` makes it queryable as a unit.
+  Date/Author: 2026-05-01 / hiterm
+
+- Decision: `ImportBooksRepository` is a separate domain trait, not an
+  extension of `BookRepository`. The infrastructure implementation is in a
+  new file `src/infrastructure/import_books_repository.rs`.
+  Rationale: The import method touches both the `book` and `author` tables in
+  a single transaction. Hanging it off `BookRepository` would couple that
+  trait to author-management concerns. A dedicated trait keeps
+  responsibilities clean.
+  Date/Author: 2026-05-01 / hiterm
+
+- Decision: Newly-inserted-author detection uses `rows_affected()` from the
+  `ON CONFLICT DO NOTHING` INSERT, not a comparison of candidate vs returned
+  ID.
+  Rationale: `rows_affected()` returns 1 for a new insert and 0 for a
+  conflict path; this is unambiguous and does not require carrying the
+  candidate UUID through a subsequent SELECT.
+  Date/Author: 2026-05-01 / hiterm
+
+
+## Outcomes & Retrospective
+
+*(Fill in when all milestones are complete.)*
+
+
+## Context and Orientation
+
+This repository is a Rust/async-graphql API backed by PostgreSQL (via sqlx).
+It follows a strict four-layer architecture; understanding it is essential
+before touching any file.
+
+**Domain layer** (`src/domain/`): Pure Rust entities and repository traits.
+No database access. Repository traits carry `#[automock]` (from the
+`mockall` crate) so unit tests can inject mock implementations without a real
+database. New domain traits go in `src/domain/repository/<name>.rs`, and
+their module is declared in `src/domain/repository.rs`.
+
+**Infrastructure layer** (`src/infrastructure/`): Concrete `Pg*Repository`
+structs that own a `sqlx::Pool<Postgres>` and implement the domain traits
+using SQL queries. Event recording belongs here — domain traits and use-case
+interactors must never be aware of it. New implementations go in
+`src/infrastructure/<name>.rs`, declared in `src/infrastructure.rs`.
+
+**Use case layer** (`src/use_case/`): Interactors contain business logic and
+depend only on domain repository traits. DTOs (plain Rust structs with public
+fields) carry data between layers. Traits for each use-case operation live in
+`src/use_case/traits/<topic>.rs` (declared in `src/use_case/traits.rs`).
+Interactors live in `src/use_case/interactor/<topic>.rs` (declared in
+`src/use_case/interactor.rs`).
+
+The **`MutationInteractor`** struct in `src/use_case/interactor/mutation.rs`
+is a façade: it holds one field per mutation use-case and delegates every
+`MutationUseCase` method to the appropriate field. It currently has nine
+generic type parameters (one per sub-use-case). Adding a new mutation
+requires appending a tenth parameter and a matching field.
+
+**Presentation layer** (`src/presentation/graphql/`): async-graphql schema,
+resolvers, and GraphQL input/output types. The mutation resolver lives in
+`src/presentation/graphql/mutation.rs`. GraphQL input types and output objects
+live in `src/presentation/graphql/object.rs`.
+
+**Dependency injection** (`src/dependency_injection.rs`): assembles
+everything for production use. `MI` is the concrete type alias for
+`MutationInteractor` with all production type params filled in.
+
+Key files relevant to this plan:
+
+    src/domain/repository.rs                          — module declarations
+    src/domain/repository/book_repository.rs          — BookRepository trait
+    src/domain/repository/author_repository.rs        — AuthorRepository trait
+    src/domain/entity/author.rs                       — Author, AuthorId, AuthorName
+    src/domain/entity/book.rs                         — Book, BookId, BookTitle, …
+    src/infrastructure.rs                             — module declarations
+    src/infrastructure/book_repository.rs             — PgBookRepository
+    src/infrastructure/author_repository.rs           — PgAuthorRepository
+    src/use_case/traits.rs                            — module declarations
+    src/use_case/traits/book.rs                       — CreateBookUseCase, …
+    src/use_case/traits/mutation.rs                   — MutationUseCase trait
+    src/use_case/interactor.rs                        — module declarations
+    src/use_case/interactor/book.rs                   — CreateBookInteractor, …
+    src/use_case/interactor/mutation.rs               — MutationInteractor + tests
+    src/use_case/dto/book.rs                          — BookDto, CreateBookDto, …
+    src/presentation/graphql/object.rs                — GraphQL types
+    src/presentation/graphql/mutation.rs              — mutation resolvers
+    src/dependency_injection.rs                       — wiring + MI/QI type aliases
+    migrations/20220306122339_create_tables.sql       — base schema
+    migrations/20260429040611_add_event_tables.sql    — event log schema
+    e2e/tests/e2e.rs                                  — E2E test suite
+
+**Existing event log schema** (relevant tables):
+
+    event_set            — one row per logical user action; references event_set_operation
+    event_set_operation  — lookup table of allowed operation strings
+    event_operation      — lookup table: 'create', 'update', 'delete', 'restore', 'snapshot'
+    book_event           — one row per book-related event; references event_set
+    book_event_author    — join table between book_event and authors
+    author_event         — one row per author-related event; references event_set
+
+The `event_set_operation` table currently contains: `create_book`,
+`update_book`, `delete_book`, `create_author`, `update_author`,
+`delete_author`, `restore_book`, `restore_author`, `snapshot_all`. We need to
+add `import_books`.
+
+**Existing `author` table** (from `migrations/20220306122339_create_tables.sql`):
+
+    CREATE TABLE author (
+      id         uuid    NOT NULL,
+      user_id    text    NOT NULL,
+      name       text    NOT NULL,
+      yomi       text    NOT NULL DEFAULT '',
+      created_at timestamptz NOT NULL DEFAULT current_timestamp,
+      updated_at timestamptz NOT NULL DEFAULT current_timestamp,
+      PRIMARY KEY (id, user_id),
+      FOREIGN KEY (user_id) REFERENCES bookshelf_user(id)
+    );
+
+There is currently no unique constraint on `(user_id, name)`. Milestone 1
+adds one so find-or-create can rely on `ON CONFLICT (user_id, name) DO
+NOTHING`.
+
+**Terminology used in this plan:**
+
+- *find-or-create*: attempt to insert a new row; if a uniqueness conflict
+  occurs, silently do nothing and then select the existing row. The caller
+  gets back the row's ID regardless of whether a new row was created.
+- *`event_set`*: a single row that groups all the events produced by one
+  logical user action (in this case, one `importBooks` call).
+- *`event_set_operation`*: the operation label on the `event_set` row (e.g.
+  `import_books`); different from the per-event `operation` column (e.g.
+  `create`, `update`).
+
+
+## Plan of Work
+
+### Milestone 1 — Database Migrations
+
+Two SQL migration files are needed, applied in timestamp order. Generate each
+timestamp with `date +%Y%m%d%H%M%S` at the time of creation so sqlx orders
+them correctly.
+
+The first migration adds a `UNIQUE(user_id, name)` constraint to the
+`author` table. Without this constraint the `ON CONFLICT` clause in the
+find-or-create logic will not compile at the database level.
+
+    -- migrations/<ts>_add_author_name_unique.sql
+    ALTER TABLE author
+      ADD CONSTRAINT author_user_id_name_unique UNIQUE (user_id, name);
+
+**Important**: existing data must not contain duplicate `(user_id, name)`
+pairs for this migration to succeed. On a fresh development or CI database
+there are no duplicates. If running against a database with pre-existing data,
+deduplicate first (this is documented in the Idempotence section below).
+
+The second migration inserts the new operation label into the lookup table:
+
+    -- migrations/<ts>_add_import_books_operation.sql
+    INSERT INTO event_set_operation VALUES ('import_books');
+
+After writing both files, verify they apply cleanly by running
+`sqlx migrate run` (requires `DATABASE_URL` to be set). Alternatively,
+`cargo test` triggers sqlx to create a fresh test database from all migrations
+and will fail if either migration has a syntax error.
+
+### Milestone 2 — Domain Layer
+
+Create `src/domain/repository/import_books_repository.rs`. This file defines
+the input struct and the trait that the use-case layer will depend on.
+
+`ImportBookInput` is a plain struct with no database concerns:
+
+    use async_trait::async_trait;
+    use mockall::automock;
+    use time::OffsetDateTime;
+
+    use crate::common::types::{BookFormat, BookStore};
+    use crate::domain::entity::{
+        author::AuthorName,
+        book::{BookId, BookTitle, Isbn, OwnedFlag, Priority, ReadFlag},
+        user::UserId,
+    };
+    use crate::domain::entity::book::Book;
+    use crate::domain::error::DomainError;
+
+    #[derive(Clone)]
+    pub struct ImportBookInput {
+        pub book_id: BookId,
+        pub title: BookTitle,
+        pub author_names: Vec<AuthorName>,
+        pub isbn: Isbn,
+        pub read: ReadFlag,
+        pub owned: OwnedFlag,
+        pub priority: Priority,
+        pub format: BookFormat,
+        pub store: BookStore,
+        pub created_at: OffsetDateTime,
+        pub updated_at: OffsetDateTime,
+    }
+
+    #[automock]
+    #[async_trait]
+    pub trait ImportBooksRepository: Send + Sync + 'static {
+        async fn import(
+            &self,
+            user_id: &UserId,
+            books: Vec<ImportBookInput>,
+        ) -> Result<Vec<Book>, DomainError>;
+    }
+
+The `#[automock]` attribute causes `mockall` to generate a
+`MockImportBooksRepository` struct used by the unit tests in Milestone 6.
+
+Add `pub mod import_books_repository;` to `src/domain/repository.rs`.
+
+After this milestone `cargo build` must succeed with no warnings.
+
+### Milestone 3 — Infrastructure Layer
+
+Create `src/infrastructure/import_books_repository.rs`. This file contains
+`PgImportBooksRepository`, which owns a `PgPool` and implements
+`ImportBooksRepository`.
+
+The entire `import` method runs inside a single PostgreSQL transaction
+(`pool.begin().await?` … `tx.commit().await?`). The steps are:
+
+**Step 1 — generate the shared event_set ID.**
+
+Before touching any rows, call `Uuid::new_v4()` once and bind it to
+`es_id`. This UUID will be reused for the single `event_set` row, all
+`author_event` rows, and all `book_event` rows. Insert the `event_set` row
+immediately so the foreign-key references in later inserts are satisfied:
+
+    INSERT INTO event_set (id, user_id, operation)
+    VALUES ($1, $2, 'import_books')
+
+**Step 2 — collect unique author names and build the name-to-ID map.**
+
+Iterate over every `ImportBookInput.author_names` (across all books) and
+de-duplicate them using a `HashMap<String, AuthorId>`. For each unique name:
+
+a. Call `Uuid::new_v4()` to produce a candidate ID.
+
+b. Execute the find-or-create INSERT:
+
+    INSERT INTO author (id, user_id, name)
+    VALUES ($candidate_id, $user_id, $name)
+    ON CONFLICT (user_id, name) DO NOTHING
+
+c. Check `rows_affected()` from the INSERT result. If it is 1, a new author
+   was created; if it is 0, the name already existed.
+
+d. Fetch the authoritative row (works for both new and existing rows because
+   the query runs inside the same transaction):
+
+    SELECT id, yomi, created_at, updated_at
+    FROM author
+    WHERE user_id = $user_id AND name = $name
+
+e. Record the returned `id` in the name-to-ID map.
+
+f. If `rows_affected()` was 1 (new author inserted), also insert an
+   `author_event` row referencing `es_id`:
+
+    INSERT INTO author_event
+      (event_set_id, operation, author_id, user_id,
+       name, yomi, author_created_at, author_updated_at)
+    VALUES ($es_id, 'create', $returned_id, $user_id,
+            $name, $yomi, $created_at, $updated_at)
+
+   Note that `yomi`, `created_at`, and `updated_at` come from the SELECT in
+   step 2d, not from the application — the DB fills in defaults and we fetch
+   them back.
+
+**Step 3 — insert books and book events.**
+
+For each `ImportBookInput` (in the original order):
+
+a. Resolve author IDs: look up each `author_name` in the map built in step 2.
+
+b. Build a `Book` entity via `Book::new(...)` using the resolved author IDs.
+
+c. Insert the book row:
+
+    INSERT INTO book
+      (id, user_id, title, isbn, read, owned, priority, format, store,
+       created_at, updated_at)
+    VALUES (...)
+
+d. If the book has authors, insert `book_author` rows:
+
+    INSERT INTO book_author (user_id, book_id, author_id)
+    SELECT $user_id, $book_id, unnest($author_ids::uuid[])
+
+e. Insert a `book_event` row referencing `es_id`:
+
+    INSERT INTO book_event
+      (event_set_id, operation, book_id, user_id,
+       title, isbn, read, owned, priority, format, store,
+       book_created_at, book_updated_at)
+    VALUES ($es_id, 'create', ...)
+    RETURNING event_id
+
+f. If the book has authors, insert `book_event_author` rows:
+
+    INSERT INTO book_event_author (event_id, author_id)
+    SELECT $event_id, unnest($author_ids::uuid[])
+
+g. Push the `Book` entity into the result vector.
+
+**Step 4 — commit.**
+
+    tx.commit().await?
+
+Return the result vector. Any error anywhere rolls back the entire transaction
+automatically (sqlx drops the transaction on error without committing).
+
+Add `pub mod import_books_repository;` to `src/infrastructure.rs`.
+
+After this milestone `cargo build && cargo test` must pass.
+
+### Milestone 4 — Use Case Layer
+
+There are four changes in this milestone: add a DTO, add a use-case trait,
+add an interactor, and update `MutationInteractor`.
+
+**Add `ImportBookEntryDto` to `src/use_case/dto/book.rs`.**
+
+    #[derive(Debug, Clone)]
+    pub struct ImportBookEntryDto {
+        pub title: String,
+        pub author_names: Vec<String>,
+        pub isbn: String,
+        pub read: bool,
+        pub owned: bool,
+        pub priority: i32,
+        pub format: BookFormat,
+        pub store: BookStore,
+    }
+
+**Add `ImportBooksUseCase` to `src/use_case/traits/book.rs`.**
+
+    #[automock]
+    #[async_trait]
+    pub trait ImportBooksUseCase: Send + Sync + 'static {
+        async fn import(
+            &self,
+            user_id: &str,
+            books: Vec<ImportBookEntryDto>,
+        ) -> Result<Vec<BookDto>, UseCaseError>;
+    }
+
+**Add `ImportBooksInteractor` to `src/use_case/interactor/book.rs`.**
+
+The interactor holds an `IBR: ImportBooksRepository` and implements
+`ImportBooksUseCase`:
+
+    pub struct ImportBooksInteractor<IBR> {
+        import_books_repository: IBR,
+    }
+
+    impl<IBR> ImportBooksInteractor<IBR> {
+        pub fn new(import_books_repository: IBR) -> Self {
+            Self { import_books_repository }
+        }
+    }
+
+The `import` implementation:
+
+1. Parse `user_id` into `UserId::new(user_id.to_string())?`.
+2. Capture `now = OffsetDateTime::now_utc()` once.
+3. Map each `ImportBookEntryDto` into an `ImportBookInput`, validating all
+   fields (title, isbn, author names, priority). If any validation fails,
+   return a `UseCaseError` immediately without calling the repository.
+4. Call `self.import_books_repository.import(&user_id, inputs).await?`.
+5. Map each returned `Book` to a `BookDto` and return the vector.
+
+The imports needed in `book.rs` for this interactor:
+
+    use crate::domain::entity::author::AuthorName;
+    use crate::domain::repository::import_books_repository::{
+        ImportBookInput, ImportBooksRepository,
+    };
+    use crate::use_case::dto::book::ImportBookEntryDto;
+    use crate::use_case::traits::book::ImportBooksUseCase;
+
+**Update `MutationUseCase` in `src/use_case/traits/mutation.rs`.**
+
+Add a method:
+
+    async fn import_books(
+        &self,
+        user_id: &str,
+        books: Vec<ImportBookEntryDto>,
+    ) -> Result<Vec<BookDto>, UseCaseError>;
+
+This requires importing `ImportBookEntryDto` at the top of the file.
+
+**Update `MutationInteractor` in `src/use_case/interactor/mutation.rs`.**
+
+Add a tenth generic parameter `IBUC` (for `ImportBooksUseCase`) appended
+after the existing nine parameters. Add a field
+`import_books_use_case: IBUC`. Update `MutationInteractor::new` to accept it
+as the tenth argument. Keep the existing
+`#[allow(clippy::too_many_arguments)]` annotation on `new`.
+
+The `where` clause on the `MutationUseCase` impl block gains:
+`IBUC: ImportBooksUseCase`.
+
+Implement `MutationUseCase::import_books` as a simple delegation:
+
+    async fn import_books(
+        &self,
+        user_id: &str,
+        books: Vec<ImportBookEntryDto>,
+    ) -> Result<Vec<BookDto>, UseCaseError> {
+        self.import_books_use_case.import(user_id, books).await
+    }
+
+**Update the `#[cfg(test)]` block in `mutation.rs`.**
+
+The `DefaultInteractor` type alias must gain a tenth type parameter
+`MockImportBooksUseCase`. The `InteractorBuilder` struct gains a new field
+`import_books: MockImportBooksUseCase` with a matching `with_import_books`
+setter. The `build()` method passes the new field as the tenth argument to
+`MutationInteractor::new`.
+
+After this milestone `cargo test` must pass.
+
+### Milestone 5 — Presentation Layer and Dependency Injection
+
+**Add `ImportBookInput` to `src/presentation/graphql/object.rs`.**
+
+    #[derive(InputObject)]
+    pub struct ImportBookInput {
+        pub title: String,
+        pub author_names: Vec<String>,
+        pub isbn: String,
+        pub read: bool,
+        pub owned: bool,
+        pub priority: i32,
+        pub format: BookFormat,
+        pub store: BookStore,
+    }
+
+    impl From<ImportBookInput> for ImportBookEntryDto {
+        fn from(input: ImportBookInput) -> Self {
+            ImportBookEntryDto {
+                title: input.title,
+                author_names: input.author_names,
+                isbn: input.isbn,
+                read: input.read,
+                owned: input.owned,
+                priority: input.priority,
+                format: input.format.into(),
+                store: input.store.into(),
+            }
+        }
+    }
+
+This requires importing `ImportBookEntryDto` at the top of `object.rs`.
+
+**Add a resolver to `src/presentation/graphql/mutation.rs`.**
+
+Inside the `#[Object] impl<MUC> Mutation<MUC>` block, add:
+
+    async fn import_books(
+        &self,
+        ctx: &Context<'_>,
+        books: Vec<ImportBookInput>,
+    ) -> Result<Vec<Book>, PresentationalError> {
+        let claims = get_claims(ctx)?;
+        let books = self
+            .mutation_use_case
+            .import_books(
+                &claims.sub,
+                books.into_iter().map(Into::into).collect(),
+            )
+            .await?;
+        Ok(books.into_iter().map(Book::from).collect())
+    }
+
+**Update `src/dependency_injection.rs`.**
+
+Import the new types:
+
+    use crate::infrastructure::import_books_repository::PgImportBooksRepository;
+    use crate::use_case::interactor::book::ImportBooksInteractor;
+
+Instantiate inside `dependency_injection`:
+
+    let import_books_repository = PgImportBooksRepository::new(pool.clone());
+    let import_books_use_case = ImportBooksInteractor::new(import_books_repository);
+
+Update the `MI` type alias to include the tenth parameter:
+
+    pub type MI = MutationInteractor<
+        RegisterUserInteractor<PgUserRepository>,
+        CreateBookInteractor<PgBookRepository>,
+        UpdateBookInteractor<PgBookRepository>,
+        DeleteBookInteractor<PgBookRepository>,
+        CreateAuthorInteractor<PgAuthorRepository>,
+        UpdateAuthorInteractor<PgAuthorRepository>,
+        DeleteAuthorInteractor<PgAuthorRepository>,
+        RestoreBookInteractor<PgBookRepository, PgBookEventRepository>,
+        RestoreAuthorInteractor<PgAuthorRepository, PgAuthorEventRepository>,
+        ImportBooksInteractor<PgImportBooksRepository>,
+    >;
+
+Pass `import_books_use_case` as the tenth argument to
+`MutationInteractor::new(...)`.
+
+After this milestone `cargo build` must succeed. Regenerate the GraphQL
+schema if a `schema.graphql` file exists in the repo:
+
+    cargo run --bin gen_schema 2>/dev/null > schema.graphql
+
+### Milestone 6 — Tests
+
+**Unit tests for `ImportBooksInteractor`** — add to the `#[cfg(test)]` module
+at the bottom of `src/use_case/interactor/book.rs`. Each test follows the
+Given / When / Then pattern used throughout the file.
+
+- `import_books_empty_list` — pass an empty `books` vec; the mock repository
+  should be called with an empty vec and return `Ok(vec![])`; the interactor
+  should return `Ok(vec![])`.
+- `import_books_with_author_names` — pass two books each with one author name;
+  verify the mock is called once with the two converted inputs and that the
+  returned `BookDto` vector has two entries.
+- `import_books_propagates_repository_error` — mock returns
+  `Err(DomainError::Unexpected(...))`, verify the interactor returns
+  `Err(UseCaseError::...)`.
+- `import_books_invalid_title_returns_error` — pass a book with an empty
+  title string; verify the interactor returns an error without calling the
+  repository (the mock expects zero calls).
+- `import_books_invalid_isbn_returns_error` — pass a book with an invalid
+  ISBN (e.g. `"1"`); same pattern.
+- `import_books_invalid_author_name_returns_error` — pass a book with an
+  empty author name string; same pattern.
+
+**Unit test for `MutationInteractor`** — add to the `#[cfg(test)]` module in
+`src/use_case/interactor/mutation.rs`:
+
+- `import_books_delegates_to_sub_use_case` — mock `MockImportBooksUseCase`,
+  expect `import` to be called with exact arguments `eq("user1")` and a
+  matching books vec; stub it to return `Ok(vec![make_book_dto(&book_id)])`.
+  Verify the interactor returns `Ok` with that dto.
+
+**E2E tests** — add to `e2e/tests/e2e.rs`. All E2E tests must be annotated
+with `#[serial]` because they share the same running server.
+
+`e2e_import_books` scenario:
+
+1. Generate a UUID for `user_id`, register the user, obtain a JWT.
+2. Pre-create an author named `"Existing Author"` via `createAuthor`; capture
+   the returned author ID.
+3. Call `importBooks` with `books`:
+   - Book 1: `title="Book One"`, `authorNames=["Existing Author"]`, other
+     fields set to valid defaults.
+   - Book 2: `title="Book Two"`, `authorNames=["New Author"]`, other fields
+     set to valid defaults.
+4. Assert the response contains exactly two books with titles `"Book One"` and
+   `"Book Two"`, each with a distinct non-empty UUID.
+5. Query `bookHistory` for each returned book ID. Each must have at least one
+   event with `operation="create"`. Both events must share the same
+   `eventSetId`.
+6. Query the authors of Book Two and verify one of them has name `"New
+   Author"`.
+7. Verify `"Existing Author"` was not duplicated by querying all authors for
+   the user and counting entries with that name; expect exactly 1.
+8. Cleanup: delete both books and both authors.
+
+`e2e_import_books_empty` scenario:
+
+1. Register a fresh user.
+2. Call `importBooks(books: [])`.
+3. Assert the response is an empty array with no error.
+
+
+## Concrete Steps
+
+Run all commands from the repository root
+(`/home/hiterm/ghq/github.com/hiterm/bookshelf-api`) unless noted otherwise.
+
+1. Create the first migration file. Use the current timestamp as the prefix:
+
+       TS=$(date +%Y%m%d%H%M%S)
+       touch migrations/${TS}_add_author_name_unique.sql
+
+   Write the `ALTER TABLE author ADD CONSTRAINT ...` SQL into that file.
+
+2. Create the second migration file immediately after (ensure a later
+   timestamp so sqlx applies them in order):
+
+       sleep 1
+       TS2=$(date +%Y%m%d%H%M%S)
+       touch migrations/${TS2}_add_import_books_operation.sql
+
+   Write the `INSERT INTO event_set_operation VALUES ('import_books')` SQL
+   into that file.
+
+3. Apply migrations (requires `DATABASE_URL`):
+
+       sqlx migrate run
+
+   Expected output: two lines of the form `Applying migrations/…` followed by
+   `Applied N migration(s)`.
+
+4. Implement Milestone 2 (domain layer). After each file, verify:
+
+       cargo build 2>&1 | head -40
+
+5. Implement Milestone 3 (infrastructure layer). Verify:
+
+       cargo build && cargo test
+
+6. Implement Milestone 4 (use case layer). Verify:
+
+       cargo test
+
+7. Implement Milestone 5 (presentation layer and DI). Verify:
+
+       cargo build
+
+   Then regenerate the schema if applicable:
+
+       cargo run --bin gen_schema 2>/dev/null > schema.graphql
+
+8. Run pre-commit checks (mandatory per CLAUDE.md):
+
+       cargo fmt --check
+       cargo clippy --all-targets -- -D warnings
+       cargo test
+
+   If `cargo fmt --check` reports diffs, run `cargo fmt` and re-check.
+   Fix all clippy warnings before committing.
+
+9. Implement Milestone 6 (tests). After adding unit tests:
+
+       cargo test
+
+   After adding E2E tests, run them against a local server (see the
+   Validation section for the exact commands).
+
+10. Commit at each logical breakpoint per CLAUDE.md conventions.
+
+
+## Validation and Acceptance
+
+**Unit test acceptance**: `cargo test` must report 0 failures. The six new
+`ImportBooksInteractor` tests and the one new `MutationInteractor` delegation
+test must exist and pass. Running `cargo test` from the repo root exercises
+all unit tests.
+
+**E2E acceptance**: both new E2E scenarios (`e2e_import_books` and
+`e2e_import_books_empty`) must pass. Run the E2E suite against a running
+server:
+
+    # Start the server (in a separate terminal, or use the existing test
+    # server if one is already running):
+    cargo run
+
+    # In another terminal, set the test server URL and run the E2E tests:
+    cd e2e
+    TEST_SERVER_URL=http://localhost:8080 cargo test
+
+    # Or, using docker-compose if configured:
+    docker compose -f docker-compose-test.yml up -d
+    cd e2e && TEST_SERVER_URL=http://localhost:8080 cargo test
+    docker compose -f docker-compose-test.yml down
+
+Both scenarios must report `ok`.
+
+**Manual smoke test** (optional, requires a running server with a valid JWT):
+
+    curl -s -X POST http://localhost:8080/graphql \
+      -H "Authorization: Bearer <token>" \
+      -H "Content-Type: application/json" \
+      -d '{"query":"mutation { importBooks(books: [
+            {title:\"Imported Book\", authorNames:[\"Author A\"],
+             isbn:\"\", read:false, owned:false, priority:50,
+             format:Unknown, store:Unknown}
+          ]) { id title } }"}'
+
+    # Expected: {"data":{"importBooks":[{"id":"<uuid>","title":"Imported Book"}]}}
+
+
+## Idempotence and Recovery
+
+Migrations use `ALTER TABLE … ADD CONSTRAINT` and `INSERT INTO … VALUES`.
+Running them a second time will fail (`constraint already exists` /
+`duplicate key value`). sqlx tracks applied migrations in `_sqlx_migrations`
+and will not re-apply them, so this is safe in practice.
+
+If the unique-constraint migration fails because duplicate `(user_id, name)`
+pairs exist in `author`, identify and remove duplicates first:
+
+    -- Find duplicates:
+    SELECT user_id, name, COUNT(*) FROM author
+    GROUP BY user_id, name HAVING COUNT(*) > 1;
+
+    -- Resolve by deleting duplicate rows (keep the oldest by created_at):
+    DELETE FROM author a
+    USING (
+        SELECT id, ROW_NUMBER() OVER (
+            PARTITION BY user_id, name ORDER BY created_at
+        ) AS rn FROM author
+    ) dup
+    WHERE a.id = dup.id AND dup.rn > 1;
+
+If an intermediate step fails to compile, fix the compilation errors before
+proceeding. Do not commit broken code. All pre-commit checks (fmt, clippy,
+test) must pass before each commit.
+
+
+## Artifacts and Notes
+
+The new GraphQL schema additions (for reference when writing E2E queries):
+
+    input ImportBookInput {
+      title: String!
+      authorNames: [String!]!
+      isbn: String!
+      read: Boolean!
+      owned: Boolean!
+      priority: Int!
+      format: BookFormat!
+      store: BookStore!
+    }
+
+    type Mutation {
+      # … existing mutations …
+      importBooks(books: [ImportBookInput!]!): [Book!]!
+    }
+
+
+## Interfaces and Dependencies
+
+In `src/domain/repository/import_books_repository.rs`, the following types
+must be defined and exported:
+
+    pub struct ImportBookInput {
+        pub book_id: BookId,
+        pub title: BookTitle,
+        pub author_names: Vec<AuthorName>,
+        pub isbn: Isbn,
+        pub read: ReadFlag,
+        pub owned: OwnedFlag,
+        pub priority: Priority,
+        pub format: BookFormat,
+        pub store: BookStore,
+        pub created_at: OffsetDateTime,
+        pub updated_at: OffsetDateTime,
+    }
+
+    #[automock]
+    #[async_trait]
+    pub trait ImportBooksRepository: Send + Sync + 'static {
+        async fn import(
+            &self,
+            user_id: &UserId,
+            books: Vec<ImportBookInput>,
+        ) -> Result<Vec<Book>, DomainError>;
+    }
+
+In `src/infrastructure/import_books_repository.rs`:
+
+    #[derive(Debug, Clone)]
+    pub struct PgImportBooksRepository {
+        pool: PgPool,
+    }
+
+    impl PgImportBooksRepository {
+        pub fn new(pool: PgPool) -> Self { Self { pool } }
+    }
+
+    #[async_trait]
+    impl ImportBooksRepository for PgImportBooksRepository { … }
+
+In `src/use_case/interactor/book.rs`:
+
+    pub struct ImportBooksInteractor<IBR> {
+        import_books_repository: IBR,
+    }
+
+    impl<IBR: ImportBooksRepository> ImportBooksUseCase
+        for ImportBooksInteractor<IBR> { … }
+
+In `src/use_case/traits/book.rs`:
+
+    #[automock]
+    #[async_trait]
+    pub trait ImportBooksUseCase: Send + Sync + 'static {
+        async fn import(
+            &self,
+            user_id: &str,
+            books: Vec<ImportBookEntryDto>,
+        ) -> Result<Vec<BookDto>, UseCaseError>;
+    }
+
+The `MutationInteractor` signature after this change:
+
+    pub struct MutationInteractor<
+        RUUC, CBUC, UBUC, DBUC, CAUC, UAUC, DAUC, RBUC, RAUC, IBUC
+    > { … }
+
+The `MI` type alias after this change:
+
+    pub type MI = MutationInteractor<
+        RegisterUserInteractor<PgUserRepository>,
+        CreateBookInteractor<PgBookRepository>,
+        UpdateBookInteractor<PgBookRepository>,
+        DeleteBookInteractor<PgBookRepository>,
+        CreateAuthorInteractor<PgAuthorRepository>,
+        UpdateAuthorInteractor<PgAuthorRepository>,
+        DeleteAuthorInteractor<PgAuthorRepository>,
+        RestoreBookInteractor<PgBookRepository, PgBookEventRepository>,
+        RestoreAuthorInteractor<PgAuthorRepository, PgAuthorEventRepository>,
+        ImportBooksInteractor<PgImportBooksRepository>,
+    >;

--- a/.agent/plans/20260501-add-bulk-book-creation.md
+++ b/.agent/plans/20260501-add-bulk-book-creation.md
@@ -47,24 +47,26 @@ recorded as a single batch.
 
 ## Progress
 
-- [ ] Milestone 1: Database migrations — unique constraint + new event_set_operation value
-  - [ ] plan updated
-- [ ] Milestone 2: Domain layer — ImportBookInput struct + ImportBooksRepository trait
-  - [ ] plan updated
-- [ ] Milestone 3: Infrastructure layer — PgImportBooksRepository (find-or-create + single tx)
-  - [ ] plan updated
-- [ ] Milestone 4: Use case layer — ImportBookEntryDto, ImportBooksUseCase, ImportBooksInteractor,
+- [x] Milestone 1: Database migrations — unique constraint + new event_set_operation value
+  - [x] plan updated
+- [x] Milestone 2: Domain layer — ImportBookInput struct + ImportBooksRepository trait
+  - [x] plan updated
+- [x] Milestone 3: Infrastructure layer — PgImportBooksRepository (find-or-create + single tx)
+  - [x] plan updated
+- [x] Milestone 4: Use case layer — ImportBookEntryDto, ImportBooksUseCase, ImportBooksInteractor,
   update MutationInteractor
-  - [ ] plan updated
-- [ ] Milestone 5: Presentation layer and DI — GraphQL input/resolver, wire everything up
-  - [ ] plan updated
-- [ ] Milestone 6: Tests — unit tests and E2E tests
-  - [ ] plan updated
+  - [x] plan updated
+- [x] Milestone 5: Presentation layer and DI — GraphQL input/resolver, wire everything up
+  - [x] plan updated
+- [x] Milestone 6: Tests — unit tests and E2E tests
+  - [x] plan updated
 
 
 ## Surprises & Discoveries
 
-*(Record unexpected behaviors, bugs, or insights here as they occur.)*
+- The existing GraphQL query for book history is named `bookEvents`, not
+  `bookHistory`. The E2E tests use `bookEvents(bookId: ...)` as documented in
+  the query resolver (`src/presentation/graphql/query.rs`).
 
 
 ## Decision Log

--- a/e2e/tests/e2e.rs
+++ b/e2e/tests/e2e.rs
@@ -1911,6 +1911,13 @@ async fn e2e_import_books() -> Result<()> {
         !author_events[0]["eventSetId"].is_null(),
         "new author event should have eventSetId"
     );
+    let author_event_set_id = author_events[0]["eventSetId"]
+        .as_str()
+        .context("author eventSetId should be string")?;
+    assert_eq!(
+        author_event_set_id, event_set_id_one,
+        "author event should share the same eventSetId as the books"
+    );
 
     // Cleanup
     delete_test_book(book_one_id, &token).await?;

--- a/e2e/tests/e2e.rs
+++ b/e2e/tests/e2e.rs
@@ -1702,3 +1702,201 @@ async fn e2e_restore_author_records_restore_event() -> Result<()> {
     delete_test_author(&author_id, &token).await?;
     Ok(())
 }
+
+#[tokio::test]
+#[serial]
+async fn e2e_import_books() -> Result<()> {
+    let user_id = uuid::Uuid::new_v4().to_string();
+    let token = generate_test_token(&user_id)?;
+    ensure_user_registered(&token).await?;
+
+    // Pre-create an author
+    let create_author_query = format!(
+        r#"mutation {{ createAuthor(authorData: {{ name: "{}" }}) {{ id }} }}"#,
+        "Existing Author"
+    );
+    let (_, response) = graphql_request(&create_author_query, Some(&token)).await?;
+    let existing_author_id = response["data"]["createAuthor"]["id"]
+        .as_str()
+        .context("author id should be string")?
+        .to_owned();
+
+    // Call importBooks
+    let import_query = r#"
+        mutation {
+            importBooks(books: [
+                {
+                    title: "Book One"
+                    authorNames: ["Existing Author"]
+                    isbn: ""
+                    read: false
+                    owned: false
+                    priority: 50
+                    format: E_BOOK
+                    store: KINDLE
+                },
+                {
+                    title: "Book Two"
+                    authorNames: ["New Author"]
+                    isbn: ""
+                    read: false
+                    owned: false
+                    priority: 50
+                    format: E_BOOK
+                    store: KINDLE
+                }
+            ]) {
+                id
+                title
+            }
+        }
+    "#;
+    let (_, response) = graphql_request(import_query, Some(&token)).await?;
+    assert!(
+        response.get("errors").is_none(),
+        "importBooks should not return errors: {:?}",
+        response.get("errors")
+    );
+
+    let imported_books = response["data"]["importBooks"]
+        .as_array()
+        .context("importBooks should return an array")?;
+    assert_eq!(imported_books.len(), 2, "should import exactly 2 books");
+
+    let book_one_id = imported_books[0]["id"]
+        .as_str()
+        .context("book id should be string")?;
+    let book_one_title = imported_books[0]["title"]
+        .as_str()
+        .context("book title should be string")?;
+    let book_two_id = imported_books[1]["id"]
+        .as_str()
+        .context("book id should be string")?;
+    let book_two_title = imported_books[1]["title"]
+        .as_str()
+        .context("book title should be string")?;
+
+    assert_eq!(book_one_title, "Book One");
+    assert_eq!(book_two_title, "Book Two");
+    assert!(
+        !book_one_id.is_empty(),
+        "book one should have a non-empty id"
+    );
+    assert!(
+        !book_two_id.is_empty(),
+        "book two should have a non-empty id"
+    );
+    assert_ne!(book_one_id, book_two_id, "book ids should be distinct");
+
+    // Query bookEvents for each book and verify shared eventSetId
+    let history_query_one = format!(
+        r#"{{ bookEvents(bookId: "{}") {{ eventSetId operation }} }}"#,
+        book_one_id
+    );
+    let (_, response) = graphql_request(&history_query_one, Some(&token)).await?;
+    let entries_one = response["data"]["bookEvents"]
+        .as_array()
+        .context("bookEvents should be an array")?;
+    assert!(
+        entries_one
+            .iter()
+            .any(|e| e["operation"].as_str() == Some("create")),
+        "book one should have a create event"
+    );
+    let event_set_id_one = entries_one[0]["eventSetId"]
+        .as_str()
+        .context("eventSetId should be string")?;
+
+    let history_query_two = format!(
+        r#"{{ bookEvents(bookId: "{}") {{ eventSetId operation }} }}"#,
+        book_two_id
+    );
+    let (_, response) = graphql_request(&history_query_two, Some(&token)).await?;
+    let entries_two = response["data"]["bookEvents"]
+        .as_array()
+        .context("bookEvents should be an array")?;
+    assert!(
+        entries_two
+            .iter()
+            .any(|e| e["operation"].as_str() == Some("create")),
+        "book two should have a create event"
+    );
+    let event_set_id_two = entries_two[0]["eventSetId"]
+        .as_str()
+        .context("eventSetId should be string")?;
+
+    assert_eq!(
+        event_set_id_one, event_set_id_two,
+        "both books should share the same eventSetId"
+    );
+
+    // Verify Book Two has "New Author"
+    let book_two_query = format!(
+        r#"{{ book(id: "{}") {{ authors {{ name }} }} }}"#,
+        book_two_id
+    );
+    let (_, response) = graphql_request(&book_two_query, Some(&token)).await?;
+    let authors = response["data"]["book"]["authors"]
+        .as_array()
+        .context("authors should be an array")?;
+    assert_eq!(authors.len(), 1, "book two should have 1 author");
+    assert_eq!(
+        authors[0]["name"].as_str(),
+        Some("New Author"),
+        "book two author should be New Author"
+    );
+
+    // Verify "Existing Author" was not duplicated
+    let authors_query = r#"{ authors { id name } }"#;
+    let (_, response) = graphql_request(authors_query, Some(&token)).await?;
+    let all_authors = response["data"]["authors"]
+        .as_array()
+        .context("authors should be an array")?;
+    let existing_count = all_authors
+        .iter()
+        .filter(|a| a["name"].as_str() == Some("Existing Author"))
+        .count();
+    assert_eq!(
+        existing_count, 1,
+        "Existing Author should appear exactly once"
+    );
+
+    // Cleanup
+    delete_test_book(book_one_id, &token).await?;
+    delete_test_book(book_two_id, &token).await?;
+    delete_test_author(&existing_author_id, &token).await?;
+
+    // Find and delete New Author
+    let new_author = all_authors
+        .iter()
+        .find(|a| a["name"].as_str() == Some("New Author"));
+    if let Some(author) = new_author {
+        let new_author_id = author["id"].as_str().context("id should be string")?;
+        delete_test_author(new_author_id, &token).await?;
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
+async fn e2e_import_books_empty() -> Result<()> {
+    let user_id = uuid::Uuid::new_v4().to_string();
+    let token = generate_test_token(&user_id)?;
+    ensure_user_registered(&token).await?;
+
+    let import_query = r#"mutation { importBooks(books: []) { id } }"#;
+    let (_, response) = graphql_request(import_query, Some(&token)).await?;
+    assert!(
+        response.get("errors").is_none(),
+        "importBooks with empty list should not return errors: {:?}",
+        response.get("errors")
+    );
+
+    let imported_books = response["data"]["importBooks"]
+        .as_array()
+        .context("importBooks should return an array")?;
+    assert!(imported_books.is_empty(), "imported books should be empty");
+
+    Ok(())
+}

--- a/e2e/tests/e2e.rs
+++ b/e2e/tests/e2e.rs
@@ -1748,6 +1748,9 @@ async fn e2e_import_books() -> Result<()> {
             ]) {
                 id
                 title
+                authors {
+                    name
+                }
             }
         }
     "#;
@@ -1769,15 +1772,28 @@ async fn e2e_import_books() -> Result<()> {
     let book_one_title = imported_books[0]["title"]
         .as_str()
         .context("book title should be string")?;
+    let book_one_authors = imported_books[0]["authors"]
+        .as_array()
+        .context("book one authors should be an array")?;
     let book_two_id = imported_books[1]["id"]
         .as_str()
         .context("book id should be string")?;
     let book_two_title = imported_books[1]["title"]
         .as_str()
         .context("book title should be string")?;
+    let book_two_authors = imported_books[1]["authors"]
+        .as_array()
+        .context("book two authors should be an array")?;
 
     assert_eq!(book_one_title, "Book One");
+    assert_eq!(book_one_authors.len(), 1);
+    assert_eq!(
+        book_one_authors[0]["name"].as_str(),
+        Some("Existing Author")
+    );
     assert_eq!(book_two_title, "Book Two");
+    assert_eq!(book_two_authors.len(), 1);
+    assert_eq!(book_two_authors[0]["name"].as_str(), Some("New Author"));
     assert!(
         !book_one_id.is_empty(),
         "book one should have a non-empty id"

--- a/e2e/tests/e2e.rs
+++ b/e2e/tests/e2e.rs
@@ -1861,19 +1861,48 @@ async fn e2e_import_books() -> Result<()> {
         "Existing Author should appear exactly once"
     );
 
+    // Verify New Author has a create event in authorEvents
+    let new_author = all_authors
+        .iter()
+        .find(|a| a["name"].as_str() == Some("New Author"));
+    let new_author_id = new_author
+        .and_then(|a| a["id"].as_str())
+        .context("new author should have an id")?;
+    let author_events_query = format!(
+        r#"{{ authorEvents(authorId: "{}") {{ eventId eventSetId operation name }} }}"#,
+        new_author_id
+    );
+    let (_, response) = graphql_request(&author_events_query, Some(&token)).await?;
+    let author_events = response["data"]["authorEvents"]
+        .as_array()
+        .context("authorEvents should be an array")?;
+    assert_eq!(
+        author_events.len(),
+        1,
+        "new author should have exactly 1 event entry"
+    );
+    assert_eq!(
+        author_events[0]["operation"].as_str(),
+        Some("create"),
+        "new author event should be create"
+    );
+    assert_eq!(
+        author_events[0]["name"].as_str(),
+        Some("New Author"),
+        "new author event name should match"
+    );
+    assert!(
+        !author_events[0]["eventSetId"].is_null(),
+        "new author event should have eventSetId"
+    );
+
     // Cleanup
     delete_test_book(book_one_id, &token).await?;
     delete_test_book(book_two_id, &token).await?;
     delete_test_author(&existing_author_id, &token).await?;
 
-    // Find and delete New Author
-    let new_author = all_authors
-        .iter()
-        .find(|a| a["name"].as_str() == Some("New Author"));
-    if let Some(author) = new_author {
-        let new_author_id = author["id"].as_str().context("id should be string")?;
-        delete_test_author(new_author_id, &token).await?;
-    }
+    // Delete New Author
+    delete_test_author(new_author_id, &token).await?;
 
     Ok(())
 }

--- a/e2e/tests/e2e.rs
+++ b/e2e/tests/e2e.rs
@@ -1909,7 +1909,7 @@ async fn e2e_import_books() -> Result<()> {
 
 #[tokio::test]
 #[serial]
-async fn e2e_import_books_empty() -> Result<()> {
+async fn e2e_import_books_empty_returns_error() -> Result<()> {
     let user_id = uuid::Uuid::new_v4().to_string();
     let token = generate_test_token(&user_id)?;
     ensure_user_registered(&token).await?;
@@ -1917,15 +1917,10 @@ async fn e2e_import_books_empty() -> Result<()> {
     let import_query = r#"mutation { importBooks(books: []) { id } }"#;
     let (_, response) = graphql_request(import_query, Some(&token)).await?;
     assert!(
-        response.get("errors").is_none(),
-        "importBooks with empty list should not return errors: {:?}",
+        response.get("errors").is_some(),
+        "importBooks with empty list should return errors: {:?}",
         response.get("errors")
     );
-
-    let imported_books = response["data"]["importBooks"]
-        .as_array()
-        .context("importBooks should return an array")?;
-    assert!(imported_books.is_empty(), "imported books should be empty");
 
     Ok(())
 }

--- a/migrations/20260515154314_add_author_name_unique.sql
+++ b/migrations/20260515154314_add_author_name_unique.sql
@@ -1,4 +1,5 @@
 ALTER TABLE author
   ADD CONSTRAINT author_user_id_name_unique UNIQUE (user_id, name);
 
-INSERT INTO event_set_operation VALUES ('import_books');
+INSERT INTO event_set_operation VALUES ('import_books')
+ON CONFLICT DO NOTHING;

--- a/migrations/20260515154314_add_author_name_unique.sql
+++ b/migrations/20260515154314_add_author_name_unique.sql
@@ -1,0 +1,2 @@
+ALTER TABLE author
+  ADD CONSTRAINT author_user_id_name_unique UNIQUE (user_id, name);

--- a/migrations/20260515154314_add_author_name_unique.sql
+++ b/migrations/20260515154314_add_author_name_unique.sql
@@ -1,2 +1,4 @@
 ALTER TABLE author
   ADD CONSTRAINT author_user_id_name_unique UNIQUE (user_id, name);
+
+INSERT INTO event_set_operation VALUES ('import_books');

--- a/migrations/20260515154315_add_import_books_operation.sql
+++ b/migrations/20260515154315_add_import_books_operation.sql
@@ -1,0 +1,1 @@
+INSERT INTO event_set_operation VALUES ('import_books');

--- a/migrations/20260515154315_add_import_books_operation.sql
+++ b/migrations/20260515154315_add_import_books_operation.sql
@@ -1,1 +1,0 @@
-INSERT INTO event_set_operation VALUES ('import_books');

--- a/schema.graphql
+++ b/schema.graphql
@@ -137,7 +137,15 @@ type Query {
 	books: [Book!]!
 	author(id: ID!): Author
 	authors: [Author!]!
+	"""
+	Returns the change history for a book.
+	Entries are sorted by `changedAt` in descending order (newest first).
+	"""
 	bookEvents(bookId: ID!): [BookEventEntry!]!
+	"""
+	Returns the change history for an author.
+	Entries are sorted by `changedAt` in descending order (newest first).
+	"""
 	authorEvents(authorId: ID!): [AuthorEventEntry!]!
 }
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -75,6 +75,17 @@ input CreateBookInput {
 	store: BookStore!
 }
 
+input ImportBookInput {
+	title: String!
+	authorNames: [String!]!
+	isbn: String!
+	read: Boolean!
+	owned: Boolean!
+	priority: Int!
+	format: BookFormat!
+	store: BookStore!
+}
+
 """
 A scalar that can represent any JSON value.
 """
@@ -90,6 +101,7 @@ type Mutation {
 	deleteAuthor(authorId: ID!): String!
 	restoreBook(eventId: ID!): Book
 	restoreAuthor(eventId: ID!): Author
+	importBooks(books: [ImportBookInput!]!): [Book!]!
 }
 
 type Query {

--- a/schema.graphql
+++ b/schema.graphql
@@ -76,13 +76,37 @@ input CreateBookInput {
 }
 
 input ImportBookInput {
+	"""
+	Title of the book.
+	"""
 	title: String!
+	"""
+	Names of the authors. Authors will be created if they do not exist.
+	"""
 	authorNames: [String!]!
+	"""
+	ISBN of the book.
+	"""
 	isbn: String!
+	"""
+	Whether the book has been read.
+	"""
 	read: Boolean!
+	"""
+	Whether the book is owned.
+	"""
 	owned: Boolean!
+	"""
+	Priority value ranging from 0 to 100.
+	"""
 	priority: Int!
+	"""
+	Format of the book.
+	"""
 	format: BookFormat!
+	"""
+	Store where the book was purchased or obtained.
+	"""
 	store: BookStore!
 }
 
@@ -101,6 +125,9 @@ type Mutation {
 	deleteAuthor(authorId: ID!): String!
 	restoreBook(eventId: ID!): Book
 	restoreAuthor(eventId: ID!): Author
+	"""
+	Imports multiple books. Creates authors if they do not exist.
+	"""
 	importBooks(books: [ImportBookInput!]!): [Book!]!
 }
 

--- a/src/dependency_injection.rs
+++ b/src/dependency_injection.rs
@@ -5,12 +5,14 @@ use crate::{
     infrastructure::{
         author_event_repository::PgAuthorEventRepository, author_repository::PgAuthorRepository,
         book_event_repository::PgBookEventRepository, book_repository::PgBookRepository,
-        user_repository::PgUserRepository,
+        import_books_repository::PgImportBooksRepository, user_repository::PgUserRepository,
     },
     presentation::graphql::{mutation::Mutation, query::Query, schema::build_schema},
     use_case::interactor::{
         author::{CreateAuthorInteractor, DeleteAuthorInteractor, UpdateAuthorInteractor},
-        book::{CreateBookInteractor, DeleteBookInteractor, UpdateBookInteractor},
+        book::{
+            CreateBookInteractor, DeleteBookInteractor, ImportBooksInteractor, UpdateBookInteractor,
+        },
         event::{RestoreAuthorInteractor, RestoreBookInteractor},
         mutation::MutationInteractor,
         query::QueryInteractor,
@@ -36,6 +38,7 @@ pub type MI = MutationInteractor<
     DeleteAuthorInteractor<PgAuthorRepository>,
     RestoreBookInteractor<PgBookRepository, PgBookEventRepository>,
     RestoreAuthorInteractor<PgAuthorRepository, PgAuthorEventRepository>,
+    ImportBooksInteractor<PgImportBooksRepository>,
 >;
 
 pub fn dependency_injection(
@@ -45,6 +48,7 @@ pub fn dependency_injection(
     let book_repository = PgBookRepository::new(pool.clone());
     let author_repository = PgAuthorRepository::new(pool.clone());
     let book_event_repository = PgBookEventRepository::new(pool.clone());
+    let import_books_repository = PgImportBooksRepository::new(pool.clone());
     let author_event_repository = PgAuthorEventRepository::new(pool);
 
     let query_use_case = QueryInteractor {
@@ -64,6 +68,7 @@ pub fn dependency_injection(
     let restore_book_use_case = RestoreBookInteractor::new(book_repository, book_event_repository);
     let restore_author_use_case =
         RestoreAuthorInteractor::new(author_repository, author_event_repository);
+    let import_books_use_case = ImportBooksInteractor::new(import_books_repository);
 
     let mutation_use_case = MutationInteractor::new(
         register_user_use_case,
@@ -75,6 +80,7 @@ pub fn dependency_injection(
         delete_author_use_case,
         restore_book_use_case,
         restore_author_use_case,
+        import_books_use_case,
     );
 
     let query = Query::new(query_use_case.clone());

--- a/src/domain/entity/event.rs
+++ b/src/domain/entity/event.rs
@@ -35,6 +35,17 @@ impl EventSetOperation {
     }
 }
 
+impl TryFrom<&str> for EventSetOperation {
+    type Error = String;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        match value {
+            "import_books" => Ok(EventSetOperation::ImportBooks),
+            _ => Err(format!("Unknown event set operation: {}", value)),
+        }
+    }
+}
+
 impl EventOperation {
     pub fn as_str(&self) -> &'static str {
         match self {
@@ -64,7 +75,7 @@ impl TryFrom<&str> for EventOperation {
 
 #[cfg(test)]
 mod tests {
-    use super::EventOperation;
+    use super::{EventOperation, EventSetOperation};
 
     #[test]
     fn event_operation_round_trip() {
@@ -85,6 +96,23 @@ mod tests {
     #[test]
     fn event_operation_unknown_returns_err() {
         assert!(EventOperation::try_from("invalid").is_err());
+    }
+
+    #[test]
+    fn event_set_operation_as_str() {
+        assert_eq!(EventSetOperation::ImportBooks.as_str(), "import_books");
+    }
+
+    #[test]
+    fn event_set_operation_roundtrip() {
+        let s = EventSetOperation::ImportBooks.as_str();
+        let back = EventSetOperation::try_from(s).expect("round-trip failed");
+        assert_eq!(back, EventSetOperation::ImportBooks);
+    }
+
+    #[test]
+    fn event_set_operation_unknown_returns_err() {
+        assert!(EventSetOperation::try_from("invalid").is_err());
     }
 }
 

--- a/src/domain/entity/event.rs
+++ b/src/domain/entity/event.rs
@@ -19,6 +19,22 @@ pub enum EventOperation {
     Snapshot,
 }
 
+/// TODO: Migrate other event_set operations (create_book, update_book, etc.)
+/// from hard-coded strings in book_repository.rs and author_repository.rs.
+/// See: https://github.com/hiterm/bookshelf-api/pull/225#issuecomment-4466306766
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EventSetOperation {
+    ImportBooks,
+}
+
+impl EventSetOperation {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            EventSetOperation::ImportBooks => "import_books",
+        }
+    }
+}
+
 impl EventOperation {
     pub fn as_str(&self) -> &'static str {
         match self {

--- a/src/domain/repository.rs
+++ b/src/domain/repository.rs
@@ -2,4 +2,5 @@ pub mod author_event_repository;
 pub mod author_repository;
 pub mod book_event_repository;
 pub mod book_repository;
+pub mod import_books_repository;
 pub mod user_repository;

--- a/src/domain/repository/import_books_repository.rs
+++ b/src/domain/repository/import_books_repository.rs
@@ -1,0 +1,36 @@
+use async_trait::async_trait;
+use mockall::automock;
+use time::OffsetDateTime;
+
+use crate::common::types::{BookFormat, BookStore};
+use crate::domain::entity::{
+    author::AuthorName,
+    book::{Book, BookId, BookTitle, Isbn, OwnedFlag, Priority, ReadFlag},
+    user::UserId,
+};
+use crate::domain::error::DomainError;
+
+#[derive(Clone)]
+pub struct ImportBookInput {
+    pub book_id: BookId,
+    pub title: BookTitle,
+    pub author_names: Vec<AuthorName>,
+    pub isbn: Isbn,
+    pub read: ReadFlag,
+    pub owned: OwnedFlag,
+    pub priority: Priority,
+    pub format: BookFormat,
+    pub store: BookStore,
+    pub created_at: OffsetDateTime,
+    pub updated_at: OffsetDateTime,
+}
+
+#[automock]
+#[async_trait]
+pub trait ImportBooksRepository: Send + Sync + 'static {
+    async fn import(
+        &self,
+        user_id: &UserId,
+        books: Vec<ImportBookInput>,
+    ) -> Result<Vec<Book>, DomainError>;
+}

--- a/src/domain/repository/import_books_repository.rs
+++ b/src/domain/repository/import_books_repository.rs
@@ -25,6 +25,12 @@ pub struct ImportBookInput {
     pub updated_at: OffsetDateTime,
 }
 
+/// NOTE: This is a temporary repository introduced because existing
+/// PgBookRepository and PgAuthorRepository do not accept external
+/// transactions, preventing use-case layer from orchestrating multiple
+/// repositories within a single transaction.
+/// When Unit of Work pattern is introduced, this trait should be removed
+/// and its responsibilities merged back into the aggregate repositories.
 #[automock]
 #[async_trait]
 pub trait ImportBooksRepository: Send + Sync + 'static {

--- a/src/infrastructure.rs
+++ b/src/infrastructure.rs
@@ -3,4 +3,5 @@ pub mod author_repository;
 pub mod book_event_repository;
 pub mod book_repository;
 pub mod error;
+pub mod import_books_repository;
 pub mod user_repository;

--- a/src/infrastructure/book_repository.rs
+++ b/src/infrastructure/book_repository.rs
@@ -978,7 +978,7 @@ mod tests {
     ) -> Result<Vec<AuthorId>, DomainError> {
         let author_id1 = AuthorId::try_from("93090e87-b7a1-403c-974c-d74d881e83b9")?;
         let author_ids = vec![author_id1.clone()];
-        let author1 = Author::new(author_id1, AuthorName::new("author1".to_owned())?)?;
+        let author1 = Author::new(author_id1, AuthorName::new("author3".to_owned())?)?;
         repository.create(user_id, &author1).await?;
 
         Ok(author_ids)

--- a/src/infrastructure/import_books_repository.rs
+++ b/src/infrastructure/import_books_repository.rs
@@ -1,0 +1,207 @@
+use std::collections::HashMap;
+
+use async_trait::async_trait;
+use sqlx::PgPool;
+use time::OffsetDateTime;
+use uuid::Uuid;
+
+use crate::domain::entity::{author::AuthorId, book::Book, user::UserId};
+use crate::domain::error::DomainError;
+use crate::domain::repository::import_books_repository::{ImportBookInput, ImportBooksRepository};
+
+#[derive(sqlx::FromRow)]
+struct AuthorSnapshotRow {
+    id: Uuid,
+    yomi: String,
+    created_at: OffsetDateTime,
+    updated_at: OffsetDateTime,
+}
+
+#[derive(Debug, Clone)]
+pub struct PgImportBooksRepository {
+    pool: PgPool,
+}
+
+impl PgImportBooksRepository {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait]
+impl ImportBooksRepository for PgImportBooksRepository {
+    async fn import(
+        &self,
+        user_id: &UserId,
+        books: Vec<ImportBookInput>,
+    ) -> Result<Vec<Book>, DomainError> {
+        let mut tx = self.pool.begin().await?;
+
+        // Step 1 — generate the shared event_set ID.
+        let es_id = Uuid::new_v4();
+        sqlx::query(
+            "INSERT INTO event_set (id, user_id, operation) VALUES ($1, $2, 'import_books')",
+        )
+        .bind(es_id)
+        .bind(user_id.as_str())
+        .execute(&mut *tx)
+        .await?;
+
+        // Step 2 — collect unique author names and build the name-to-ID map.
+        let mut name_to_id: HashMap<String, AuthorId> = HashMap::new();
+
+        for book in &books {
+            for author_name in &book.author_names {
+                let name = author_name.as_str().to_owned();
+                if name_to_id.contains_key(&name) {
+                    continue;
+                }
+
+                let candidate_id = Uuid::new_v4();
+
+                let result = sqlx::query(
+                    "INSERT INTO author (id, user_id, name) VALUES ($1, $2, $3)
+                     ON CONFLICT (user_id, name) DO NOTHING",
+                )
+                .bind(candidate_id)
+                .bind(user_id.as_str())
+                .bind(&name)
+                .execute(&mut *tx)
+                .await?;
+
+                let rows_affected = result.rows_affected();
+
+                let snap: AuthorSnapshotRow = sqlx::query_as(
+                    "SELECT id, yomi, created_at, updated_at
+                     FROM author
+                     WHERE user_id = $1 AND name = $2",
+                )
+                .bind(user_id.as_str())
+                .bind(&name)
+                .fetch_one(&mut *tx)
+                .await?;
+
+                let author_id = AuthorId::new(snap.id);
+                name_to_id.insert(name.clone(), author_id.clone());
+
+                if rows_affected == 1 {
+                    sqlx::query(
+                        "INSERT INTO author_event
+                           (event_set_id, operation, author_id, user_id,
+                            name, yomi, author_created_at, author_updated_at)
+                         VALUES ($1, 'create', $2, $3, $4, $5, $6, $7)",
+                    )
+                    .bind(es_id)
+                    .bind(author_id.to_uuid())
+                    .bind(user_id.as_str())
+                    .bind(&name)
+                    .bind(&snap.yomi)
+                    .bind(snap.created_at)
+                    .bind(snap.updated_at)
+                    .execute(&mut *tx)
+                    .await?;
+                }
+            }
+        }
+
+        // Step 3 — insert books and book events.
+        let mut result_books = Vec::with_capacity(books.len());
+
+        for book in books {
+            let author_ids: Vec<AuthorId> = book
+                .author_names
+                .iter()
+                .map(|name| name_to_id[name.as_str()].clone())
+                .collect();
+
+            let book_entity = Book::new(
+                book.book_id.clone(),
+                book.title.clone(),
+                author_ids.clone(),
+                book.isbn.clone(),
+                book.read.clone(),
+                book.owned.clone(),
+                book.priority.clone(),
+                book.format,
+                book.store,
+                book.created_at,
+                book.updated_at,
+            )?;
+
+            sqlx::query(
+                "INSERT INTO book
+                   (id, user_id, title, isbn, read, owned, priority, format, store,
+                    created_at, updated_at)
+                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)",
+            )
+            .bind(book_entity.id().to_uuid())
+            .bind(user_id.as_str())
+            .bind(book_entity.title().as_str())
+            .bind(book_entity.isbn().as_str())
+            .bind(book_entity.read().to_bool())
+            .bind(book_entity.owned().to_bool())
+            .bind(book_entity.priority().to_i32())
+            .bind(book_entity.format().to_string())
+            .bind(book_entity.store().to_string())
+            .bind(book_entity.created_at())
+            .bind(book_entity.updated_at())
+            .execute(&mut *tx)
+            .await?;
+
+            let author_uuids: Vec<Uuid> = author_ids.iter().map(|id| id.to_uuid()).collect();
+
+            if !author_uuids.is_empty() {
+                sqlx::query(
+                    "INSERT INTO book_author (user_id, book_id, author_id)
+                            SELECT $1, $2::uuid, * FROM UNNEST($3::uuid[])",
+                )
+                .bind(user_id.as_str())
+                .bind(book_entity.id().to_uuid())
+                .bind(&author_uuids)
+                .execute(&mut *tx)
+                .await?;
+            }
+
+            let (event_id,): (i64,) = sqlx::query_as(
+                "INSERT INTO book_event
+                   (event_set_id, operation, book_id, user_id,
+                    title, isbn, read, owned, priority, format, store,
+                    book_created_at, book_updated_at)
+                 VALUES ($1, 'create', $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+                 RETURNING event_id",
+            )
+            .bind(es_id)
+            .bind(book_entity.id().to_uuid())
+            .bind(user_id.as_str())
+            .bind(book_entity.title().as_str())
+            .bind(book_entity.isbn().as_str())
+            .bind(book_entity.read().to_bool())
+            .bind(book_entity.owned().to_bool())
+            .bind(book_entity.priority().to_i32())
+            .bind(book_entity.format().to_string())
+            .bind(book_entity.store().to_string())
+            .bind(book_entity.created_at())
+            .bind(book_entity.updated_at())
+            .fetch_one(&mut *tx)
+            .await?;
+
+            if !author_uuids.is_empty() {
+                sqlx::query(
+                    "INSERT INTO book_event_author (event_id, author_id)
+                            SELECT $1, * FROM UNNEST($2::uuid[])",
+                )
+                .bind(event_id)
+                .bind(&author_uuids)
+                .execute(&mut *tx)
+                .await?;
+            }
+
+            result_books.push(book_entity);
+        }
+
+        // Step 4 — commit.
+        tx.commit().await?;
+
+        Ok(result_books)
+    }
+}

--- a/src/infrastructure/import_books_repository.rs
+++ b/src/infrastructure/import_books_repository.rs
@@ -98,8 +98,8 @@ impl ImportBooksRepository for PgImportBooksRepository {
                             name, yomi, author_created_at, author_updated_at)
                          VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
                     )
-                    .bind(EventOperation::Create.as_str())
                     .bind(es_id)
+                    .bind(EventOperation::Create.as_str())
                     .bind(author_id.to_uuid())
                     .bind(user_id.as_str())
                     .bind(&name)
@@ -185,8 +185,8 @@ impl ImportBooksRepository for PgImportBooksRepository {
                  VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
                  RETURNING event_id",
             )
-            .bind(EventOperation::Create.as_str())
             .bind(es_id)
+            .bind(EventOperation::Create.as_str())
             .bind(book_entity.id().to_uuid())
             .bind(user_id.as_str())
             .bind(book_entity.title().as_str())

--- a/src/infrastructure/import_books_repository.rs
+++ b/src/infrastructure/import_books_repository.rs
@@ -5,7 +5,12 @@ use sqlx::PgPool;
 use time::OffsetDateTime;
 use uuid::Uuid;
 
-use crate::domain::entity::{author::AuthorId, book::Book, user::UserId};
+use crate::domain::entity::{
+    author::AuthorId,
+    book::Book,
+    event::{EventOperation, EventSetOperation},
+    user::UserId,
+};
 use crate::domain::error::DomainError;
 use crate::domain::repository::import_books_repository::{ImportBookInput, ImportBooksRepository};
 
@@ -17,6 +22,9 @@ struct AuthorSnapshotRow {
     updated_at: OffsetDateTime,
 }
 
+/// NOTE: Temporary infrastructure repository. See `ImportBooksRepository` trait
+/// documentation for rationale. Should be dissolved into aggregate
+/// repositories once Unit of Work pattern is introduced.
 #[derive(Debug, Clone)]
 pub struct PgImportBooksRepository {
     pool: PgPool,
@@ -39,13 +47,12 @@ impl ImportBooksRepository for PgImportBooksRepository {
 
         // Step 1 — generate the shared event_set ID.
         let es_id = Uuid::new_v4();
-        sqlx::query(
-            "INSERT INTO event_set (id, user_id, operation) VALUES ($1, $2, 'import_books')",
-        )
-        .bind(es_id)
-        .bind(user_id.as_str())
-        .execute(&mut *tx)
-        .await?;
+        sqlx::query("INSERT INTO event_set (id, user_id, operation) VALUES ($1, $2, $3)")
+            .bind(EventSetOperation::ImportBooks.as_str())
+            .bind(es_id)
+            .bind(user_id.as_str())
+            .execute(&mut *tx)
+            .await?;
 
         // Step 2 — collect unique author names and build the name-to-ID map.
         let mut name_to_id: HashMap<String, AuthorId> = HashMap::new();
@@ -89,8 +96,9 @@ impl ImportBooksRepository for PgImportBooksRepository {
                         "INSERT INTO author_event
                            (event_set_id, operation, author_id, user_id,
                             name, yomi, author_created_at, author_updated_at)
-                         VALUES ($1, 'create', $2, $3, $4, $5, $6, $7)",
+                         VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
                     )
+                    .bind(EventOperation::Create.as_str())
                     .bind(es_id)
                     .bind(author_id.to_uuid())
                     .bind(user_id.as_str())
@@ -111,8 +119,15 @@ impl ImportBooksRepository for PgImportBooksRepository {
             let author_ids: Vec<AuthorId> = book
                 .author_names
                 .iter()
-                .map(|name| name_to_id[name.as_str()].clone())
-                .collect();
+                .map(|name| {
+                    name_to_id.get(name.as_str()).cloned().ok_or_else(|| {
+                        DomainError::Unexpected(format!(
+                            "author name '{}' not found in name_to_id map",
+                            name.as_str()
+                        ))
+                    })
+                })
+                .collect::<Result<Vec<_>, _>>()?;
 
             let book_entity = Book::new(
                 book.book_id.clone(),
@@ -167,9 +182,10 @@ impl ImportBooksRepository for PgImportBooksRepository {
                    (event_set_id, operation, book_id, user_id,
                     title, isbn, read, owned, priority, format, store,
                     book_created_at, book_updated_at)
-                 VALUES ($1, 'create', $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
                  RETURNING event_id",
             )
+            .bind(EventOperation::Create.as_str())
             .bind(es_id)
             .bind(book_entity.id().to_uuid())
             .bind(user_id.as_str())
@@ -220,6 +236,7 @@ mod tests {
             entity::{
                 author::{Author, AuthorName},
                 book::{BookId, BookTitle, Isbn, OwnedFlag, Priority, ReadFlag},
+                event::{EventOperation, EventSetOperation},
                 user::User,
             },
             error::DomainError,
@@ -253,8 +270,8 @@ mod tests {
 
         // Import two books: one with existing author, one with new author
         let inputs = vec![
-            make_import_input("Book One", vec!["Existing Author"]),
-            make_import_input("Book Two", vec!["New Author"]),
+            make_import_input("Book One", vec!["Existing Author"])?,
+            make_import_input("Book Two", vec!["New Author"])?,
         ];
 
         let result = import_repo.import(&user_id, inputs).await?;
@@ -271,14 +288,16 @@ mod tests {
         assert_eq!(author_rows[1].0, "New Author");
 
         // Verify exactly one author_event for the newly created author
-        let (new_author_event_count,): (i64,) = sqlx::query_as(
+        let query = format!(
             "SELECT COUNT(*) FROM author_event ae
              JOIN event_set es ON ae.event_set_id = es.id
-             WHERE ae.user_id = $1 AND es.operation = 'import_books'",
-        )
-        .bind(user_id.as_str())
-        .fetch_one(&pool)
-        .await?;
+             WHERE ae.user_id = $1 AND es.operation = '{}'",
+            EventSetOperation::ImportBooks.as_str()
+        );
+        let (new_author_event_count,): (i64,) = sqlx::query_as(&query)
+            .bind(user_id.as_str())
+            .fetch_one(&pool)
+            .await?;
         assert_eq!(new_author_event_count, 1);
 
         Ok(())
@@ -293,8 +312,8 @@ mod tests {
 
         // Import two books that share the same author
         let inputs = vec![
-            make_import_input("Book One", vec!["Shared Author"]),
-            make_import_input("Book Two", vec!["Shared Author"]),
+            make_import_input("Book One", vec!["Shared Author"])?,
+            make_import_input("Book Two", vec!["Shared Author"])?,
         ];
 
         let result = import_repo.import(&user_id, inputs).await?;
@@ -326,18 +345,20 @@ mod tests {
 
         let user_id = prepare_user(&user_repo, "user1").await?;
 
-        let inputs = vec![make_import_input("Imported Book", vec!["Author A"])];
+        let inputs = vec![make_import_input("Imported Book", vec!["Author A"])?];
         let result = import_repo.import(&user_id, inputs).await?;
         assert_eq!(result.len(), 1);
 
         // Verify event_set
-        let (es_op,): (String,) = sqlx::query_as(
-            "SELECT operation FROM event_set WHERE user_id = $1 AND operation = 'import_books'",
-        )
-        .bind(user_id.as_str())
-        .fetch_one(&pool)
-        .await?;
-        assert_eq!(es_op, "import_books");
+        let query = format!(
+            "SELECT operation FROM event_set WHERE user_id = $1 AND operation = '{}'",
+            EventSetOperation::ImportBooks.as_str()
+        );
+        let (es_op,): (String,) = sqlx::query_as(&query)
+            .bind(user_id.as_str())
+            .fetch_one(&pool)
+            .await?;
+        assert_eq!(es_op, EventSetOperation::ImportBooks.as_str());
 
         // Verify book_event
         let (be_op, be_title): (String, String) =
@@ -345,7 +366,7 @@ mod tests {
                 .bind(user_id.as_str())
                 .fetch_one(&pool)
                 .await?;
-        assert_eq!(be_op, "create");
+        assert_eq!(be_op, EventOperation::Create.as_str());
         assert_eq!(be_title, "Imported Book");
 
         // Verify book_event_author
@@ -365,7 +386,7 @@ mod tests {
                 .bind(user_id.as_str())
                 .fetch_one(&pool)
                 .await?;
-        assert_eq!(ae_op, "create");
+        assert_eq!(ae_op, EventOperation::Create.as_str());
         assert_eq!(ae_name, "Author A");
 
         Ok(())
@@ -461,6 +482,53 @@ mod tests {
         Ok(())
     }
 
+    #[sqlx::test]
+    async fn import_empty_author_names(pool: PgPool) -> anyhow::Result<()> {
+        let user_repo = PgUserRepository::new(pool.clone());
+        let import_repo = PgImportBooksRepository::new(pool.clone());
+
+        let user_id = prepare_user(&user_repo, "user1").await?;
+
+        let inputs = vec![make_import_input("Book With No Authors", vec![])?];
+
+        let result = import_repo.import(&user_id, inputs).await?;
+        assert_eq!(result.len(), 1);
+
+        // Verify book exists
+        let (book_count,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM book WHERE user_id = $1")
+            .bind(user_id.as_str())
+            .fetch_one(&pool)
+            .await?;
+        assert_eq!(book_count, 1);
+
+        // Verify no book_author rows created
+        let (book_author_count,): (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM book_author WHERE user_id = $1")
+                .bind(user_id.as_str())
+                .fetch_one(&pool)
+                .await?;
+        assert_eq!(
+            book_author_count, 0,
+            "book_author should be empty when no authors"
+        );
+
+        // Verify no book_event_author rows created
+        let (book_event_author_count,): (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM book_event_author bea
+             JOIN book_event be ON bea.event_id = be.event_id
+             WHERE be.user_id = $1",
+        )
+        .bind(user_id.as_str())
+        .fetch_one(&pool)
+        .await?;
+        assert_eq!(
+            book_event_author_count, 0,
+            "book_event_author should be empty when no authors"
+        );
+
+        Ok(())
+    }
+
     async fn prepare_user(repository: &PgUserRepository, id: &str) -> Result<UserId, DomainError> {
         let user_id = UserId::new(String::from(id))?;
         let user = User::new(user_id.clone());
@@ -468,23 +536,26 @@ mod tests {
         Ok(user_id)
     }
 
-    fn make_import_input(title: &str, author_names: Vec<&str>) -> ImportBookInput {
+    fn make_import_input(
+        title: &str,
+        author_names: Vec<&str>,
+    ) -> Result<ImportBookInput, DomainError> {
         let now = PrimitiveDateTime::new(date!(2022 - 05 - 05), time!(0:00)).assume_utc();
-        ImportBookInput {
-            book_id: BookId::new(Uuid::new_v4()).unwrap(),
-            title: BookTitle::new(title.to_owned()).unwrap(),
+        Ok(ImportBookInput {
+            book_id: BookId::new(Uuid::new_v4())?,
+            title: BookTitle::new(title.to_owned())?,
             author_names: author_names
                 .into_iter()
-                .map(|n| AuthorName::new(n.to_owned()).unwrap())
-                .collect(),
-            isbn: Isbn::new("".to_owned()).unwrap(),
+                .map(|n| AuthorName::new(n.to_owned()))
+                .collect::<Result<Vec<_>, _>>()?,
+            isbn: Isbn::new("".to_owned())?,
             read: ReadFlag::new(false),
             owned: OwnedFlag::new(false),
-            priority: Priority::new(50).unwrap(),
+            priority: Priority::new(50)?,
             format: BookFormat::EBook,
             store: BookStore::Kindle,
             created_at: now,
             updated_at: now,
-        }
+        })
     }
 }

--- a/src/infrastructure/import_books_repository.rs
+++ b/src/infrastructure/import_books_repository.rs
@@ -48,9 +48,9 @@ impl ImportBooksRepository for PgImportBooksRepository {
         // Step 1 — generate the shared event_set ID.
         let es_id = Uuid::new_v4();
         sqlx::query("INSERT INTO event_set (id, user_id, operation) VALUES ($1, $2, $3)")
-            .bind(EventSetOperation::ImportBooks.as_str())
             .bind(es_id)
             .bind(user_id.as_str())
+            .bind(EventSetOperation::ImportBooks.as_str())
             .execute(&mut *tx)
             .await?;
 

--- a/src/infrastructure/import_books_repository.rs
+++ b/src/infrastructure/import_books_repository.rs
@@ -205,3 +205,266 @@ impl ImportBooksRepository for PgImportBooksRepository {
         Ok(result_books)
     }
 }
+
+#[cfg(feature = "test-with-database")]
+#[cfg(test)]
+mod tests {
+    use time::{
+        PrimitiveDateTime,
+        macros::{date, time},
+    };
+
+    use crate::{
+        common::types::{BookFormat, BookStore},
+        domain::{
+            entity::{
+                author::{Author, AuthorName},
+                book::{BookId, BookTitle, Isbn, OwnedFlag, Priority, ReadFlag},
+                user::User,
+            },
+            error::DomainError,
+            repository::{
+                author_repository::AuthorRepository, import_books_repository::ImportBookInput,
+                user_repository::UserRepository,
+            },
+        },
+        infrastructure::{
+            author_repository::PgAuthorRepository, user_repository::PgUserRepository,
+        },
+    };
+
+    use super::*;
+
+    #[sqlx::test]
+    async fn import_creates_new_authors_and_reuses_existing(pool: PgPool) -> anyhow::Result<()> {
+        let user_repo = PgUserRepository::new(pool.clone());
+        let author_repo = PgAuthorRepository::new(pool.clone());
+        let import_repo = PgImportBooksRepository::new(pool.clone());
+
+        let user_id = prepare_user(&user_repo, "user1").await?;
+
+        // Pre-create an existing author
+        let existing_author_id = AuthorId::try_from("e324be11-5b77-4ba6-8423-9f27e2d228f1")?;
+        let existing_author = Author::new(
+            existing_author_id,
+            AuthorName::new("Existing Author".to_string())?,
+        )?;
+        author_repo.create(&user_id, &existing_author).await?;
+
+        // Import two books: one with existing author, one with new author
+        let inputs = vec![
+            make_import_input("Book One", vec!["Existing Author"]),
+            make_import_input("Book Two", vec!["New Author"]),
+        ];
+
+        let result = import_repo.import(&user_id, inputs).await?;
+        assert_eq!(result.len(), 2);
+
+        // Verify exactly 2 authors exist for user
+        let author_rows: Vec<(String,)> =
+            sqlx::query_as("SELECT name FROM author WHERE user_id = $1 ORDER BY name")
+                .bind(user_id.as_str())
+                .fetch_all(&pool)
+                .await?;
+        assert_eq!(author_rows.len(), 2);
+        assert_eq!(author_rows[0].0, "Existing Author");
+        assert_eq!(author_rows[1].0, "New Author");
+
+        // Verify exactly one author_event for the newly created author
+        let (new_author_event_count,): (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM author_event ae
+             JOIN event_set es ON ae.event_set_id = es.id
+             WHERE ae.user_id = $1 AND es.operation = 'import_books'",
+        )
+        .bind(user_id.as_str())
+        .fetch_one(&pool)
+        .await?;
+        assert_eq!(new_author_event_count, 1);
+
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn import_deduplicates_shared_author_names(pool: PgPool) -> anyhow::Result<()> {
+        let user_repo = PgUserRepository::new(pool.clone());
+        let import_repo = PgImportBooksRepository::new(pool.clone());
+
+        let user_id = prepare_user(&user_repo, "user1").await?;
+
+        // Import two books that share the same author
+        let inputs = vec![
+            make_import_input("Book One", vec!["Shared Author"]),
+            make_import_input("Book Two", vec!["Shared Author"]),
+        ];
+
+        let result = import_repo.import(&user_id, inputs).await?;
+        assert_eq!(result.len(), 2);
+
+        // Only one author row should exist
+        let (author_count,): (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM author WHERE user_id = $1")
+                .bind(user_id.as_str())
+                .fetch_one(&pool)
+                .await?;
+        assert_eq!(author_count, 1);
+
+        // Each book should reference that single author
+        let book_ids: Vec<(Uuid,)> =
+            sqlx::query_as("SELECT book_id FROM book_author WHERE user_id = $1")
+                .bind(user_id.as_str())
+                .fetch_all(&pool)
+                .await?;
+        assert_eq!(book_ids.len(), 2);
+
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn import_records_events_with_expected_fields(pool: PgPool) -> anyhow::Result<()> {
+        let user_repo = PgUserRepository::new(pool.clone());
+        let import_repo = PgImportBooksRepository::new(pool.clone());
+
+        let user_id = prepare_user(&user_repo, "user1").await?;
+
+        let inputs = vec![make_import_input("Imported Book", vec!["Author A"])];
+        let result = import_repo.import(&user_id, inputs).await?;
+        assert_eq!(result.len(), 1);
+
+        // Verify event_set
+        let (es_op,): (String,) = sqlx::query_as(
+            "SELECT operation FROM event_set WHERE user_id = $1 AND operation = 'import_books'",
+        )
+        .bind(user_id.as_str())
+        .fetch_one(&pool)
+        .await?;
+        assert_eq!(es_op, "import_books");
+
+        // Verify book_event
+        let (be_op, be_title): (String, String) =
+            sqlx::query_as("SELECT operation, title FROM book_event WHERE user_id = $1")
+                .bind(user_id.as_str())
+                .fetch_one(&pool)
+                .await?;
+        assert_eq!(be_op, "create");
+        assert_eq!(be_title, "Imported Book");
+
+        // Verify book_event_author
+        let (book_event_author_count,): (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM book_event_author bea
+             JOIN book_event be ON bea.event_id = be.event_id
+             WHERE be.user_id = $1",
+        )
+        .bind(user_id.as_str())
+        .fetch_one(&pool)
+        .await?;
+        assert_eq!(book_event_author_count, 1);
+
+        // Verify author_event
+        let (ae_op, ae_name): (String, String) =
+            sqlx::query_as("SELECT operation, name FROM author_event WHERE user_id = $1")
+                .bind(user_id.as_str())
+                .fetch_one(&pool)
+                .await?;
+        assert_eq!(ae_op, "create");
+        assert_eq!(ae_name, "Author A");
+
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn import_rolls_back_on_failure(pool: PgPool) -> anyhow::Result<()> {
+        let user_repo = PgUserRepository::new(pool.clone());
+        let import_repo = PgImportBooksRepository::new(pool.clone());
+
+        let user_id = prepare_user(&user_repo, "user1").await?;
+
+        let shared_book_id = BookId::try_from("675bc8d9-3155-42fb-87b0-0a82cb162848")?;
+        let now = PrimitiveDateTime::new(date!(2022 - 05 - 05), time!(0:00)).assume_utc();
+
+        // First book succeeds, second book has duplicate ID to force failure
+        let inputs = vec![
+            ImportBookInput {
+                book_id: shared_book_id.clone(),
+                title: BookTitle::new("First Book".to_owned())?,
+                author_names: vec![AuthorName::new("Author A".to_owned())?],
+                isbn: Isbn::new("".to_owned())?,
+                read: ReadFlag::new(false),
+                owned: OwnedFlag::new(false),
+                priority: Priority::new(50)?,
+                format: BookFormat::EBook,
+                store: BookStore::Kindle,
+                created_at: now,
+                updated_at: now,
+            },
+            ImportBookInput {
+                book_id: shared_book_id,
+                title: BookTitle::new("Second Book".to_owned())?,
+                author_names: vec![AuthorName::new("Author B".to_owned())?],
+                isbn: Isbn::new("".to_owned())?,
+                read: ReadFlag::new(false),
+                owned: OwnedFlag::new(false),
+                priority: Priority::new(50)?,
+                format: BookFormat::EBook,
+                store: BookStore::Kindle,
+                created_at: now,
+                updated_at: now,
+            },
+        ];
+
+        let result = import_repo.import(&user_id, inputs).await;
+        assert!(
+            result.is_err(),
+            "import should fail due to duplicate book_id"
+        );
+
+        // Assert no partial rows persisted
+        let (book_count,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM book WHERE user_id = $1")
+            .bind(user_id.as_str())
+            .fetch_one(&pool)
+            .await?;
+        assert_eq!(book_count, 0, "no book rows should be persisted");
+
+        let (author_count,): (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM author WHERE user_id = $1")
+                .bind(user_id.as_str())
+                .fetch_one(&pool)
+                .await?;
+        assert_eq!(author_count, 0, "no author rows should be persisted");
+
+        let (event_set_count,): (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM event_set WHERE user_id = $1")
+                .bind(user_id.as_str())
+                .fetch_one(&pool)
+                .await?;
+        assert_eq!(event_set_count, 0, "no event_set rows should be persisted");
+
+        Ok(())
+    }
+
+    async fn prepare_user(repository: &PgUserRepository, id: &str) -> Result<UserId, DomainError> {
+        let user_id = UserId::new(String::from(id))?;
+        let user = User::new(user_id.clone());
+        repository.create(&user).await?;
+        Ok(user_id)
+    }
+
+    fn make_import_input(title: &str, author_names: Vec<&str>) -> ImportBookInput {
+        let now = PrimitiveDateTime::new(date!(2022 - 05 - 05), time!(0:00)).assume_utc();
+        ImportBookInput {
+            book_id: BookId::new(Uuid::new_v4()).unwrap(),
+            title: BookTitle::new(title.to_owned()).unwrap(),
+            author_names: author_names
+                .into_iter()
+                .map(|n| AuthorName::new(n.to_owned()).unwrap())
+                .collect(),
+            isbn: Isbn::new("".to_owned()).unwrap(),
+            read: ReadFlag::new(false),
+            owned: OwnedFlag::new(false),
+            priority: Priority::new(50).unwrap(),
+            format: BookFormat::EBook,
+            store: BookStore::Kindle,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+}

--- a/src/infrastructure/import_books_repository.rs
+++ b/src/infrastructure/import_books_repository.rs
@@ -438,6 +438,26 @@ mod tests {
                 .await?;
         assert_eq!(event_set_count, 0, "no event_set rows should be persisted");
 
+        let (book_event_count,): (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM book_event WHERE user_id = $1")
+                .bind(user_id.as_str())
+                .fetch_one(&pool)
+                .await?;
+        assert_eq!(
+            book_event_count, 0,
+            "no book_event rows should be persisted"
+        );
+
+        let (author_event_count,): (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM author_event WHERE user_id = $1")
+                .bind(user_id.as_str())
+                .fetch_one(&pool)
+                .await?;
+        assert_eq!(
+            author_event_count, 0,
+            "no author_event rows should be persisted"
+        );
+
         Ok(())
     }
 

--- a/src/presentation/graphql/mutation.rs
+++ b/src/presentation/graphql/mutation.rs
@@ -148,6 +148,7 @@ where
         Ok(author.map(Author::from))
     }
 
+    /// Imports multiple books. Creates authors if they do not exist.
     async fn import_books(
         &self,
         ctx: &Context<'_>,

--- a/src/presentation/graphql/mutation.rs
+++ b/src/presentation/graphql/mutation.rs
@@ -8,7 +8,8 @@ use crate::{
 };
 
 use super::object::{
-    Author, Book, CreateAuthorInput, CreateBookInput, UpdateAuthorInput, UpdateBookInput, User,
+    Author, Book, CreateAuthorInput, CreateBookInput, ImportBookInput, UpdateAuthorInput,
+    UpdateBookInput, User,
 };
 
 pub struct Mutation<MUC> {
@@ -145,6 +146,19 @@ where
             .restore_author(&claims.sub, eid)
             .await?;
         Ok(author.map(Author::from))
+    }
+
+    async fn import_books(
+        &self,
+        ctx: &Context<'_>,
+        books: Vec<ImportBookInput>,
+    ) -> Result<Vec<Book>, PresentationalError> {
+        let claims = get_claims(ctx)?;
+        let books = self
+            .mutation_use_case
+            .import_books(&claims.sub, books.into_iter().map(Into::into).collect())
+            .await?;
+        Ok(books.into_iter().map(Book::from).collect())
     }
 }
 

--- a/src/presentation/graphql/object.rs
+++ b/src/presentation/graphql/object.rs
@@ -283,13 +283,21 @@ impl From<UpdateAuthorInput> for UpdateAuthorDto {
 
 #[derive(InputObject)]
 pub struct ImportBookInput {
+    /// Title of the book.
     pub title: String,
+    /// Names of the authors. Authors will be created if they do not exist.
     pub author_names: Vec<String>,
+    /// ISBN of the book.
     pub isbn: String,
+    /// Whether the book has been read.
     pub read: bool,
+    /// Whether the book is owned.
     pub owned: bool,
+    /// Priority value ranging from 0 to 100.
     pub priority: i32,
+    /// Format of the book.
     pub format: BookFormat,
+    /// Store where the book was purchased or obtained.
     pub store: BookStore,
 }
 

--- a/src/presentation/graphql/object.rs
+++ b/src/presentation/graphql/object.rs
@@ -6,7 +6,7 @@ use serde_json::Value;
 use crate::common::types::{BookFormat as CommonBookFormat, BookStore as CommonBookStore};
 use crate::dependency_injection::QI;
 use crate::use_case::dto::author::{AuthorDto, CreateAuthorDto, UpdateAuthorDto};
-use crate::use_case::dto::book::{BookDto, CreateBookDto, UpdateBookDto};
+use crate::use_case::dto::book::{BookDto, CreateBookDto, ImportBookEntryDto, UpdateBookDto};
 use crate::use_case::dto::event::{AuthorEventDto, BookEventDto};
 
 use super::loader::AuthorLoader;
@@ -278,6 +278,33 @@ pub struct UpdateAuthorInput {
 impl From<UpdateAuthorInput> for UpdateAuthorDto {
     fn from(val: UpdateAuthorInput) -> Self {
         UpdateAuthorDto::new(val.id.to_string(), val.name)
+    }
+}
+
+#[derive(InputObject)]
+pub struct ImportBookInput {
+    pub title: String,
+    pub author_names: Vec<String>,
+    pub isbn: String,
+    pub read: bool,
+    pub owned: bool,
+    pub priority: i32,
+    pub format: BookFormat,
+    pub store: BookStore,
+}
+
+impl From<ImportBookInput> for ImportBookEntryDto {
+    fn from(input: ImportBookInput) -> Self {
+        ImportBookEntryDto {
+            title: input.title,
+            author_names: input.author_names,
+            isbn: input.isbn,
+            read: input.read,
+            owned: input.owned,
+            priority: input.priority,
+            format: input.format.into(),
+            store: input.store.into(),
+        }
     }
 }
 

--- a/src/presentation/graphql/query.rs
+++ b/src/presentation/graphql/query.rs
@@ -68,6 +68,8 @@ where
         Ok(authors)
     }
 
+    /// Returns the change history for a book.
+    /// Entries are sorted by `changedAt` in descending order (newest first).
     async fn book_events(
         &self,
         ctx: &Context<'_>,
@@ -81,6 +83,8 @@ where
         Ok(entries.into_iter().map(BookEventEntry::from).collect())
     }
 
+    /// Returns the change history for an author.
+    /// Entries are sorted by `changedAt` in descending order (newest first).
     async fn author_events(
         &self,
         ctx: &Context<'_>,

--- a/src/use_case/dto/book.rs
+++ b/src/use_case/dto/book.rs
@@ -158,6 +158,18 @@ pub struct UpdateBookDto {
     pub store: BookStore,
 }
 
+#[derive(Debug, Clone)]
+pub struct ImportBookEntryDto {
+    pub title: String,
+    pub author_names: Vec<String>,
+    pub isbn: String,
+    pub read: bool,
+    pub owned: bool,
+    pub priority: i32,
+    pub format: BookFormat,
+    pub store: BookStore,
+}
+
 impl UpdateBookDto {
     #[allow(clippy::too_many_arguments)]
     pub fn new(

--- a/src/use_case/interactor/book.rs
+++ b/src/use_case/interactor/book.rs
@@ -166,6 +166,12 @@ where
         user_id: &str,
         books: Vec<ImportBookEntryDto>,
     ) -> Result<Vec<BookDto>, UseCaseError> {
+        if books.is_empty() {
+            return Err(UseCaseError::Validation(
+                "books cannot be empty".to_string(),
+            ));
+        }
+
         let user_id = UserId::new(user_id.to_string())?;
         let now = OffsetDateTime::now_utc();
 
@@ -412,21 +418,20 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn import_books_empty_list() {
+    async fn import_books_empty_list_returns_validation_error() {
         // Given
-        let mut mock = MockImportBooksRepository::new();
-        mock.expect_import()
-            .with(always(), always())
-            .returning(|_, _| Ok(vec![]));
-
+        let mock = MockImportBooksRepository::new();
         let interactor = ImportBooksInteractor::new(mock);
 
         // When
         let result = interactor.import("user1", vec![]).await;
 
         // Then
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap().len(), 0);
+        assert!(
+            matches!(result, Err(UseCaseError::Validation(ref msg)) if msg == "books cannot be empty"),
+            "expected validation error for empty list, got {:?}",
+            result
+        );
     }
 
     #[tokio::test]

--- a/src/use_case/interactor/book.rs
+++ b/src/use_case/interactor/book.rs
@@ -5,17 +5,22 @@ use uuid::Uuid;
 use crate::{
     domain::{
         entity::{
-            author::AuthorId,
+            author::{AuthorId, AuthorName},
             book::{Book, BookId, BookTitle, Isbn, OwnedFlag, Priority, ReadFlag},
             user::UserId,
         },
         error::DomainError,
-        repository::book_repository::BookRepository,
+        repository::{
+            book_repository::BookRepository,
+            import_books_repository::{ImportBookInput, ImportBooksRepository},
+        },
     },
     use_case::{
-        dto::book::{BookDto, CreateBookDto, TimeInfo, UpdateBookDto},
+        dto::book::{BookDto, CreateBookDto, ImportBookEntryDto, TimeInfo, UpdateBookDto},
         error::UseCaseError,
-        traits::book::{CreateBookUseCase, DeleteBookUseCase, UpdateBookUseCase},
+        traits::book::{
+            CreateBookUseCase, DeleteBookUseCase, ImportBooksUseCase, UpdateBookUseCase,
+        },
     },
 };
 
@@ -139,6 +144,67 @@ where
     }
 }
 
+pub struct ImportBooksInteractor<IBR> {
+    import_books_repository: IBR,
+}
+
+impl<IBR> ImportBooksInteractor<IBR> {
+    pub fn new(import_books_repository: IBR) -> Self {
+        Self {
+            import_books_repository,
+        }
+    }
+}
+
+#[async_trait]
+impl<IBR> ImportBooksUseCase for ImportBooksInteractor<IBR>
+where
+    IBR: ImportBooksRepository,
+{
+    async fn import(
+        &self,
+        user_id: &str,
+        books: Vec<ImportBookEntryDto>,
+    ) -> Result<Vec<BookDto>, UseCaseError> {
+        let user_id = UserId::new(user_id.to_string())?;
+        let now = OffsetDateTime::now_utc();
+
+        let inputs: Result<Vec<ImportBookInput>, UseCaseError> = books
+            .into_iter()
+            .map(|dto| {
+                let title = BookTitle::new(dto.title)?;
+                let author_names: Result<Vec<AuthorName>, DomainError> =
+                    dto.author_names.into_iter().map(AuthorName::new).collect();
+                let author_names = author_names?;
+                let isbn = Isbn::new(dto.isbn)?;
+                let priority = Priority::new(dto.priority)?;
+
+                Ok(ImportBookInput {
+                    book_id: BookId::new(Uuid::new_v4())?,
+                    title,
+                    author_names,
+                    isbn,
+                    read: ReadFlag::new(dto.read),
+                    owned: OwnedFlag::new(dto.owned),
+                    priority,
+                    format: dto.format,
+                    store: dto.store,
+                    created_at: now,
+                    updated_at: now,
+                })
+            })
+            .collect();
+        let inputs = inputs?;
+
+        let books = self
+            .import_books_repository
+            .import(&user_id, inputs)
+            .await?;
+
+        Ok(books.into_iter().map(BookDto::from).collect())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use mockall::predicate::always;
@@ -149,13 +215,22 @@ mod tests {
         common::types::{BookFormat, BookStore},
         domain::{
             entity::book::{Book, BookId, BookTitle, Isbn, OwnedFlag, Priority, ReadFlag},
-            repository::book_repository::MockBookRepository,
+            error::DomainError,
+            repository::{
+                book_repository::MockBookRepository,
+                import_books_repository::MockImportBooksRepository,
+            },
         },
         use_case::{
-            dto::book::{CreateBookDto, UpdateBookDto},
+            dto::book::{CreateBookDto, ImportBookEntryDto, UpdateBookDto},
             error::UseCaseError,
-            interactor::book::{CreateBookInteractor, DeleteBookInteractor, UpdateBookInteractor},
-            traits::book::{CreateBookUseCase, DeleteBookUseCase, UpdateBookUseCase},
+            interactor::book::{
+                CreateBookInteractor, DeleteBookInteractor, ImportBooksInteractor,
+                UpdateBookInteractor,
+            },
+            traits::book::{
+                CreateBookUseCase, DeleteBookUseCase, ImportBooksUseCase, UpdateBookUseCase,
+            },
         },
     };
 
@@ -331,6 +406,164 @@ mod tests {
 
         // When
         let result = interactor.delete("user1", "not-a-valid-uuid").await;
+
+        // Then
+        assert!(matches!(result, Err(UseCaseError::Validation(_))));
+    }
+
+    #[tokio::test]
+    async fn import_books_empty_list() {
+        // Given
+        let mut mock = MockImportBooksRepository::new();
+        mock.expect_import()
+            .with(always(), always())
+            .returning(|_, _| Ok(vec![]));
+
+        let interactor = ImportBooksInteractor::new(mock);
+
+        // When
+        let result = interactor.import("user1", vec![]).await;
+
+        // Then
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().len(), 0);
+    }
+
+    #[tokio::test]
+    async fn import_books_with_author_names() {
+        // Given
+        let book1 = make_book(Uuid::new_v4());
+        let book2 = make_book(Uuid::new_v4());
+
+        let mut mock = MockImportBooksRepository::new();
+        mock.expect_import()
+            .with(always(), always())
+            .returning(move |_, _| Ok(vec![book1.clone(), book2.clone()]));
+
+        let interactor = ImportBooksInteractor::new(mock);
+        let books = vec![
+            ImportBookEntryDto {
+                title: "Book One".to_string(),
+                author_names: vec!["Author A".to_string()],
+                isbn: "".to_string(),
+                read: false,
+                owned: false,
+                priority: 50,
+                format: BookFormat::Unknown,
+                store: BookStore::Unknown,
+            },
+            ImportBookEntryDto {
+                title: "Book Two".to_string(),
+                author_names: vec!["Author B".to_string()],
+                isbn: "".to_string(),
+                read: false,
+                owned: false,
+                priority: 50,
+                format: BookFormat::Unknown,
+                store: BookStore::Unknown,
+            },
+        ];
+
+        // When
+        let result = interactor.import("user1", books).await;
+
+        // Then
+        assert!(result.is_ok());
+        let dtos = result.unwrap();
+        assert_eq!(dtos.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn import_books_propagates_repository_error() {
+        // Given
+        let mut mock = MockImportBooksRepository::new();
+        mock.expect_import()
+            .with(always(), always())
+            .returning(|_, _| Err(DomainError::Unexpected(String::from("db error"))));
+
+        let interactor = ImportBooksInteractor::new(mock);
+        let books = vec![ImportBookEntryDto {
+            title: "Book".to_string(),
+            author_names: vec![],
+            isbn: "".to_string(),
+            read: false,
+            owned: false,
+            priority: 50,
+            format: BookFormat::Unknown,
+            store: BookStore::Unknown,
+        }];
+
+        // When
+        let result = interactor.import("user1", books).await;
+
+        // Then
+        assert!(matches!(result, Err(UseCaseError::Unexpected(_))));
+    }
+
+    #[tokio::test]
+    async fn import_books_invalid_title_returns_error() {
+        // Given
+        let mock = MockImportBooksRepository::new();
+        let interactor = ImportBooksInteractor::new(mock);
+        let books = vec![ImportBookEntryDto {
+            title: "".to_string(),
+            author_names: vec![],
+            isbn: "".to_string(),
+            read: false,
+            owned: false,
+            priority: 50,
+            format: BookFormat::Unknown,
+            store: BookStore::Unknown,
+        }];
+
+        // When
+        let result = interactor.import("user1", books).await;
+
+        // Then
+        assert!(matches!(result, Err(UseCaseError::Validation(_))));
+    }
+
+    #[tokio::test]
+    async fn import_books_invalid_isbn_returns_error() {
+        // Given
+        let mock = MockImportBooksRepository::new();
+        let interactor = ImportBooksInteractor::new(mock);
+        let books = vec![ImportBookEntryDto {
+            title: "Valid Title".to_string(),
+            author_names: vec![],
+            isbn: "1".to_string(),
+            read: false,
+            owned: false,
+            priority: 50,
+            format: BookFormat::Unknown,
+            store: BookStore::Unknown,
+        }];
+
+        // When
+        let result = interactor.import("user1", books).await;
+
+        // Then
+        assert!(matches!(result, Err(UseCaseError::Validation(_))));
+    }
+
+    #[tokio::test]
+    async fn import_books_invalid_author_name_returns_error() {
+        // Given
+        let mock = MockImportBooksRepository::new();
+        let interactor = ImportBooksInteractor::new(mock);
+        let books = vec![ImportBookEntryDto {
+            title: "Valid Title".to_string(),
+            author_names: vec!["".to_string()],
+            isbn: "".to_string(),
+            read: false,
+            owned: false,
+            priority: 50,
+            format: BookFormat::Unknown,
+            store: BookStore::Unknown,
+        }];
+
+        // When
+        let result = interactor.import("user1", books).await;
 
         // Then
         assert!(matches!(result, Err(UseCaseError::Validation(_))));

--- a/src/use_case/interactor/book.rs
+++ b/src/use_case/interactor/book.rs
@@ -24,6 +24,8 @@ use crate::{
     },
 };
 
+const MAX_BOOK_BATCH: usize = 1000;
+
 pub struct CreateBookInteractor<BR> {
     book_repository: BR,
 }
@@ -170,6 +172,12 @@ where
             return Err(UseCaseError::Validation(
                 "books cannot be empty".to_string(),
             ));
+        }
+
+        if books.len() > MAX_BOOK_BATCH {
+            return Err(UseCaseError::Validation(format!(
+                "books cannot exceed {MAX_BOOK_BATCH}"
+            )));
         }
 
         let user_id = UserId::new(user_id.to_string())?;
@@ -430,6 +438,67 @@ mod tests {
         assert!(
             matches!(result, Err(UseCaseError::Validation(ref msg)) if msg == "books cannot be empty"),
             "expected validation error for empty list, got {:?}",
+            result
+        );
+    }
+
+    #[tokio::test]
+    async fn import_books_at_max_batch_succeeds() {
+        // Given
+        let book = make_book(Uuid::new_v4());
+        let mut mock = MockImportBooksRepository::new();
+        mock.expect_import()
+            .with(always(), always())
+            .returning(move |_, _| Ok(vec![book.clone()]));
+
+        let interactor = ImportBooksInteractor::new(mock);
+        let books = vec![
+            ImportBookEntryDto {
+                title: "Book".to_string(),
+                author_names: vec![],
+                isbn: "".to_string(),
+                read: false,
+                owned: false,
+                priority: 50,
+                format: BookFormat::Unknown,
+                store: BookStore::Unknown,
+            };
+            super::MAX_BOOK_BATCH
+        ];
+
+        // When
+        let result = interactor.import("user1", books).await;
+
+        // Then
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn import_books_exceeds_max_batch_returns_validation_error() {
+        // Given
+        let mock = MockImportBooksRepository::new();
+        let interactor = ImportBooksInteractor::new(mock);
+        let books = vec![
+            ImportBookEntryDto {
+                title: "Book".to_string(),
+                author_names: vec![],
+                isbn: "".to_string(),
+                read: false,
+                owned: false,
+                priority: 50,
+                format: BookFormat::Unknown,
+                store: BookStore::Unknown,
+            };
+            super::MAX_BOOK_BATCH + 1
+        ];
+
+        // When
+        let result = interactor.import("user1", books).await;
+
+        // Then
+        assert!(
+            matches!(result, Err(UseCaseError::Validation(ref msg)) if msg.contains("cannot exceed")),
+            "expected validation error for exceeding max batch, got {:?}",
             result
         );
     }

--- a/src/use_case/interactor/mutation.rs
+++ b/src/use_case/interactor/mutation.rs
@@ -3,20 +3,20 @@ use async_trait::async_trait;
 use crate::use_case::{
     dto::{
         author::{AuthorDto, CreateAuthorDto, UpdateAuthorDto},
-        book::{BookDto, CreateBookDto, UpdateBookDto},
+        book::{BookDto, CreateBookDto, ImportBookEntryDto, UpdateBookDto},
         user::UserDto,
     },
     error::UseCaseError,
     traits::{
         author::{CreateAuthorUseCase, DeleteAuthorUseCase, UpdateAuthorUseCase},
-        book::{CreateBookUseCase, DeleteBookUseCase, UpdateBookUseCase},
+        book::{CreateBookUseCase, DeleteBookUseCase, ImportBooksUseCase, UpdateBookUseCase},
         event::{RestoreAuthorUseCase, RestoreBookUseCase},
         mutation::MutationUseCase,
         user::RegisterUserUseCase,
     },
 };
 
-pub struct MutationInteractor<RUUC, CBUC, UBUC, DBUC, CAUC, UAUC, DAUC, RBUC, RAUC> {
+pub struct MutationInteractor<RUUC, CBUC, UBUC, DBUC, CAUC, UAUC, DAUC, RBUC, RAUC, IBUC> {
     register_user_use_case: RUUC,
     create_book_use_case: CBUC,
     update_book_use_case: UBUC,
@@ -26,10 +26,11 @@ pub struct MutationInteractor<RUUC, CBUC, UBUC, DBUC, CAUC, UAUC, DAUC, RBUC, RA
     delete_author_use_case: DAUC,
     restore_book_use_case: RBUC,
     restore_author_use_case: RAUC,
+    import_books_use_case: IBUC,
 }
 
-impl<RUUC, CBUC, UBUC, DBUC, CAUC, UAUC, DAUC, RBUC, RAUC>
-    MutationInteractor<RUUC, CBUC, UBUC, DBUC, CAUC, UAUC, DAUC, RBUC, RAUC>
+impl<RUUC, CBUC, UBUC, DBUC, CAUC, UAUC, DAUC, RBUC, RAUC, IBUC>
+    MutationInteractor<RUUC, CBUC, UBUC, DBUC, CAUC, UAUC, DAUC, RBUC, RAUC, IBUC>
 {
     // This constructor takes many arguments because MutationInteractor composes all
     // mutation use cases via dependency injection. Splitting it would reduce clarity
@@ -45,6 +46,7 @@ impl<RUUC, CBUC, UBUC, DBUC, CAUC, UAUC, DAUC, RBUC, RAUC>
         delete_author_use_case: DAUC,
         restore_book_use_case: RBUC,
         restore_author_use_case: RAUC,
+        import_books_use_case: IBUC,
     ) -> Self {
         Self {
             register_user_use_case,
@@ -56,13 +58,14 @@ impl<RUUC, CBUC, UBUC, DBUC, CAUC, UAUC, DAUC, RBUC, RAUC>
             delete_author_use_case,
             restore_book_use_case,
             restore_author_use_case,
+            import_books_use_case,
         }
     }
 }
 
 #[async_trait]
-impl<RUUC, CBUC, UBUC, DBUC, CAUC, UAUC, DAUC, RBUC, RAUC> MutationUseCase
-    for MutationInteractor<RUUC, CBUC, UBUC, DBUC, CAUC, UAUC, DAUC, RBUC, RAUC>
+impl<RUUC, CBUC, UBUC, DBUC, CAUC, UAUC, DAUC, RBUC, RAUC, IBUC> MutationUseCase
+    for MutationInteractor<RUUC, CBUC, UBUC, DBUC, CAUC, UAUC, DAUC, RBUC, RAUC, IBUC>
 where
     RUUC: RegisterUserUseCase,
     CBUC: CreateBookUseCase,
@@ -73,6 +76,7 @@ where
     DAUC: DeleteAuthorUseCase,
     RBUC: RestoreBookUseCase,
     RAUC: RestoreAuthorUseCase,
+    IBUC: ImportBooksUseCase,
 {
     async fn register_user(&self, user_id: &str) -> Result<UserDto, UseCaseError> {
         let user = self.register_user_use_case.register_user(user_id).await?;
@@ -150,6 +154,14 @@ where
             .restore(user_id, event_id)
             .await
     }
+
+    async fn import_books(
+        &self,
+        user_id: &str,
+        books: Vec<ImportBookEntryDto>,
+    ) -> Result<Vec<BookDto>, UseCaseError> {
+        self.import_books_use_case.import(user_id, books).await
+    }
 }
 
 #[cfg(test)]
@@ -161,13 +173,16 @@ mod tests {
     use crate::use_case::{
         dto::{
             author::{AuthorDto, CreateAuthorDto, UpdateAuthorDto},
-            book::{BookDto, CreateBookDto, UpdateBookDto},
+            book::{BookDto, CreateBookDto, ImportBookEntryDto, UpdateBookDto},
             user::UserDto,
         },
         interactor::mutation::MutationInteractor,
         traits::{
             author::{MockCreateAuthorUseCase, MockDeleteAuthorUseCase, MockUpdateAuthorUseCase},
-            book::{MockCreateBookUseCase, MockDeleteBookUseCase, MockUpdateBookUseCase},
+            book::{
+                MockCreateBookUseCase, MockDeleteBookUseCase, MockImportBooksUseCase,
+                MockUpdateBookUseCase,
+            },
             event::{MockRestoreAuthorUseCase, MockRestoreBookUseCase},
             mutation::MutationUseCase,
             user::MockRegisterUserUseCase,
@@ -186,6 +201,7 @@ mod tests {
         MockDeleteAuthorUseCase,
         MockRestoreBookUseCase,
         MockRestoreAuthorUseCase,
+        MockImportBooksUseCase,
     >;
 
     struct InteractorBuilder {
@@ -198,6 +214,7 @@ mod tests {
         delete_author: MockDeleteAuthorUseCase,
         restore_book: MockRestoreBookUseCase,
         restore_author: MockRestoreAuthorUseCase,
+        import_books: MockImportBooksUseCase,
     }
 
     impl InteractorBuilder {
@@ -212,6 +229,7 @@ mod tests {
                 delete_author: MockDeleteAuthorUseCase::new(),
                 restore_book: MockRestoreBookUseCase::new(),
                 restore_author: MockRestoreAuthorUseCase::new(),
+                import_books: MockImportBooksUseCase::new(),
             }
         }
 
@@ -260,6 +278,11 @@ mod tests {
             self
         }
 
+        fn with_import_books(mut self, mock: MockImportBooksUseCase) -> Self {
+            self.import_books = mock;
+            self
+        }
+
         fn build(self) -> DefaultInteractor {
             MutationInteractor::new(
                 self.register_user,
@@ -271,6 +294,7 @@ mod tests {
                 self.delete_author,
                 self.restore_book,
                 self.restore_author,
+                self.import_books,
             )
         }
     }
@@ -669,5 +693,40 @@ mod tests {
 
         // Then
         assert!(matches!(result, Err(UseCaseError::NotFound { .. })));
+    }
+
+    #[tokio::test]
+    async fn import_books_delegates_to_sub_use_case() {
+        // Given
+        let book_id = Uuid::new_v4().hyphenated().to_string();
+        let expected_dto = make_book_dto(&book_id);
+
+        let mut mock_import_books = MockImportBooksUseCase::new();
+        mock_import_books
+            .expect_import()
+            .with(eq("user1"), always())
+            .returning(move |_, _| Ok(vec![make_book_dto(&book_id)]));
+
+        let interactor = InteractorBuilder::new()
+            .with_import_books(mock_import_books)
+            .build();
+
+        let books = vec![ImportBookEntryDto {
+            title: "Imported Book".to_string(),
+            author_names: vec!["Author".to_string()],
+            isbn: "".to_string(),
+            read: false,
+            owned: false,
+            priority: 50,
+            format: BookFormat::Unknown,
+            store: BookStore::Unknown,
+        }];
+
+        // When
+        let result = interactor.import_books("user1", books).await;
+
+        // Then
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap()[0].id, expected_dto.id);
     }
 }

--- a/src/use_case/traits/book.rs
+++ b/src/use_case/traits/book.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use mockall::automock;
 
 use crate::use_case::{
-    dto::book::{BookDto, CreateBookDto, UpdateBookDto},
+    dto::book::{BookDto, CreateBookDto, ImportBookEntryDto, UpdateBookDto},
     error::UseCaseError,
 };
 
@@ -30,4 +30,14 @@ pub trait UpdateBookUseCase: Send + Sync + 'static {
 #[async_trait]
 pub trait DeleteBookUseCase: Send + Sync + 'static {
     async fn delete(&self, user_id: &str, book_id: &str) -> Result<(), UseCaseError>;
+}
+
+#[automock]
+#[async_trait]
+pub trait ImportBooksUseCase: Send + Sync + 'static {
+    async fn import(
+        &self,
+        user_id: &str,
+        books: Vec<ImportBookEntryDto>,
+    ) -> Result<Vec<BookDto>, UseCaseError>;
 }

--- a/src/use_case/traits/mutation.rs
+++ b/src/use_case/traits/mutation.rs
@@ -4,7 +4,7 @@ use mockall::automock;
 use crate::use_case::{
     dto::{
         author::{AuthorDto, CreateAuthorDto, UpdateAuthorDto},
-        book::{BookDto, CreateBookDto, UpdateBookDto},
+        book::{BookDto, CreateBookDto, ImportBookEntryDto, UpdateBookDto},
         user::UserDto,
     },
     error::UseCaseError,
@@ -46,4 +46,9 @@ pub trait MutationUseCase: Send + Sync + 'static {
         user_id: &str,
         event_id: i64,
     ) -> Result<Option<AuthorDto>, UseCaseError>;
+    async fn import_books(
+        &self,
+        user_id: &str,
+        books: Vec<ImportBookEntryDto>,
+    ) -> Result<Vec<BookDto>, UseCaseError>;
 }


### PR DESCRIPTION
## Summary

- Add `importBooks` GraphQL mutation for bulk book creation
- Authors are resolved by name via find-or-create within a single transaction
- All book and author events are recorded under one shared `event_set`

## Changes

- **Migrations**: Add `UNIQUE(user_id, name)` on `author`; add `import_books` operation
- **Domain**: `ImportBooksRepository` trait with `ImportBookInput`
- **Infrastructure**: `PgImportBooksRepository` with single-transaction find-or-create
- **Use case**: `ImportBooksUseCase`, `ImportBooksInteractor`, extend `MutationInteractor`
- **Presentation**: GraphQL `ImportBookInput` and `importBooks` resolver
- **Tests**: Unit tests + E2E tests (`e2e_import_books`, `e2e_import_books_empty`)

## CI

All checks passing ✅

## TODO

- [x] 本番で重複レコードがないか確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 複数冊の書籍を一括インポートする機能を追加しました。既存および新規著者の自動判別と紐付けに対応し、効率的な書籍登録が可能になります。

* **テスト**
  * 一括インポート機能の E2E テストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->