### PR TITLE
Add minimumReleaseAge to Renovate config

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -3,6 +3,7 @@
   "extends": [
     "config:best-practices",
   ],
+  "minimumReleaseAge": "3 days",
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
Set a global minimumReleaseAge of 3 days in Renovate configuration to avoid immediate updates for freshly released packages.