### PR TITLE
Add eventSets and eventSet GraphQL queries

### DIFF
--- a/.agent/plans/20260613-add-event-set-queries.md
+++ b/.agent/plans/20260613-add-event-set-queries.md
@@ -16,16 +16,15 @@ This enables building a full audit trail UI: the user sees a chronological feed 
   breaks the existing Pg impls until they are implemented (the tree cannot compile, and so
   cannot pass `cargo test`, with domain-only changes).
   - [x] plan updated
-- [ ] Milestone 3: Use-case DTO and trait — EventSetDto, EventSetDetailDto, and two new QueryUseCase methods.
-  - [ ] plan updated
-- [ ] Milestone 4: Use-case interactor — QueryInteractor gains ESR generic param and implements the two new methods.
-  - [ ] plan updated
-- [ ] Milestone 5: Presentation — EventSetEntry and EventSetDetail GraphQL objects; eventSets and eventSet resolvers; schema regenerated.
-  - [ ] plan updated
-- [ ] Milestone 6: DI — PgEventSetRepository wired into dependency_injection.
-  - [ ] plan updated
-- [ ] Milestone 7: E2E tests — e2e_event_sets test and eventSet assertion added to e2e_import_books.
-  - [ ] plan updated
+- [x] Milestone 3+4+5+6: Use-case (EventSetDto/EventSetDetailDto, two QueryUseCase methods,
+  QueryInteractor ESR generic + impl + unit tests), Presentation (EventSetEntry/EventSetDetail
+  objects, eventSets/eventSet resolvers), DI (PgEventSetRepository wired), and regenerated
+  schema.graphql. Committed together because the trait method additions, interactor impl, DI
+  arity change, and resolvers are interdependent and only compile as a unit.
+  - [x] plan updated
+- [x] Milestone 7: E2E tests — new e2e_event_sets test and an eventSet(id) grouping assertion
+  added to e2e_import_books.
+  - [x] plan updated
 
 ## Surprises & Discoveries
 
@@ -33,6 +32,12 @@ This enables building a full audit trail UI: the user sees a chronological feed 
   breaks compilation of the existing `Pg*` impls until those impls are added. A domain-only
   milestone therefore cannot pass `cargo test`, so Milestones 1 and 2 were combined into a
   single commit that keeps the tree green.
+- `cargo clippy --all-targets` (matching CI) flagged pre-existing `cloned_ref_to_slice_refs`
+  warnings in existing test code (`author_repository.rs`, `book_event_repository.rs`) that
+  CI's clippy was not previously catching. These were fixed (`&[x.clone()]` ->
+  `std::slice::from_ref(&x)`) in a dedicated commit so the mandatory clippy gate passes.
+- `EventSetId::try_from` returns `Result<_, String>` (not `DomainError` like `BookId::try_from`),
+  so the interactor maps its error via `DomainError::Unexpected` before surfacing it.
 
 ## Decision Log
 

--- a/.agent/plans/20260613-add-event-set-queries.md
+++ b/.agent/plans/20260613-add-event-set-queries.md
@@ -1,0 +1,157 @@
+# Add EventSet Queries
+
+This ExecPlan is a living document. The sections `Progress`, `Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work proceeds. This document must be maintained in accordance with `.agent/PLANS.md`.
+
+## Purpose / Big Picture
+
+After this change, users can query their full change history at the event-set level via GraphQL. An "event set" is a single logical operation (e.g. "import_books", "create_book") that may span multiple entity changes in one database transaction. Before this change, users can only see events for a single book or author by ID. After this change, they can list all event sets with `{ eventSets { id operation createdAt } }` and drill into any one with `{ eventSet(id: "...") { id operation bookEvents { ... } authorEvents { ... } } }`.
+
+This enables building a full audit trail UI: the user sees a chronological feed of every write operation they performed, and can expand any entry to see exactly which books and authors were created, updated, or deleted.
+
+## Progress
+
+- [x] Milestone 1+2: Domain + Infrastructure — EventSetRepository trait, find_by_event_set
+  on BookEventRepository/AuthorEventRepository, PgEventSetRepository, and the matching
+  infra impls plus DB-gated tests. Combined into one commit because adding a trait method
+  breaks the existing Pg impls until they are implemented (the tree cannot compile, and so
+  cannot pass `cargo test`, with domain-only changes).
+  - [x] plan updated
+- [ ] Milestone 3: Use-case DTO and trait — EventSetDto, EventSetDetailDto, and two new QueryUseCase methods.
+  - [ ] plan updated
+- [ ] Milestone 4: Use-case interactor — QueryInteractor gains ESR generic param and implements the two new methods.
+  - [ ] plan updated
+- [ ] Milestone 5: Presentation — EventSetEntry and EventSetDetail GraphQL objects; eventSets and eventSet resolvers; schema regenerated.
+  - [ ] plan updated
+- [ ] Milestone 6: DI — PgEventSetRepository wired into dependency_injection.
+  - [ ] plan updated
+- [ ] Milestone 7: E2E tests — e2e_event_sets test and eventSet assertion added to e2e_import_books.
+  - [ ] plan updated
+
+## Surprises & Discoveries
+
+- Adding `find_by_event_set` to the `BookEventRepository`/`AuthorEventRepository` traits
+  breaks compilation of the existing `Pg*` impls until those impls are added. A domain-only
+  milestone therefore cannot pass `cargo test`, so Milestones 1 and 2 were combined into a
+  single commit that keeps the tree green.
+
+## Decision Log
+
+- Decision: EventSetRepository uses a separate infra file rather than folding into the transaction module.
+  Rationale: Consistent with existing pattern (PgBookEventRepository, PgAuthorEventRepository each have their own file). The transaction module focuses on write concerns; a query-only repository belongs alongside the other read repositories.
+  Date/Author: 2026-06-13
+
+- Decision: EventSetDetailDto is constructed by the use-case interactor by joining the EventSet with BookEvent and AuthorEvent lookups by event_set_id.
+  Rationale: The infra layer is kept simple (three separate queries). Joining at the use-case level keeps SQL queries straightforward and avoids a complex multi-entity SQL join that would need custom row mapping.
+  Date/Author: 2026-06-13
+
+## Outcomes & Retrospective
+
+Not yet written.
+
+## Context and Orientation
+
+The project is a Rust GraphQL API using async-graphql, sqlx (Postgres), and a layered architecture: domain → use-case → infrastructure → presentation.
+
+Key files:
+
+- `src/domain/entity/event_set.rs` — defines `EventSet` (id, user_id, operation, created_at) and `EventSetId`.
+- `src/domain/repository/` — trait files for each repository. `book_event_repository.rs` and `author_event_repository.rs` already exist.
+- `src/infrastructure/` — `PgBookEventRepository`, `PgAuthorEventRepository` are examples to follow.
+- `src/use_case/dto/event.rs` — `BookEventDto`, `AuthorEventDto` exist. We add `event_set.rs`.
+- `src/use_case/traits/query.rs` — `QueryUseCase` trait; extended with two new methods.
+- `src/use_case/interactor/query.rs` — `QueryInteractor<UR, BR, AR, BER, AER>` implements `QueryUseCase`. Extended with a new `ESR` type parameter.
+- `src/presentation/graphql/object.rs` — `BookEventEntry`, `AuthorEventEntry` exist; we add `EventSetEntry`, `EventSetDetail`.
+- `src/presentation/graphql/query.rs` — GraphQL resolvers; two new resolvers added.
+- `src/dependency_injection.rs` — type alias `QI` and `dependency_injection()` function; updated to include `PgEventSetRepository`.
+- `e2e/tests/e2e.rs` — integration tests.
+
+An "event set" in the domain represents one logical transaction boundary. `PgTransactionManager::begin` inserts one row into the `event_set` table. Each repository method participating in that transaction inserts a row into `book_event` or `author_event` with the same `event_set_id`.
+
+The existing `EventSetRepository` trait does not yet exist — we create it. `BookEventRepository` and `AuthorEventRepository` both need a new `find_by_event_set` method.
+
+## Plan of Work
+
+Milestone 1 adds the domain repository trait for `EventSetRepository` and extends the two existing event repository traits with a `find_by_event_set` method. No infrastructure changes yet.
+
+Milestone 2 creates `PgEventSetRepository` in `src/infrastructure/event_set_repository.rs`, implements `find_by_event_set` on `PgBookEventRepository` and `PgAuthorEventRepository`, and registers the new module in `src/infrastructure.rs`. DB-gated tests are included in each infra file.
+
+Milestone 3 creates `src/use_case/dto/event_set.rs` with `EventSetDto` and `EventSetDetailDto`, registers it in `src/use_case/dto.rs`, and adds `list_event_sets` and `find_event_set` to the `QueryUseCase` trait.
+
+Milestone 4 updates `QueryInteractor` to accept a 6th generic `ESR: EventSetRepository`, adds the `event_set_repository` field, implements both new methods, updates all existing test constructions to include `event_set_repository: MockEventSetRepository::new()`, and adds five new unit tests.
+
+Milestone 5 adds `EventSetEntry` and `EventSetDetail` to `src/presentation/graphql/object.rs`, adds `event_sets` and `event_set` resolvers to `src/presentation/graphql/query.rs`, and regenerates `schema.graphql` by running `cargo run --bin gen_schema > schema.graphql`.
+
+Milestone 6 updates `src/dependency_injection.rs` to import `PgEventSetRepository`, extend the `QI` type alias to 6 type params, and add the new repository to the `QueryInteractor` construction.
+
+Milestone 7 adds the `e2e_event_sets` test to `e2e/tests/e2e.rs` and inserts an `eventSet` assertion block inside the existing `e2e_import_books` test.
+
+## Concrete Steps
+
+All commands run from `/home/user/bookshelf-api`.
+
+Pre-commit checks (run before every commit):
+
+    cargo fmt --check
+    git add -A && cargo clippy --fix --allow-staged --all-targets -- -D warnings
+    cargo test
+
+Milestone 1 commit message: "Add EventSetRepository domain trait and find_by_event_set methods"
+Milestone 2 commit message: "Add PgEventSetRepository and find_by_event_set impls"
+Milestone 3 commit message: "Add EventSet DTOs and QueryUseCase methods"
+Milestone 4 commit message: "Implement list_event_sets and find_event_set in QueryInteractor"
+Milestone 5 commit message: "Add eventSets and eventSet GraphQL queries"
+Milestone 6 commit message: "Wire PgEventSetRepository into DI"
+Milestone 7 commit message: "Add e2e_event_sets test and eventSet assertion in e2e_import_books"
+
+## Validation and Acceptance
+
+Run `cargo test` after each milestone. All existing tests must pass.
+
+After Milestone 5, run `cargo run --bin gen_schema > schema.graphql` and inspect the diff — it should contain `eventSets`, `eventSet`, `EventSetEntry`, `EventSetDetail`.
+
+After Milestone 7, run `cargo test -p bookshelf-e2e --no-run` to confirm the e2e crate compiles. Full e2e test execution requires a running Postgres and app server.
+
+## Idempotence and Recovery
+
+Each milestone is committed independently. To restart from any milestone, check out the relevant commit and re-apply the steps from the next milestone onward.
+
+## Artifacts and Notes
+
+The `event_set` table schema (from existing migrations):
+
+    CREATE TABLE event_set (
+        id UUID PRIMARY KEY,
+        user_id TEXT NOT NULL REFERENCES "user"(id),
+        operation TEXT NOT NULL,
+        created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+    );
+
+`book_event` and `author_event` both have an `event_set_id UUID NOT NULL REFERENCES event_set(id)` column and a `user_id TEXT NOT NULL` column, enabling per-user filtering.
+
+## Interfaces and Dependencies
+
+In `src/domain/repository/event_set_repository.rs`:
+
+    #[automock]
+    #[async_trait]
+    pub trait EventSetRepository: Send + Sync + 'static {
+        async fn find_all(&self, user_id: &UserId) -> Result<Vec<EventSet>, DomainError>;
+        async fn find_by_id(
+            &self,
+            user_id: &UserId,
+            event_set_id: &EventSetId,
+        ) -> Result<Option<EventSet>, DomainError>;
+    }
+
+In `src/use_case/traits/query.rs` (additions):
+
+    async fn list_event_sets(&self, user_id: &str) -> Result<Vec<EventSetDto>, UseCaseError>;
+    async fn find_event_set(
+        &self,
+        user_id: &str,
+        event_set_id: &str,
+    ) -> Result<Option<EventSetDetailDto>, UseCaseError>;
+
+In `src/use_case/interactor/query.rs`:
+
+    pub struct QueryInteractor<UR, BR, AR, BER, AER, ESR> { ... }

--- a/.agent/plans/20260613-add-event-set-queries.md
+++ b/.agent/plans/20260613-add-event-set-queries.md
@@ -97,7 +97,7 @@ All commands run from `/home/user/bookshelf-api`.
 Pre-commit checks (run before every commit):
 
     cargo fmt --check
-    git add -A && cargo clippy --fix --allow-staged --all-targets -- -D warnings
+    cargo clippy --fix --all-targets -- -D warnings
     cargo test
 
 Milestone 1 commit message: "Add EventSetRepository domain trait and find_by_event_set methods"

--- a/e2e/tests/e2e.rs
+++ b/e2e/tests/e2e.rs
@@ -1804,47 +1804,18 @@ async fn e2e_import_books() -> Result<()> {
     );
     assert_ne!(book_one_id, book_two_id, "book ids should be distinct");
 
-    // Query bookEvents for each book and verify shared eventSetId
-    let history_query_one = format!(
-        r#"{{ bookEvents(bookId: "{}") {{ eventSetId operation }} }}"#,
-        book_one_id
-    );
-    let (_, response) = graphql_request(&history_query_one, Some(&token)).await?;
-    let entries_one = response["data"]["bookEvents"]
+    // Locate the single event set produced by the import via eventSets, then
+    // inspect it directly. This replaces the old workaround of comparing the
+    // eventSetId across separate per-book bookEvents queries.
+    let (_, response) = graphql_request(r#"{ eventSets { id operation } }"#, Some(&token)).await?;
+    let event_sets = response["data"]["eventSets"]
         .as_array()
-        .context("bookEvents should be an array")?;
-    assert!(
-        entries_one
-            .iter()
-            .any(|e| e["operation"].as_str() == Some("create")),
-        "book one should have a create event"
-    );
-    let event_set_id_one = entries_one[0]["eventSetId"]
-        .as_str()
-        .context("eventSetId should be string")?;
-
-    let history_query_two = format!(
-        r#"{{ bookEvents(bookId: "{}") {{ eventSetId operation }} }}"#,
-        book_two_id
-    );
-    let (_, response) = graphql_request(&history_query_two, Some(&token)).await?;
-    let entries_two = response["data"]["bookEvents"]
-        .as_array()
-        .context("bookEvents should be an array")?;
-    assert!(
-        entries_two
-            .iter()
-            .any(|e| e["operation"].as_str() == Some("create")),
-        "book two should have a create event"
-    );
-    let event_set_id_two = entries_two[0]["eventSetId"]
-        .as_str()
-        .context("eventSetId should be string")?;
-
-    assert_eq!(
-        event_set_id_one, event_set_id_two,
-        "both books should share the same eventSetId"
-    );
+        .context("eventSets should be an array")?;
+    let import_set_id = event_sets
+        .iter()
+        .find(|s| s["operation"].as_str() == Some("import_books"))
+        .and_then(|s| s["id"].as_str())
+        .context("there should be an import_books event set")?;
 
     // The shared event set groups both book creates and the new author create.
     let event_set_query = format!(
@@ -1853,7 +1824,7 @@ async fn e2e_import_books() -> Result<()> {
             bookEvents {{ bookId operation }}
             authorEvents {{ name operation }}
         }} }}"#,
-        event_set_id_one
+        import_set_id
     );
     let (_, response) = graphql_request(&event_set_query, Some(&token)).await?;
     let event_set = &response["data"]["eventSet"];
@@ -1940,7 +1911,7 @@ async fn e2e_import_books() -> Result<()> {
         .and_then(|a| a["id"].as_str())
         .context("new author should have an id")?;
     let author_events_query = format!(
-        r#"{{ authorEvents(authorId: "{}") {{ eventId eventSetId operation name }} }}"#,
+        r#"{{ authorEvents(authorId: "{}") {{ operation name }} }}"#,
         new_author_id
     );
     let (_, response) = graphql_request(&author_events_query, Some(&token)).await?;
@@ -1961,17 +1932,6 @@ async fn e2e_import_books() -> Result<()> {
         author_events[0]["name"].as_str(),
         Some("New Author"),
         "new author event name should match"
-    );
-    assert!(
-        !author_events[0]["eventSetId"].is_null(),
-        "new author event should have eventSetId"
-    );
-    let author_event_set_id = author_events[0]["eventSetId"]
-        .as_str()
-        .context("author eventSetId should be string")?;
-    assert_eq!(
-        author_event_set_id, event_set_id_one,
-        "author event should share the same eventSetId as the books"
     );
 
     // Cleanup

--- a/e2e/tests/e2e.rs
+++ b/e2e/tests/e2e.rs
@@ -1846,6 +1846,61 @@ async fn e2e_import_books() -> Result<()> {
         "both books should share the same eventSetId"
     );
 
+    // The shared event set groups both book creates and the new author create.
+    let event_set_query = format!(
+        r#"{{ eventSet(id: "{}") {{
+            operation
+            bookEvents {{ bookId operation }}
+            authorEvents {{ name operation }}
+        }} }}"#,
+        event_set_id_one
+    );
+    let (_, response) = graphql_request(&event_set_query, Some(&token)).await?;
+    let event_set = &response["data"]["eventSet"];
+    assert!(!event_set.is_null(), "import event set should be found");
+    assert_eq!(
+        event_set["operation"].as_str(),
+        Some("import_books"),
+        "import event set operation should be import_books"
+    );
+    let grouped_book_events = event_set["bookEvents"]
+        .as_array()
+        .context("bookEvents should be an array")?;
+    assert_eq!(
+        grouped_book_events.len(),
+        2,
+        "import event set should group both book create events"
+    );
+    assert!(
+        grouped_book_events
+            .iter()
+            .all(|e| e["operation"].as_str() == Some("create")),
+        "all grouped book events should be create events"
+    );
+    let grouped_book_ids: Vec<&str> = grouped_book_events
+        .iter()
+        .filter_map(|e| e["bookId"].as_str())
+        .collect();
+    assert!(grouped_book_ids.contains(&book_one_id));
+    assert!(grouped_book_ids.contains(&book_two_id));
+    let grouped_author_events = event_set["authorEvents"]
+        .as_array()
+        .context("authorEvents should be an array")?;
+    assert_eq!(
+        grouped_author_events.len(),
+        1,
+        "import event set should group the newly created author event"
+    );
+    assert_eq!(
+        grouped_author_events[0]["name"].as_str(),
+        Some("New Author"),
+        "grouped author event should be the new author"
+    );
+    assert_eq!(
+        grouped_author_events[0]["operation"].as_str(),
+        Some("create")
+    );
+
     // Verify Book Two has "New Author"
     let book_two_query = format!(
         r#"{{ book(id: "{}") {{ authors {{ name }} }} }}"#,
@@ -1944,6 +1999,132 @@ async fn e2e_import_books_empty_returns_error() -> Result<()> {
         "importBooks with empty list should return errors: {:?}",
         response.get("errors")
     );
+
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
+async fn e2e_event_sets() -> Result<()> {
+    let user_id = uuid::Uuid::new_v4().to_string();
+    let token = generate_test_token(&user_id)?;
+    ensure_user_registered(&token).await?;
+
+    // Two separate operations => two event sets (create_author, then create_book).
+    let author_id = create_test_author(
+        &format!("Event Set Author {}", uuid::Uuid::new_v4()),
+        &token,
+    )
+    .await?;
+    let book_id = create_test_book("Event Set Book", &author_id, &token).await?;
+
+    // List event sets: newest first, exactly the two operations above.
+    let (_, response) =
+        graphql_request(r#"{ eventSets { id operation createdAt } }"#, Some(&token)).await?;
+    let sets = response["data"]["eventSets"]
+        .as_array()
+        .context("eventSets should be an array")?;
+    assert_eq!(sets.len(), 2, "fresh user should have exactly 2 event sets");
+    // Ordered by createdAt descending (newest first).
+    let created0 = sets[0]["createdAt"].as_i64().context("createdAt is i64")?;
+    let created1 = sets[1]["createdAt"].as_i64().context("createdAt is i64")?;
+    assert!(created0 >= created1, "event sets should be newest first");
+    let operations: Vec<&str> = sets
+        .iter()
+        .filter_map(|s| s["operation"].as_str())
+        .collect();
+    assert!(
+        operations.contains(&"create_book"),
+        "should contain a create_book event set"
+    );
+    assert!(
+        operations.contains(&"create_author"),
+        "should contain a create_author event set"
+    );
+
+    // Drill into the create_book event set: it groups the book's create event.
+    let create_book_set_id = sets
+        .iter()
+        .find(|s| s["operation"].as_str() == Some("create_book"))
+        .and_then(|s| s["id"].as_str())
+        .context("create_book event set should have an id")?;
+    let detail_query = format!(
+        r#"{{ eventSet(id: "{}") {{
+            id operation createdAt
+            bookEvents {{ bookId operation }}
+            authorEvents {{ name operation }}
+        }} }}"#,
+        create_book_set_id
+    );
+    let (_, response) = graphql_request(&detail_query, Some(&token)).await?;
+    let detail = &response["data"]["eventSet"];
+    assert!(!detail.is_null(), "eventSet should be found");
+    assert_eq!(detail["operation"].as_str(), Some("create_book"));
+    let book_events = detail["bookEvents"]
+        .as_array()
+        .context("bookEvents should be an array")?;
+    assert_eq!(book_events.len(), 1, "create_book set has one book event");
+    assert_eq!(book_events[0]["bookId"].as_str(), Some(book_id.as_str()));
+    assert_eq!(book_events[0]["operation"].as_str(), Some("create"));
+    assert!(
+        detail["authorEvents"]
+            .as_array()
+            .context("authorEvents should be an array")?
+            .is_empty(),
+        "create_book set has no author events"
+    );
+
+    // Drill into the create_author event set: it groups the author's create event.
+    let create_author_set_id = sets
+        .iter()
+        .find(|s| s["operation"].as_str() == Some("create_author"))
+        .and_then(|s| s["id"].as_str())
+        .context("create_author event set should have an id")?;
+    let detail_query = format!(
+        r#"{{ eventSet(id: "{}") {{ authorEvents {{ name operation }} bookEvents {{ bookId }} }} }}"#,
+        create_author_set_id
+    );
+    let (_, response) = graphql_request(&detail_query, Some(&token)).await?;
+    let author_events = response["data"]["eventSet"]["authorEvents"]
+        .as_array()
+        .context("authorEvents should be an array")?;
+    assert_eq!(
+        author_events.len(),
+        1,
+        "create_author set has one author event"
+    );
+    assert_eq!(author_events[0]["operation"].as_str(), Some("create"));
+
+    // Unknown id returns null.
+    let unknown_query = format!(r#"{{ eventSet(id: "{}") {{ id }} }}"#, uuid::Uuid::new_v4());
+    let (_, response) = graphql_request(&unknown_query, Some(&token)).await?;
+    assert!(
+        response["data"]["eventSet"].is_null(),
+        "unknown event set id should return null"
+    );
+
+    // User isolation: a second user cannot see the first user's event set.
+    let other_user_id = uuid::Uuid::new_v4().to_string();
+    let other_token = generate_test_token(&other_user_id)?;
+    ensure_user_registered(&other_token).await?;
+    let isolation_query = format!(r#"{{ eventSet(id: "{}") {{ id }} }}"#, create_book_set_id);
+    let (_, response) = graphql_request(&isolation_query, Some(&other_token)).await?;
+    assert!(
+        response["data"]["eventSet"].is_null(),
+        "other user must not see another user's event set"
+    );
+    let (_, response) = graphql_request(r#"{ eventSets { id } }"#, Some(&other_token)).await?;
+    assert!(
+        response["data"]["eventSets"]
+            .as_array()
+            .context("eventSets should be an array")?
+            .is_empty(),
+        "a fresh user should have no event sets"
+    );
+
+    // Cleanup.
+    delete_test_book(&book_id, &token).await?;
+    delete_test_author(&author_id, &token).await?;
 
     Ok(())
 }

--- a/e2e/tests/e2e.rs
+++ b/e2e/tests/e2e.rs
@@ -2011,7 +2011,7 @@ async fn e2e_event_sets() -> Result<()> {
     let detail_query = format!(
         r#"{{ eventSet(id: "{}") {{
             id operation createdAt
-            bookEvents {{ bookId operation }}
+            bookEvents {{ bookId operation title changedAt }}
             authorEvents {{ name operation }}
         }} }}"#,
         create_book_set_id
@@ -2019,13 +2019,33 @@ async fn e2e_event_sets() -> Result<()> {
     let (_, response) = graphql_request(&detail_query, Some(&token)).await?;
     let detail = &response["data"]["eventSet"];
     assert!(!detail.is_null(), "eventSet should be found");
+    assert_eq!(
+        detail["id"].as_str(),
+        Some(create_book_set_id),
+        "eventSet id should round-trip the queried id"
+    );
     assert_eq!(detail["operation"].as_str(), Some("create_book"));
+    assert!(
+        detail["createdAt"].as_i64().is_some(),
+        "createdAt should be an Int"
+    );
     let book_events = detail["bookEvents"]
         .as_array()
         .context("bookEvents should be an array")?;
     assert_eq!(book_events.len(), 1, "create_book set has one book event");
     assert_eq!(book_events[0]["bookId"].as_str(), Some(book_id.as_str()));
     assert_eq!(book_events[0]["operation"].as_str(), Some("create"));
+    // The nested entry must carry the full BookEventEntry data, not just ids
+    // (guards the find_by_event_set projection).
+    assert_eq!(
+        book_events[0]["title"].as_str(),
+        Some("Event Set Book"),
+        "nested book event should carry the title"
+    );
+    assert!(
+        !book_events[0]["changedAt"].is_null(),
+        "nested book event changedAt should not be null"
+    );
     assert!(
         detail["authorEvents"]
             .as_array()

--- a/schema.graphql
+++ b/schema.graphql
@@ -75,6 +75,20 @@ input CreateBookInput {
 	store: BookStore!
 }
 
+type EventSetDetail {
+	id: ID!
+	operation: String!
+	createdAt: Int!
+	bookEvents: [BookEventEntry!]!
+	authorEvents: [AuthorEventEntry!]!
+}
+
+type EventSetEntry {
+	id: ID!
+	operation: String!
+	createdAt: Int!
+}
+
 input ImportBookInput {
 	"""
 	Title of the book.
@@ -147,6 +161,14 @@ type Query {
 	Entries are sorted by `changedAt` in descending order (newest first).
 	"""
 	authorEvents(authorId: ID!): [AuthorEventEntry!]!
+	"""
+	Returns the logged-in user's event sets, newest first.
+	"""
+	eventSets: [EventSetEntry!]!
+	"""
+	Returns a single event set with nested events, or null if not found.
+	"""
+	eventSet(id: ID!): EventSetDetail
 }
 
 input UpdateAuthorInput {

--- a/src/dependency_injection.rs
+++ b/src/dependency_injection.rs
@@ -5,7 +5,8 @@ use crate::{
     infrastructure::{
         author_event_repository::PgAuthorEventRepository, author_repository::PgAuthorRepository,
         book_event_repository::PgBookEventRepository, book_repository::PgBookRepository,
-        transaction::PgTransactionManager, user_repository::PgUserRepository,
+        event_set_repository::PgEventSetRepository, transaction::PgTransactionManager,
+        user_repository::PgUserRepository,
     },
     presentation::graphql::{mutation::Mutation, query::Query, schema::build_schema},
     use_case::interactor::{
@@ -26,6 +27,7 @@ pub type QI = QueryInteractor<
     PgAuthorRepository,
     PgBookEventRepository,
     PgAuthorEventRepository,
+    PgEventSetRepository,
 >;
 
 pub type MI = MutationInteractor<
@@ -49,6 +51,7 @@ pub fn dependency_injection(
     let author_repository = PgAuthorRepository::new(pool.clone());
     let book_event_repository = PgBookEventRepository::new(pool.clone());
     let author_event_repository = PgAuthorEventRepository::new(pool.clone());
+    let event_set_repository = PgEventSetRepository::new(pool.clone());
     let transaction_manager = PgTransactionManager::new(pool);
 
     let query_use_case = QueryInteractor {
@@ -57,6 +60,7 @@ pub fn dependency_injection(
         author_repository: author_repository.clone(),
         book_event_repository: book_event_repository.clone(),
         author_event_repository: author_event_repository.clone(),
+        event_set_repository,
     };
     let register_user_use_case = RegisterUserInteractor::new(user_repository);
     let create_book_use_case =

--- a/src/domain/repository.rs
+++ b/src/domain/repository.rs
@@ -2,5 +2,6 @@ pub mod author_event_repository;
 pub mod author_repository;
 pub mod book_event_repository;
 pub mod book_repository;
+pub mod event_set_repository;
 pub mod transaction;
 pub mod user_repository;

--- a/src/domain/repository/author_event_repository.rs
+++ b/src/domain/repository/author_event_repository.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use mockall::automock;
 
 use crate::domain::{
-    entity::{author::AuthorId, event::AuthorEvent, user::UserId},
+    entity::{author::AuthorId, event::AuthorEvent, event_set::EventSetId, user::UserId},
     error::DomainError,
 };
 
@@ -20,4 +20,10 @@ pub trait AuthorEventRepository: Send + Sync + 'static {
         user_id: &UserId,
         event_id: i64,
     ) -> Result<Option<AuthorEvent>, DomainError>;
+
+    async fn find_by_event_set(
+        &self,
+        user_id: &UserId,
+        event_set_id: &EventSetId,
+    ) -> Result<Vec<AuthorEvent>, DomainError>;
 }

--- a/src/domain/repository/book_event_repository.rs
+++ b/src/domain/repository/book_event_repository.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use mockall::automock;
 
 use crate::domain::{
-    entity::{book::BookId, event::BookEvent, user::UserId},
+    entity::{book::BookId, event::BookEvent, event_set::EventSetId, user::UserId},
     error::DomainError,
 };
 
@@ -20,4 +20,10 @@ pub trait BookEventRepository: Send + Sync + 'static {
         user_id: &UserId,
         event_id: i64,
     ) -> Result<Option<BookEvent>, DomainError>;
+
+    async fn find_by_event_set(
+        &self,
+        user_id: &UserId,
+        event_set_id: &EventSetId,
+    ) -> Result<Vec<BookEvent>, DomainError>;
 }

--- a/src/domain/repository/event_set_repository.rs
+++ b/src/domain/repository/event_set_repository.rs
@@ -1,0 +1,21 @@
+use async_trait::async_trait;
+use mockall::automock;
+
+use crate::domain::{
+    entity::{
+        event_set::{EventSet, EventSetId},
+        user::UserId,
+    },
+    error::DomainError,
+};
+
+#[automock]
+#[async_trait]
+pub trait EventSetRepository: Send + Sync + 'static {
+    async fn find_all(&self, user_id: &UserId) -> Result<Vec<EventSet>, DomainError>;
+    async fn find_by_id(
+        &self,
+        user_id: &UserId,
+        event_set_id: &EventSetId,
+    ) -> Result<Option<EventSet>, DomainError>;
+}

--- a/src/infrastructure.rs
+++ b/src/infrastructure.rs
@@ -3,5 +3,6 @@ pub mod author_repository;
 pub mod book_event_repository;
 pub mod book_repository;
 pub mod error;
+pub mod event_set_repository;
 pub mod transaction;
 pub mod user_repository;

--- a/src/infrastructure/author_event_repository.rs
+++ b/src/infrastructure/author_event_repository.rs
@@ -205,4 +205,38 @@ mod tests {
 
         Ok(())
     }
+
+    #[sqlx::test]
+    async fn find_by_event_set_is_user_scoped_returns_empty_for_other_user(
+        pool: PgPool,
+    ) -> anyhow::Result<()> {
+        let user_repo = PgUserRepository::new(pool.clone());
+        let author_repo = PgAuthorRepository::new(pool.clone());
+        let event_repo = PgAuthorEventRepository::new(pool.clone());
+
+        let user1_id = prepare_user(&user_repo, "user1").await?;
+        let user2_id = prepare_user(&user_repo, "user2").await?;
+        let author_id = AuthorId::try_from("278935cf-ed83-4346-9b35-b84bbdb630c0")?;
+        create_author(
+            &pool,
+            &author_repo,
+            &user1_id,
+            &Author::new(author_id, AuthorName::new("author1".to_owned())?)?,
+        )
+        .await?;
+
+        let (event_set_id,): (Uuid,) =
+            sqlx::query_as("SELECT event_set_id FROM author_event WHERE user_id = $1")
+                .bind(user1_id.as_str())
+                .fetch_one(&pool)
+                .await?;
+
+        // user2 must not see user1's event set events.
+        let entries = event_repo
+            .find_by_event_set(&user2_id, &EventSetId::from(event_set_id))
+            .await?;
+        assert!(entries.is_empty());
+
+        Ok(())
+    }
 }

--- a/src/infrastructure/author_event_repository.rs
+++ b/src/infrastructure/author_event_repository.rs
@@ -98,4 +98,111 @@ impl AuthorEventRepository for PgAuthorEventRepository {
 
         row.map(row_to_author_event).transpose()
     }
+
+    async fn find_by_event_set(
+        &self,
+        user_id: &UserId,
+        event_set_id: &EventSetId,
+    ) -> Result<Vec<AuthorEvent>, DomainError> {
+        let rows: Vec<AuthorEventRow> = sqlx::query_as(
+            "SELECT event_id, event_set_id, operation, author_id, name, yomi,
+                    author_created_at, author_updated_at, changed_at, extra
+             FROM author_event
+             WHERE user_id = $1 AND event_set_id = $2
+             ORDER BY changed_at DESC",
+        )
+        .bind(user_id.as_str())
+        .bind(event_set_id.to_uuid())
+        .fetch_all(&self.pool)
+        .await?;
+
+        rows.into_iter().map(row_to_author_event).collect()
+    }
+}
+
+#[cfg(feature = "test-with-database")]
+#[cfg(test)]
+mod tests {
+    use crate::domain::{
+        entity::{
+            author::{Author, AuthorName},
+            event::{EventOperation, EventSetOperation},
+            user::User,
+        },
+        repository::{
+            author_repository::AuthorRepository, transaction::TransactionManager,
+            user_repository::UserRepository,
+        },
+    };
+    use crate::infrastructure::{
+        author_repository::PgAuthorRepository, transaction::PgTransactionManager,
+        user_repository::PgUserRepository,
+    };
+
+    use super::*;
+
+    async fn prepare_user(repository: &PgUserRepository, id: &str) -> Result<UserId, DomainError> {
+        let user_id = UserId::new(id.to_string())?;
+        repository.create(&User::new(user_id.clone())).await?;
+        Ok(user_id)
+    }
+
+    async fn create_author(
+        pool: &PgPool,
+        author_repo: &PgAuthorRepository,
+        user_id: &UserId,
+        author: &Author,
+    ) -> Result<(), DomainError> {
+        let tm = PgTransactionManager::new(pool.clone());
+        let mut tx = tm.begin(user_id, EventSetOperation::CreateAuthor).await?;
+        author_repo.create(&mut tx, user_id, author).await?;
+        tm.commit(tx).await
+    }
+
+    #[sqlx::test]
+    async fn find_by_event_set_returns_events(pool: PgPool) -> anyhow::Result<()> {
+        let user_repo = PgUserRepository::new(pool.clone());
+        let author_repo = PgAuthorRepository::new(pool.clone());
+        let event_repo = PgAuthorEventRepository::new(pool.clone());
+
+        let user_id = prepare_user(&user_repo, "user1").await?;
+        let author_id = AuthorId::try_from("278935cf-ed83-4346-9b35-b84bbdb630c0")?;
+        create_author(
+            &pool,
+            &author_repo,
+            &user_id,
+            &Author::new(author_id, AuthorName::new("author1".to_owned())?)?,
+        )
+        .await?;
+
+        let (event_set_id,): (Uuid,) =
+            sqlx::query_as("SELECT event_set_id FROM author_event WHERE user_id = $1")
+                .bind(user_id.as_str())
+                .fetch_one(&pool)
+                .await?;
+
+        let entries = event_repo
+            .find_by_event_set(&user_id, &EventSetId::from(event_set_id))
+            .await?;
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].operation, EventOperation::Create);
+        assert_eq!(entries[0].name.as_deref(), Some("author1"));
+
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn find_by_event_set_returns_empty_for_unknown_set(pool: PgPool) -> anyhow::Result<()> {
+        let user_repo = PgUserRepository::new(pool.clone());
+        let event_repo = PgAuthorEventRepository::new(pool.clone());
+
+        let user_id = prepare_user(&user_repo, "user1").await?;
+        let unknown = EventSetId::try_from("00000000-0000-0000-0000-000000000000")
+            .map_err(DomainError::Unexpected)?;
+
+        let entries = event_repo.find_by_event_set(&user_id, &unknown).await?;
+        assert!(entries.is_empty());
+
+        Ok(())
+    }
 }

--- a/src/infrastructure/author_repository.rs
+++ b/src/infrastructure/author_repository.rs
@@ -733,7 +733,10 @@ mod tests {
         let author = Author::new(author_id.clone(), AuthorName::new("author1".to_string())?)?;
         create_author(&pool, &author_repository, &user_id, &author).await?;
 
-        let book = make_book("675bc8d9-3155-42fb-87b0-0a82cb162848", &[author_id.clone()])?;
+        let book = make_book(
+            "675bc8d9-3155-42fb-87b0-0a82cb162848",
+            std::slice::from_ref(&author_id),
+        )?;
         create_book(&pool, &book_repository, &user_id, &book).await?;
 
         let result = delete_author(&pool, &author_repository, &user_id, &author_id).await;
@@ -802,9 +805,15 @@ mod tests {
         create_author(&pool, &author_repository, &user1_id, &author1).await?;
         create_author(&pool, &author_repository, &user2_id, &author2).await?;
 
-        let book1 = make_book("675bc8d9-3155-42fb-87b0-0a82cb162848", &[author_id.clone()])?;
+        let book1 = make_book(
+            "675bc8d9-3155-42fb-87b0-0a82cb162848",
+            std::slice::from_ref(&author_id),
+        )?;
         create_book(&pool, &book_repository, &user1_id, &book1).await?;
-        let book2 = make_book("675bc8d9-3155-42fb-87b0-0a82cb162848", &[author_id.clone()])?;
+        let book2 = make_book(
+            "675bc8d9-3155-42fb-87b0-0a82cb162848",
+            std::slice::from_ref(&author_id),
+        )?;
         create_book(&pool, &book_repository, &user2_id, &book2).await?;
 
         // user2 has an associated book, so delete must fail

--- a/src/infrastructure/book_event_repository.rs
+++ b/src/infrastructure/book_event_repository.rs
@@ -167,6 +167,43 @@ impl BookEventRepository for PgBookEventRepository {
 
         row.map(row_to_book_event).transpose()
     }
+
+    async fn find_by_event_set(
+        &self,
+        user_id: &UserId,
+        event_set_id: &EventSetId,
+    ) -> Result<Vec<BookEvent>, DomainError> {
+        let rows: Vec<BookEventRow> = sqlx::query_as(
+            "SELECT
+                be.event_id,
+                be.event_set_id,
+                be.operation,
+                be.book_id,
+                be.title,
+                be.isbn,
+                be.read,
+                be.owned,
+                be.priority,
+                be.format,
+                be.store,
+                be.book_created_at,
+                be.book_updated_at,
+                be.changed_at,
+                array_agg(bea.author_id) FILTER (WHERE bea.author_id IS NOT NULL) AS author_ids,
+                be.extra
+            FROM book_event be
+            LEFT JOIN book_event_author bea ON be.event_id = bea.event_id
+            WHERE be.user_id = $1 AND be.event_set_id = $2
+            GROUP BY be.event_id
+            ORDER BY be.changed_at DESC",
+        )
+        .bind(user_id.as_str())
+        .bind(event_set_id.to_uuid())
+        .fetch_all(&self.pool)
+        .await?;
+
+        rows.into_iter().map(row_to_book_event).collect()
+    }
 }
 
 #[cfg(feature = "test-with-database")]
@@ -179,6 +216,7 @@ mod tests {
                 author::{Author, AuthorId, AuthorName},
                 book::{Book, BookId, BookTitle, Isbn, OwnedFlag, Priority, ReadFlag},
                 event::{EventOperation, EventSetOperation},
+                event_set::EventSetId,
                 user::User,
             },
             error::DomainError,
@@ -437,6 +475,61 @@ mod tests {
         // user2 must not see user1's event entry
         let entry = event_repo.find_by_event_id(&user2_id, event_id).await?;
         assert!(entry.is_none());
+
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn find_by_event_set_returns_events(pool: PgPool) -> anyhow::Result<()> {
+        let user_repo = PgUserRepository::new(pool.clone());
+        let author_repo = PgAuthorRepository::new(pool.clone());
+        let book_repo = PgBookRepository::new(pool.clone());
+        let event_repo = PgBookEventRepository::new(pool.clone());
+
+        let user_id = prepare_user(&user_repo, "user1").await?;
+        let author_id = AuthorId::try_from("278935cf-ed83-4346-9b35-b84bbdb630c0")?;
+        create_author(
+            &pool,
+            &author_repo,
+            &user_id,
+            &Author::new(author_id.clone(), AuthorName::new("author1".to_owned())?)?,
+        )
+        .await?;
+
+        let book = make_book(
+            "675bc8d9-3155-42fb-87b0-0a82cb162848",
+            "title1",
+            &[author_id.clone()],
+        )?;
+        create_book(&pool, &book_repo, &user_id, &book).await?;
+
+        let (event_set_id,): (uuid::Uuid,) =
+            sqlx::query_as("SELECT event_set_id FROM book_event WHERE user_id = $1")
+                .bind(user_id.as_str())
+                .fetch_one(&pool)
+                .await?;
+
+        let entries = event_repo
+            .find_by_event_set(&user_id, &EventSetId::from(event_set_id))
+            .await?;
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].operation, EventOperation::Create);
+        assert_eq!(entries[0].author_ids, vec![author_id]);
+
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn find_by_event_set_returns_empty_for_unknown_set(pool: PgPool) -> anyhow::Result<()> {
+        let user_repo = PgUserRepository::new(pool.clone());
+        let event_repo = PgBookEventRepository::new(pool.clone());
+
+        let user_id = prepare_user(&user_repo, "user1").await?;
+        let unknown = EventSetId::try_from("00000000-0000-0000-0000-000000000000")
+            .map_err(DomainError::Unexpected)?;
+
+        let entries = event_repo.find_by_event_set(&user_id, &unknown).await?;
+        assert!(entries.is_empty());
 
         Ok(())
     }

--- a/src/infrastructure/book_event_repository.rs
+++ b/src/infrastructure/book_event_repository.rs
@@ -324,7 +324,7 @@ mod tests {
         let book = make_book(
             "675bc8d9-3155-42fb-87b0-0a82cb162848",
             "original",
-            &[author_id.clone()],
+            std::slice::from_ref(&author_id),
         )?;
         create_book(&pool, &book_repo, &user_id, &book).await?;
 
@@ -499,7 +499,7 @@ mod tests {
         let book = make_book(
             "675bc8d9-3155-42fb-87b0-0a82cb162848",
             "title1",
-            &[author_id.clone()],
+            std::slice::from_ref(&author_id),
         )?;
         create_book(&pool, &book_repo, &user_id, &book).await?;
 

--- a/src/infrastructure/event_set_repository.rs
+++ b/src/infrastructure/event_set_repository.rs
@@ -1,0 +1,283 @@
+use async_trait::async_trait;
+use sqlx::PgPool;
+use time::OffsetDateTime;
+use uuid::Uuid;
+
+use crate::domain::{
+    entity::{
+        event_set::{EventSet, EventSetId},
+        user::UserId,
+    },
+    error::DomainError,
+    repository::event_set_repository::EventSetRepository,
+};
+
+#[derive(sqlx::FromRow)]
+struct EventSetRow {
+    id: Uuid,
+    user_id: String,
+    operation: String,
+    created_at: OffsetDateTime,
+}
+
+fn row_to_event_set(row: EventSetRow) -> Result<EventSet, DomainError> {
+    Ok(EventSet {
+        id: EventSetId::from(row.id),
+        user_id: UserId::new(row.user_id)?,
+        operation: row.operation,
+        created_at: row.created_at,
+    })
+}
+
+#[derive(Debug, Clone)]
+pub struct PgEventSetRepository {
+    pool: PgPool,
+}
+
+impl PgEventSetRepository {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait]
+impl EventSetRepository for PgEventSetRepository {
+    async fn find_all(&self, user_id: &UserId) -> Result<Vec<EventSet>, DomainError> {
+        let rows: Vec<EventSetRow> = sqlx::query_as(
+            "SELECT id, user_id, operation, created_at
+             FROM event_set
+             WHERE user_id = $1
+             ORDER BY created_at DESC",
+        )
+        .bind(user_id.as_str())
+        .fetch_all(&self.pool)
+        .await?;
+
+        rows.into_iter().map(row_to_event_set).collect()
+    }
+
+    async fn find_by_id(
+        &self,
+        user_id: &UserId,
+        event_set_id: &EventSetId,
+    ) -> Result<Option<EventSet>, DomainError> {
+        let row: Option<EventSetRow> = sqlx::query_as(
+            "SELECT id, user_id, operation, created_at
+             FROM event_set
+             WHERE user_id = $1 AND id = $2",
+        )
+        .bind(user_id.as_str())
+        .bind(event_set_id.to_uuid())
+        .fetch_optional(&self.pool)
+        .await?;
+
+        row.map(row_to_event_set).transpose()
+    }
+}
+
+#[cfg(feature = "test-with-database")]
+#[cfg(test)]
+mod tests {
+    use crate::{
+        common::types::{BookFormat, BookStore},
+        domain::{
+            entity::{
+                author::{Author, AuthorId, AuthorName},
+                book::{Book, BookId, BookTitle, Isbn, OwnedFlag, Priority, ReadFlag},
+                event::EventSetOperation,
+                user::User,
+            },
+            error::DomainError,
+            repository::{
+                author_repository::AuthorRepository, book_repository::BookRepository,
+                transaction::TransactionManager, user_repository::UserRepository,
+            },
+        },
+        infrastructure::{
+            author_repository::PgAuthorRepository, book_repository::PgBookRepository,
+            transaction::PgTransactionManager, user_repository::PgUserRepository,
+        },
+    };
+    use time::{
+        PrimitiveDateTime,
+        macros::{date, time},
+    };
+
+    use super::*;
+
+    async fn prepare_user(repository: &PgUserRepository, id: &str) -> Result<UserId, DomainError> {
+        let user_id = UserId::new(id.to_string())?;
+        let user = User::new(user_id.clone());
+        repository.create(&user).await?;
+        Ok(user_id)
+    }
+
+    async fn create_author(
+        pool: &PgPool,
+        author_repo: &PgAuthorRepository,
+        user_id: &UserId,
+        author: &Author,
+    ) -> Result<(), DomainError> {
+        let tm = PgTransactionManager::new(pool.clone());
+        let mut tx = tm.begin(user_id, EventSetOperation::CreateAuthor).await?;
+        author_repo.create(&mut tx, user_id, author).await?;
+        tm.commit(tx).await
+    }
+
+    async fn create_book(
+        pool: &PgPool,
+        book_repo: &PgBookRepository,
+        user_id: &UserId,
+        book: &Book,
+    ) -> Result<(), DomainError> {
+        let tm = PgTransactionManager::new(pool.clone());
+        let mut tx = tm.begin(user_id, EventSetOperation::CreateBook).await?;
+        book_repo.create(&mut tx, user_id, book).await?;
+        tm.commit(tx).await
+    }
+
+    fn make_book(
+        book_id_str: &str,
+        title: &str,
+        author_ids: &[AuthorId],
+    ) -> Result<Book, DomainError> {
+        let created_at = PrimitiveDateTime::new(date!(2022 - 05 - 05), time!(0:00)).assume_utc();
+        Book::new(
+            BookId::try_from(book_id_str)?,
+            BookTitle::new(title.to_owned())?,
+            author_ids.to_vec(),
+            Isbn::new("1111111111116".to_owned())?,
+            ReadFlag::new(false),
+            OwnedFlag::new(false),
+            Priority::new(50)?,
+            BookFormat::EBook,
+            BookStore::Kindle,
+            created_at,
+            created_at,
+        )
+    }
+
+    #[sqlx::test]
+    async fn find_all_returns_event_sets_ordered_desc(pool: PgPool) -> anyhow::Result<()> {
+        let user_repo = PgUserRepository::new(pool.clone());
+        let author_repo = PgAuthorRepository::new(pool.clone());
+        let book_repo = PgBookRepository::new(pool.clone());
+        let event_set_repo = PgEventSetRepository::new(pool.clone());
+
+        let user_id = prepare_user(&user_repo, "user1").await?;
+        let author_id = AuthorId::try_from("278935cf-ed83-4346-9b35-b84bbdb630c0")?;
+        // First event set: create author.
+        create_author(
+            &pool,
+            &author_repo,
+            &user_id,
+            &Author::new(author_id.clone(), AuthorName::new("author1".to_owned())?)?,
+        )
+        .await?;
+        // Second event set: create book.
+        let book = make_book(
+            "675bc8d9-3155-42fb-87b0-0a82cb162848",
+            "title1",
+            &[author_id],
+        )?;
+        create_book(&pool, &book_repo, &user_id, &book).await?;
+
+        let event_sets = event_set_repo.find_all(&user_id).await?;
+        assert_eq!(event_sets.len(), 2);
+        // Newest first: the book creation event set precedes the author one.
+        assert_eq!(event_sets[0].operation, "create_book");
+        assert_eq!(event_sets[1].operation, "create_author");
+        assert!(event_sets[0].created_at >= event_sets[1].created_at);
+
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn find_all_returns_empty_for_user_without_events(pool: PgPool) -> anyhow::Result<()> {
+        let user_repo = PgUserRepository::new(pool.clone());
+        let event_set_repo = PgEventSetRepository::new(pool.clone());
+
+        let user_id = prepare_user(&user_repo, "user1").await?;
+
+        let event_sets = event_set_repo.find_all(&user_id).await?;
+        assert!(event_sets.is_empty());
+
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn find_by_id_returns_event_set_for_owner(pool: PgPool) -> anyhow::Result<()> {
+        let user_repo = PgUserRepository::new(pool.clone());
+        let author_repo = PgAuthorRepository::new(pool.clone());
+        let event_set_repo = PgEventSetRepository::new(pool.clone());
+
+        let user_id = prepare_user(&user_repo, "user1").await?;
+        let author_id = AuthorId::try_from("278935cf-ed83-4346-9b35-b84bbdb630c0")?;
+        create_author(
+            &pool,
+            &author_repo,
+            &user_id,
+            &Author::new(author_id, AuthorName::new("author1".to_owned())?)?,
+        )
+        .await?;
+
+        let (id,): (Uuid,) = sqlx::query_as("SELECT id FROM event_set WHERE user_id = $1")
+            .bind(user_id.as_str())
+            .fetch_one(&pool)
+            .await?;
+        let event_set_id = EventSetId::from(id);
+
+        let event_set = event_set_repo.find_by_id(&user_id, &event_set_id).await?;
+        assert!(event_set.is_some());
+        let event_set = event_set.unwrap();
+        assert_eq!(event_set.id, event_set_id);
+        assert_eq!(event_set.operation, "create_author");
+
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn find_by_id_returns_none_for_wrong_user(pool: PgPool) -> anyhow::Result<()> {
+        let user_repo = PgUserRepository::new(pool.clone());
+        let author_repo = PgAuthorRepository::new(pool.clone());
+        let event_set_repo = PgEventSetRepository::new(pool.clone());
+
+        let user1_id = prepare_user(&user_repo, "user1").await?;
+        let user2_id = prepare_user(&user_repo, "user2").await?;
+        let author_id = AuthorId::try_from("278935cf-ed83-4346-9b35-b84bbdb630c0")?;
+        create_author(
+            &pool,
+            &author_repo,
+            &user1_id,
+            &Author::new(author_id, AuthorName::new("author1".to_owned())?)?,
+        )
+        .await?;
+
+        let (id,): (Uuid,) = sqlx::query_as("SELECT id FROM event_set WHERE user_id = $1")
+            .bind(user1_id.as_str())
+            .fetch_one(&pool)
+            .await?;
+        let event_set_id = EventSetId::from(id);
+
+        // user2 must not see user1's event set.
+        let event_set = event_set_repo.find_by_id(&user2_id, &event_set_id).await?;
+        assert!(event_set.is_none());
+
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn find_by_id_returns_none_for_unknown_id(pool: PgPool) -> anyhow::Result<()> {
+        let user_repo = PgUserRepository::new(pool.clone());
+        let event_set_repo = PgEventSetRepository::new(pool.clone());
+
+        let user_id = prepare_user(&user_repo, "user1").await?;
+        let unknown = EventSetId::try_from("00000000-0000-0000-0000-000000000000")
+            .map_err(DomainError::Unexpected)?;
+
+        let event_set = event_set_repo.find_by_id(&user_id, &unknown).await?;
+        assert!(event_set.is_none());
+
+        Ok(())
+    }
+}

--- a/src/presentation/graphql/object.rs
+++ b/src/presentation/graphql/object.rs
@@ -8,6 +8,7 @@ use crate::dependency_injection::QI;
 use crate::use_case::dto::author::{AuthorDto, CreateAuthorDto, UpdateAuthorDto};
 use crate::use_case::dto::book::{BookDto, CreateBookDto, ImportBookEntryDto, UpdateBookDto};
 use crate::use_case::dto::event::{AuthorEventDto, BookEventDto};
+use crate::use_case::dto::event_set::{EventSetDetailDto, EventSetDto};
 
 use super::loader::AuthorLoader;
 
@@ -386,6 +387,52 @@ impl From<AuthorEventDto> for AuthorEventEntry {
             author_updated_at: dto.author_updated_at.map(|t| t.unix_timestamp()),
             changed_at: dto.changed_at.unix_timestamp(),
             extra: dto.extra.map(Json),
+        }
+    }
+}
+
+#[derive(SimpleObject)]
+pub struct EventSetEntry {
+    pub id: ID,
+    pub operation: String,
+    pub created_at: i64,
+}
+
+impl From<EventSetDto> for EventSetEntry {
+    fn from(dto: EventSetDto) -> Self {
+        Self {
+            id: ID(dto.id),
+            operation: dto.operation,
+            created_at: dto.created_at.unix_timestamp(),
+        }
+    }
+}
+
+#[derive(SimpleObject)]
+pub struct EventSetDetail {
+    pub id: ID,
+    pub operation: String,
+    pub created_at: i64,
+    pub book_events: Vec<BookEventEntry>,
+    pub author_events: Vec<AuthorEventEntry>,
+}
+
+impl From<EventSetDetailDto> for EventSetDetail {
+    fn from(dto: EventSetDetailDto) -> Self {
+        Self {
+            id: ID(dto.id),
+            operation: dto.operation,
+            created_at: dto.created_at.unix_timestamp(),
+            book_events: dto
+                .book_events
+                .into_iter()
+                .map(BookEventEntry::from)
+                .collect(),
+            author_events: dto
+                .author_events
+                .into_iter()
+                .map(AuthorEventEntry::from)
+                .collect(),
         }
     }
 }

--- a/src/presentation/graphql/query.rs
+++ b/src/presentation/graphql/query.rs
@@ -7,7 +7,9 @@ use crate::{
     use_case::traits::query::QueryUseCase,
 };
 
-use super::object::{Author, AuthorEventEntry, Book, BookEventEntry, User};
+use super::object::{
+    Author, AuthorEventEntry, Book, BookEventEntry, EventSetDetail, EventSetEntry, User,
+};
 
 pub struct Query<QUC> {
     query_use_case: QUC,
@@ -96,6 +98,30 @@ where
             .list_author_events(&claims.sub, author_id.as_str())
             .await?;
         Ok(entries.into_iter().map(AuthorEventEntry::from).collect())
+    }
+
+    /// Returns the logged-in user's event sets, newest first.
+    async fn event_sets(
+        &self,
+        ctx: &Context<'_>,
+    ) -> Result<Vec<EventSetEntry>, PresentationalError> {
+        let claims = get_claims(ctx)?;
+        let sets = self.query_use_case.list_event_sets(&claims.sub).await?;
+        Ok(sets.into_iter().map(EventSetEntry::from).collect())
+    }
+
+    /// Returns a single event set with nested events, or null if not found.
+    async fn event_set(
+        &self,
+        ctx: &Context<'_>,
+        id: ID,
+    ) -> Result<Option<EventSetDetail>, PresentationalError> {
+        let claims = get_claims(ctx)?;
+        let detail = self
+            .query_use_case
+            .find_event_set(&claims.sub, id.as_str())
+            .await?;
+        Ok(detail.map(EventSetDetail::from))
     }
 }
 

--- a/src/use_case/dto.rs
+++ b/src/use_case/dto.rs
@@ -1,4 +1,5 @@
 pub mod author;
 pub mod book;
 pub mod event;
+pub mod event_set;
 pub mod user;

--- a/src/use_case/dto/event_set.rs
+++ b/src/use_case/dto/event_set.rs
@@ -1,0 +1,48 @@
+use time::OffsetDateTime;
+
+use crate::{
+    domain::entity::event_set::EventSet,
+    use_case::dto::event::{AuthorEventDto, BookEventDto},
+};
+
+#[derive(Debug, Clone)]
+pub struct EventSetDto {
+    pub id: String,
+    pub operation: String,
+    pub created_at: OffsetDateTime,
+}
+
+impl From<EventSet> for EventSetDto {
+    fn from(e: EventSet) -> Self {
+        Self {
+            id: e.id.to_string(),
+            operation: e.operation,
+            created_at: e.created_at,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct EventSetDetailDto {
+    pub id: String,
+    pub operation: String,
+    pub created_at: OffsetDateTime,
+    pub book_events: Vec<BookEventDto>,
+    pub author_events: Vec<AuthorEventDto>,
+}
+
+impl EventSetDetailDto {
+    pub fn new(
+        event_set: EventSet,
+        book_events: Vec<BookEventDto>,
+        author_events: Vec<AuthorEventDto>,
+    ) -> Self {
+        Self {
+            id: event_set.id.to_string(),
+            operation: event_set.operation,
+            created_at: event_set.created_at,
+            book_events,
+            author_events,
+        }
+    }
+}

--- a/src/use_case/interactor/query.rs
+++ b/src/use_case/interactor/query.rs
@@ -4,12 +4,12 @@ use async_trait::async_trait;
 
 use crate::{
     domain::{
-        entity::{author::AuthorId, book::BookId, user::UserId},
+        entity::{author::AuthorId, book::BookId, event_set::EventSetId, user::UserId},
         error::DomainError,
         repository::{
             author_event_repository::AuthorEventRepository, author_repository::AuthorRepository,
             book_event_repository::BookEventRepository, book_repository::BookRepository,
-            user_repository::UserRepository,
+            event_set_repository::EventSetRepository, user_repository::UserRepository,
         },
     },
     use_case::{
@@ -17,6 +17,7 @@ use crate::{
             author::AuthorDto,
             book::BookDto,
             event::{AuthorEventDto, BookEventDto},
+            event_set::{EventSetDetailDto, EventSetDto},
             user::UserDto,
         },
         error::UseCaseError,
@@ -25,22 +26,24 @@ use crate::{
 };
 
 #[derive(Debug, Clone)]
-pub struct QueryInteractor<UR, BR, AR, BER, AER> {
+pub struct QueryInteractor<UR, BR, AR, BER, AER, ESR> {
     pub user_repository: UR,
     pub book_repository: BR,
     pub author_repository: AR,
     pub book_event_repository: BER,
     pub author_event_repository: AER,
+    pub event_set_repository: ESR,
 }
 
 #[async_trait]
-impl<UR, BR, AR, BER, AER> QueryUseCase for QueryInteractor<UR, BR, AR, BER, AER>
+impl<UR, BR, AR, BER, AER, ESR> QueryUseCase for QueryInteractor<UR, BR, AR, BER, AER, ESR>
 where
     UR: UserRepository,
     BR: BookRepository,
     AR: AuthorRepository,
     BER: BookEventRepository,
     AER: AuthorEventRepository,
+    ESR: EventSetRepository,
 {
     async fn find_user_by_id(&self, raw_user_id: &str) -> Result<Option<UserDto>, UseCaseError> {
         let user_id = UserId::new(raw_user_id.to_string())?;
@@ -141,6 +144,48 @@ where
             .await?;
         Ok(entries.into_iter().map(AuthorEventDto::from).collect())
     }
+
+    async fn list_event_sets(&self, user_id: &str) -> Result<Vec<EventSetDto>, UseCaseError> {
+        let user_id = UserId::new(user_id.to_string())?;
+        let sets = self.event_set_repository.find_all(&user_id).await?;
+        Ok(sets.into_iter().map(EventSetDto::from).collect())
+    }
+
+    async fn find_event_set(
+        &self,
+        user_id: &str,
+        event_set_id: &str,
+    ) -> Result<Option<EventSetDetailDto>, UseCaseError> {
+        let user_id = UserId::new(user_id.to_string())?;
+        let event_set_id = EventSetId::try_from(event_set_id)
+            .map_err(|e| UseCaseError::from(DomainError::Unexpected(e)))?;
+        let event_set = self
+            .event_set_repository
+            .find_by_id(&user_id, &event_set_id)
+            .await?;
+        let Some(event_set) = event_set else {
+            return Ok(None);
+        };
+        let book_events = self
+            .book_event_repository
+            .find_by_event_set(&user_id, &event_set_id)
+            .await?;
+        let author_events = self
+            .author_event_repository
+            .find_by_event_set(&user_id, &event_set_id)
+            .await?;
+        let book_events: Vec<BookEventDto> =
+            book_events.into_iter().map(BookEventDto::from).collect();
+        let author_events: Vec<AuthorEventDto> = author_events
+            .into_iter()
+            .map(AuthorEventDto::from)
+            .collect();
+        Ok(Some(EventSetDetailDto::new(
+            event_set,
+            book_events,
+            author_events,
+        )))
+    }
 }
 
 #[cfg(test)]
@@ -159,14 +204,15 @@ mod tests {
                 author::{Author, AuthorId, AuthorName},
                 book::{Book, BookId, BookTitle, Isbn, OwnedFlag, Priority, ReadFlag},
                 event::{AuthorEvent, BookEvent, EventOperation},
-                event_set::EventSetId,
+                event_set::{EventSet, EventSetId},
                 user::{User, UserId},
             },
             repository::{
                 author_event_repository::MockAuthorEventRepository,
                 author_repository::MockAuthorRepository,
                 book_event_repository::MockBookEventRepository,
-                book_repository::MockBookRepository, user_repository::MockUserRepository,
+                book_repository::MockBookRepository, event_set_repository::MockEventSetRepository,
+                user_repository::MockUserRepository,
             },
         },
         use_case::{
@@ -222,6 +268,7 @@ mod tests {
             author_repository,
             book_event_repository: MockBookEventRepository::new(),
             author_event_repository: MockAuthorEventRepository::new(),
+            event_set_repository: MockEventSetRepository::new(),
         };
 
         // When
@@ -251,6 +298,7 @@ mod tests {
             author_repository,
             book_event_repository: MockBookEventRepository::new(),
             author_event_repository: MockAuthorEventRepository::new(),
+            event_set_repository: MockEventSetRepository::new(),
         };
 
         // When
@@ -281,6 +329,7 @@ mod tests {
             author_repository,
             book_event_repository: MockBookEventRepository::new(),
             author_event_repository: MockAuthorEventRepository::new(),
+            event_set_repository: MockEventSetRepository::new(),
         };
 
         // When
@@ -313,6 +362,7 @@ mod tests {
             author_repository,
             book_event_repository: MockBookEventRepository::new(),
             author_event_repository: MockAuthorEventRepository::new(),
+            event_set_repository: MockEventSetRepository::new(),
         };
 
         // When
@@ -342,6 +392,7 @@ mod tests {
             author_repository,
             book_event_repository: MockBookEventRepository::new(),
             author_event_repository: MockAuthorEventRepository::new(),
+            event_set_repository: MockEventSetRepository::new(),
         };
 
         // When
@@ -382,6 +433,7 @@ mod tests {
             author_repository,
             book_event_repository: MockBookEventRepository::new(),
             author_event_repository: MockAuthorEventRepository::new(),
+            event_set_repository: MockEventSetRepository::new(),
         };
 
         let actual = query_interactor
@@ -419,6 +471,7 @@ mod tests {
             author_repository,
             book_event_repository: MockBookEventRepository::new(),
             author_event_repository: MockAuthorEventRepository::new(),
+            event_set_repository: MockEventSetRepository::new(),
         };
 
         // When
@@ -447,6 +500,7 @@ mod tests {
             author_repository,
             book_event_repository: MockBookEventRepository::new(),
             author_event_repository: MockAuthorEventRepository::new(),
+            event_set_repository: MockEventSetRepository::new(),
         };
 
         // When
@@ -477,6 +531,7 @@ mod tests {
             author_repository,
             book_event_repository: MockBookEventRepository::new(),
             author_event_repository: MockAuthorEventRepository::new(),
+            event_set_repository: MockEventSetRepository::new(),
         };
 
         // When
@@ -508,6 +563,7 @@ mod tests {
             author_repository,
             book_event_repository: MockBookEventRepository::new(),
             author_event_repository: MockAuthorEventRepository::new(),
+            event_set_repository: MockEventSetRepository::new(),
         };
 
         // When
@@ -540,6 +596,7 @@ mod tests {
             author_repository,
             book_event_repository: MockBookEventRepository::new(),
             author_event_repository: MockAuthorEventRepository::new(),
+            event_set_repository: MockEventSetRepository::new(),
         };
 
         // When
@@ -570,6 +627,7 @@ mod tests {
             author_repository,
             book_event_repository: MockBookEventRepository::new(),
             author_event_repository: MockAuthorEventRepository::new(),
+            event_set_repository: MockEventSetRepository::new(),
         };
 
         // When
@@ -612,6 +670,7 @@ mod tests {
             author_repository,
             book_event_repository: MockBookEventRepository::new(),
             author_event_repository: MockAuthorEventRepository::new(),
+            event_set_repository: MockEventSetRepository::new(),
         };
 
         // When
@@ -667,6 +726,15 @@ mod tests {
         }
     }
 
+    fn make_event_set() -> EventSet {
+        EventSet {
+            id: EventSetId::from(Uuid::new_v4()),
+            user_id: UserId::new("user1".to_string()).unwrap(),
+            operation: "create_book".to_string(),
+            created_at: OffsetDateTime::now_utc(),
+        }
+    }
+
     #[tokio::test]
     async fn list_book_events_returns_dto_list() {
         let book_uuid = Uuid::new_v4();
@@ -685,6 +753,7 @@ mod tests {
             author_repository: MockAuthorRepository::new(),
             book_event_repository,
             author_event_repository: MockAuthorEventRepository::new(),
+            event_set_repository: MockEventSetRepository::new(),
         };
 
         let result = query_interactor
@@ -714,6 +783,7 @@ mod tests {
             author_repository: MockAuthorRepository::new(),
             book_event_repository,
             author_event_repository: MockAuthorEventRepository::new(),
+            event_set_repository: MockEventSetRepository::new(),
         };
 
         let result = query_interactor
@@ -732,6 +802,7 @@ mod tests {
             author_repository: MockAuthorRepository::new(),
             book_event_repository: MockBookEventRepository::new(),
             author_event_repository: MockAuthorEventRepository::new(),
+            event_set_repository: MockEventSetRepository::new(),
         };
 
         let result = query_interactor
@@ -759,6 +830,7 @@ mod tests {
             author_repository: MockAuthorRepository::new(),
             book_event_repository: MockBookEventRepository::new(),
             author_event_repository,
+            event_set_repository: MockEventSetRepository::new(),
         };
 
         let result = query_interactor
@@ -788,6 +860,7 @@ mod tests {
             author_repository: MockAuthorRepository::new(),
             book_event_repository: MockBookEventRepository::new(),
             author_event_repository,
+            event_set_repository: MockEventSetRepository::new(),
         };
 
         let result = query_interactor
@@ -806,11 +879,150 @@ mod tests {
             author_repository: MockAuthorRepository::new(),
             book_event_repository: MockBookEventRepository::new(),
             author_event_repository: MockAuthorEventRepository::new(),
+            event_set_repository: MockEventSetRepository::new(),
         };
 
         let result = query_interactor
             .list_author_events("user1", "not-a-uuid")
             .await;
+
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn list_event_sets_returns_dto_list() {
+        let mut event_set_repository = MockEventSetRepository::new();
+        event_set_repository
+            .expect_find_all()
+            .with(always())
+            .returning(|_| Ok(vec![make_event_set()]));
+
+        let query_interactor = QueryInteractor {
+            user_repository: MockUserRepository::new(),
+            book_repository: MockBookRepository::new(),
+            author_repository: MockAuthorRepository::new(),
+            book_event_repository: MockBookEventRepository::new(),
+            author_event_repository: MockAuthorEventRepository::new(),
+            event_set_repository,
+        };
+
+        let result = query_interactor.list_event_sets("user1").await;
+
+        assert!(result.is_ok());
+        let list = result.unwrap();
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0].operation, "create_book");
+    }
+
+    #[tokio::test]
+    async fn list_event_sets_returns_empty() {
+        let mut event_set_repository = MockEventSetRepository::new();
+        event_set_repository
+            .expect_find_all()
+            .with(always())
+            .returning(|_| Ok(vec![]));
+
+        let query_interactor = QueryInteractor {
+            user_repository: MockUserRepository::new(),
+            book_repository: MockBookRepository::new(),
+            author_repository: MockAuthorRepository::new(),
+            book_event_repository: MockBookEventRepository::new(),
+            author_event_repository: MockAuthorEventRepository::new(),
+            event_set_repository,
+        };
+
+        let result = query_interactor.list_event_sets("user1").await;
+
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn find_event_set_returns_detail_when_found() {
+        let event_set = make_event_set();
+        let book_uuid = Uuid::new_v4();
+        let author_uuid = Uuid::new_v4();
+        let book_event = make_book_event(book_uuid);
+        let author_event = make_author_event(author_uuid);
+
+        let mut event_set_repository = MockEventSetRepository::new();
+        event_set_repository
+            .expect_find_by_id()
+            .with(always(), always())
+            .returning(|_, _| Ok(Some(make_event_set())));
+
+        let mut book_event_repository = MockBookEventRepository::new();
+        book_event_repository
+            .expect_find_by_event_set()
+            .with(always(), always())
+            .returning(move |_, _| Ok(vec![book_event.clone()]));
+
+        let mut author_event_repository = MockAuthorEventRepository::new();
+        author_event_repository
+            .expect_find_by_event_set()
+            .with(always(), always())
+            .returning(move |_, _| Ok(vec![author_event.clone()]));
+
+        let query_interactor = QueryInteractor {
+            user_repository: MockUserRepository::new(),
+            book_repository: MockBookRepository::new(),
+            author_repository: MockAuthorRepository::new(),
+            book_event_repository,
+            author_event_repository,
+            event_set_repository,
+        };
+
+        let result = query_interactor
+            .find_event_set("user1", &event_set.id.to_string())
+            .await;
+
+        assert!(result.is_ok());
+        let detail = result.unwrap();
+        assert!(detail.is_some());
+        let detail = detail.unwrap();
+        assert_eq!(detail.operation, "create_book");
+        assert_eq!(detail.book_events.len(), 1);
+        assert_eq!(detail.author_events.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn find_event_set_returns_none_when_not_found() {
+        let mut event_set_repository = MockEventSetRepository::new();
+        event_set_repository
+            .expect_find_by_id()
+            .with(always(), always())
+            .returning(|_, _| Ok(None));
+
+        let query_interactor = QueryInteractor {
+            user_repository: MockUserRepository::new(),
+            book_repository: MockBookRepository::new(),
+            author_repository: MockAuthorRepository::new(),
+            book_event_repository: MockBookEventRepository::new(),
+            author_event_repository: MockAuthorEventRepository::new(),
+            event_set_repository,
+        };
+
+        let event_set_id = Uuid::new_v4().hyphenated().to_string();
+        let result = query_interactor
+            .find_event_set("user1", &event_set_id)
+            .await;
+
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn find_event_set_invalid_id_returns_error() {
+        let query_interactor = QueryInteractor {
+            user_repository: MockUserRepository::new(),
+            book_repository: MockBookRepository::new(),
+            author_repository: MockAuthorRepository::new(),
+            book_event_repository: MockBookEventRepository::new(),
+            author_event_repository: MockAuthorEventRepository::new(),
+            event_set_repository: MockEventSetRepository::new(),
+        };
+
+        let result = query_interactor.find_event_set("user1", "not-a-uuid").await;
 
         assert!(result.is_err());
     }

--- a/src/use_case/interactor/query.rs
+++ b/src/use_case/interactor/query.rs
@@ -192,7 +192,7 @@ where
 mod tests {
     use std::collections::HashMap;
 
-    use mockall::predicate::always;
+    use mockall::predicate::{always, eq};
     use time::OffsetDateTime;
     use uuid::Uuid;
 
@@ -940,27 +940,29 @@ mod tests {
     #[tokio::test]
     async fn find_event_set_returns_detail_when_found() {
         let event_set = make_event_set();
+        let event_set_id = event_set.id.clone();
         let book_uuid = Uuid::new_v4();
         let author_uuid = Uuid::new_v4();
         let book_event = make_book_event(book_uuid);
         let author_event = make_author_event(author_uuid);
 
+        // Each repository must receive the parsed event_set_id, not just any id.
         let mut event_set_repository = MockEventSetRepository::new();
         event_set_repository
             .expect_find_by_id()
-            .with(always(), always())
+            .with(always(), eq(event_set_id.clone()))
             .returning(|_, _| Ok(Some(make_event_set())));
 
         let mut book_event_repository = MockBookEventRepository::new();
         book_event_repository
             .expect_find_by_event_set()
-            .with(always(), always())
+            .with(always(), eq(event_set_id.clone()))
             .returning(move |_, _| Ok(vec![book_event.clone()]));
 
         let mut author_event_repository = MockAuthorEventRepository::new();
         author_event_repository
             .expect_find_by_event_set()
-            .with(always(), always())
+            .with(always(), eq(event_set_id.clone()))
             .returning(move |_, _| Ok(vec![author_event.clone()]));
 
         let query_interactor = QueryInteractor {

--- a/src/use_case/traits/query.rs
+++ b/src/use_case/traits/query.rs
@@ -8,6 +8,7 @@ use crate::use_case::{
         author::AuthorDto,
         book::BookDto,
         event::{AuthorEventDto, BookEventDto},
+        event_set::{EventSetDetailDto, EventSetDto},
         user::UserDto,
     },
     error::UseCaseError,
@@ -44,4 +45,10 @@ pub trait QueryUseCase: Send + Sync + 'static {
         user_id: &str,
         author_id: &str,
     ) -> Result<Vec<AuthorEventDto>, UseCaseError>;
+    async fn list_event_sets(&self, user_id: &str) -> Result<Vec<EventSetDto>, UseCaseError>;
+    async fn find_event_set(
+        &self,
+        user_id: &str,
+        event_set_id: &str,
+    ) -> Result<Option<EventSetDetailDto>, UseCaseError>;
 }


### PR DESCRIPTION
## 概要

`event_set` は `PgTransactionManager::begin` で書き込まれるものの、GraphQL から読む手段が一切ありませんでした。本PRで `event_set` の読み取り経路を追加し、変更履歴を「1トランザクション（イベントセット）単位」で取得・閲覧できるようにします。既存の `bookEvents`/`authorEvents` のパターンを踏襲しています。

## ⚠️ ベースブランチについて

このPRのベースは **`main` ではなく `claude/clever-sagan-ebq3jh`**（ImportBooksRepository 削除 / TransactionManager 導入のブランチ, `a8bdc47`）です。本PRはその上に積まれた **stacked PR** です。

- 本PRの差分は **event_set クエリ追加の5コミットのみ**（`a8bdc47..1bcf6d0`）で、ベースブランチ側の変更（ImportBooksRepository 削除等）は含みません。
- マージ順序: 先にベースの `claude/clever-sagan-ebq3jh` をマージしてください。その後、本PRのベースは自動的に `main` へ付け替わります（または手動で付け替え）。
- レビュー時はベースブランチとの差分のみを確認すれば十分です。

## 追加する GraphQL Query

- `eventSets`: ログインユーザーの event set 一覧（新しい順）— `{ id, operation, createdAt }`
- `eventSet(id: ID!)`: 単一の event set を、含まれる `bookEvents` / `authorEvents` をネストして返す（未所有・存在しなければ `null`）

## 変更内容（レイヤー別）

- **Domain**: `EventSetRepository` トレイト（`find_all` / `find_by_id`）、`BookEventRepository` / `AuthorEventRepository` に `find_by_event_set` を追加
- **Infrastructure**: `PgEventSetRepository`、両イベントリポジトリの `find_by_event_set` 実装（いずれも `user_id` でスコープ）
- **Use-case**: `EventSetDto` / `EventSetDetailDto`、`QueryUseCase` に `list_event_sets` / `find_event_set` を追加。`QueryInteractor` に `ESR: EventSetRepository` ジェネリクスを追加し、`find_by_id` + 各 `find_by_event_set` を合成してネスト詳細を組み立て
- **Presentation**: `EventSetEntry` / `EventSetDetail` オブジェクトと `eventSets` / `eventSet` リゾルバ、`schema.graphql` 再生成
- **DI**: `PgEventSetRepository` を配線

いずれも純粋な読み取り操作で、イベント記録・トランザクション・マイグレーション・新しい `EventSetOperation` の追加はありません。

## テスト

- **Unit**: interactor のモックテスト（event_set_id が各リポジトリへ正しく伝播することをアサート）、各リポジトリの `#[sqlx::test]`（新しい順・所有者スコープ・他ユーザー分離を含む）
- **E2E**: 新規 `e2e_event_sets`（一覧・新しい順・詳細ネスト・未知ID→null・ユーザー分離）、および `e2e_import_books` に「2件の book create と新規 author create が同一の `import_books` イベントセットに集約される」グルーピング検証を追加

## 検証

- `cargo fmt --check` ✅
- `cargo clippy --all-targets --all-features -- -D warnings` ✅
- `cargo test --lib`（DB 込み）**192 件 pass** ✅
- `cargo run --bin gen_schema` の出力が `schema.graphql` と一致（CI 整合）✅
- e2e クレートのコンパイル ✅（E2E 実行はサーバー起動が必要なため CI の e2e ワークフローで実施）

## 補足

- `cargo clippy --all-targets`（CI 相当）が既存テストコードの `cloned_ref_to_slice_refs` を検出したため、`&[x.clone()]` → `std::slice::from_ref(&x)` を専用コミットで修正しています。
- 設計と経緯は ExecPlan `.agent/plans/20260613-add-event-set-queries.md` に記録済みです。

https://claude.ai/code/session_012ZmXYvAxBNcM6AygJqpBtb