### PR TITLE
Migrate CI workflows from npm to pnpm

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,6 +59,7 @@ jobs:
         # release events, so cache poisoning by external actors is not a realistic risk.
       - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
         with:
+          version: "10"
           run_install: false
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0 # zizmor: ignore[cache-poisoning]
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,7 +57,7 @@ jobs:
           skip-extraction: ${{ steps.cache.outputs.cache-hit }}
         # cache-poisoning: GHA cache is repo-scoped and this workflow only triggers on
         # release events, so cache poisoning by external actors is not a realistic risk.
-      - uses: pnpm/action-setup@a7487c4ef87a13f60d99d9e8146330a3c3e61d73 # v4.1.0
+      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
         with:
           run_install: false
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0 # zizmor: ignore[cache-poisoning]

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,10 +57,9 @@ jobs:
           skip-extraction: ${{ steps.cache.outputs.cache-hit }}
         # cache-poisoning: GHA cache is repo-scoped and this workflow only triggers on
         # release events, so cache poisoning by external actors is not a realistic risk.
-      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
-          version: "10"
-          run_install: false
+          package_json_file: bookshelf-src/package.json
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0 # zizmor: ignore[cache-poisoning]
         with:
           node-version: "24"
@@ -158,7 +157,7 @@ jobs:
           exit 1
 
       - name: Install pnpm dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
         working-directory: bookshelf-src
 
       - name: Generate GraphQL types

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,11 +57,14 @@ jobs:
           skip-extraction: ${{ steps.cache.outputs.cache-hit }}
         # cache-poisoning: GHA cache is repo-scoped and this workflow only triggers on
         # release events, so cache poisoning by external actors is not a realistic risk.
+      - uses: pnpm/action-setup@a7487c4ef87a13f60d99d9e8146330a3c3e61d73 # v4.1.0
+        with:
+          run_install: false
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0 # zizmor: ignore[cache-poisoning]
         with:
           node-version: "24"
-          cache: "npm"
-          cache-dependency-path: bookshelf-src/package-lock.json
+          cache: "pnpm"
+          cache-dependency-path: bookshelf-src/pnpm-lock.yaml
 
       - uses: ./.github/actions/setup-rust-toolchain
 
@@ -153,20 +156,20 @@ jobs:
           docker logs bookshelf-api
           exit 1
 
-      - name: Install npm dependencies
-        run: npm ci
+      - name: Install pnpm dependencies
+        run: pnpm install
         working-directory: bookshelf-src
 
       - name: Generate GraphQL types
-        run: npm run generate
+        run: pnpm run generate
         working-directory: bookshelf-src
 
       - name: Install Playwright browsers
-        run: npx playwright install --with-deps chromium
+        run: pnpm exec playwright install --with-deps chromium
         working-directory: bookshelf-src
 
       - name: Run e2e-integration tests
-        run: npm run test:integration
+        run: pnpm run test:integration
         working-directory: bookshelf-src
 
       - name: Build and push Docker image

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -99,11 +99,14 @@ jobs:
           ref: main
           path: bookshelf-src
           persist-credentials: false
+      - uses: pnpm/action-setup@a7487c4ef87a13f60d99d9e8146330a3c3e61d73 # v4.1.0
+        with:
+          run_install: false
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: "24"
-          cache: "npm"
-          cache-dependency-path: bookshelf-src/package-lock.json
+          cache: "pnpm"
+          cache-dependency-path: bookshelf-src/pnpm-lock.yaml
       - uses: ./.github/actions/setup-rust-toolchain
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - name: Build bookshelf-api
@@ -157,15 +160,15 @@ jobs:
             sleep 1
           done
           cat /tmp/api.log; exit 1
-      - name: Install npm dependencies
-        run: npm ci
+      - name: Install pnpm dependencies
+        run: pnpm install
         working-directory: bookshelf-src
       - name: Generate GraphQL types
-        run: npm run generate
+        run: pnpm run generate
         working-directory: bookshelf-src
       - name: Install Playwright browsers
-        run: npx playwright install --with-deps chromium
+        run: pnpm exec playwright install --with-deps chromium
         working-directory: bookshelf-src
       - name: Run e2e-integration tests
-        run: npm run test:integration
+        run: pnpm run test:integration
         working-directory: bookshelf-src

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -99,10 +99,9 @@ jobs:
           ref: main
           path: bookshelf-src
           persist-credentials: false
-      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
-          version: "10"
-          run_install: false
+          package_json_file: bookshelf-src/package.json
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: "24"
@@ -162,7 +161,7 @@ jobs:
           done
           cat /tmp/api.log; exit 1
       - name: Install pnpm dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
         working-directory: bookshelf-src
       - name: Generate GraphQL types
         run: pnpm run generate

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -99,7 +99,7 @@ jobs:
           ref: main
           path: bookshelf-src
           persist-credentials: false
-      - uses: pnpm/action-setup@a7487c4ef87a13f60d99d9e8146330a3c3e61d73 # v4.1.0
+      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
         with:
           run_install: false
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -101,6 +101,7 @@ jobs:
           persist-credentials: false
       - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
         with:
+          version: "10"
           run_install: false
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:


### PR DESCRIPTION
Migrate e2e.yml and deploy.yml to use pnpm after bookshelf frontend switched from npm.