### PR TITLE
Refactor EventSet operation field to use typed enum

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -24,6 +24,7 @@ Lookup table for valid `event_set.operation` values.
 | `update_author` | An author was updated                            |
 | `delete_author` | An author was deleted                            |
 | `restore_author`| An author restore was performed                  |
+| `import_books`  | A bulk import of books was performed             |
 | `snapshot_all`  | A point-in-time snapshot of all entities (system)|
 
 ### `event_set`

--- a/src/domain/entity/event.rs
+++ b/src/domain/entity/event.rs
@@ -30,6 +30,7 @@ pub enum EventSetOperation {
     DeleteAuthor,
     RestoreAuthor,
     ImportBooks,
+    SnapshotAll,
 }
 
 impl EventSetOperation {
@@ -44,6 +45,7 @@ impl EventSetOperation {
             EventSetOperation::DeleteAuthor => "delete_author",
             EventSetOperation::RestoreAuthor => "restore_author",
             EventSetOperation::ImportBooks => "import_books",
+            EventSetOperation::SnapshotAll => "snapshot_all",
         }
     }
 }
@@ -62,6 +64,7 @@ impl TryFrom<&str> for EventSetOperation {
             "delete_author" => Ok(EventSetOperation::DeleteAuthor),
             "restore_author" => Ok(EventSetOperation::RestoreAuthor),
             "import_books" => Ok(EventSetOperation::ImportBooks),
+            "snapshot_all" => Ok(EventSetOperation::SnapshotAll),
             _ => Err(format!("Unknown event set operation: {}", value)),
         }
     }
@@ -130,6 +133,7 @@ mod tests {
         assert_eq!(EventSetOperation::DeleteAuthor.as_str(), "delete_author");
         assert_eq!(EventSetOperation::RestoreAuthor.as_str(), "restore_author");
         assert_eq!(EventSetOperation::ImportBooks.as_str(), "import_books");
+        assert_eq!(EventSetOperation::SnapshotAll.as_str(), "snapshot_all");
     }
 
     #[test]
@@ -144,6 +148,7 @@ mod tests {
             EventSetOperation::DeleteAuthor,
             EventSetOperation::RestoreAuthor,
             EventSetOperation::ImportBooks,
+            EventSetOperation::SnapshotAll,
         ];
         for variant in &variants {
             let s = variant.as_str();

--- a/src/domain/entity/event_set.rs
+++ b/src/domain/entity/event_set.rs
@@ -1,7 +1,7 @@
 use time::OffsetDateTime;
 use uuid::Uuid;
 
-use crate::domain::entity::user::UserId;
+use crate::domain::entity::{event::EventSetOperation, user::UserId};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EventSetId(Uuid);
@@ -47,6 +47,6 @@ impl From<Uuid> for EventSetId {
 pub struct EventSet {
     pub id: EventSetId,
     pub user_id: UserId,
-    pub operation: String,
+    pub operation: EventSetOperation,
     pub created_at: OffsetDateTime,
 }

--- a/src/infrastructure/event_set_repository.rs
+++ b/src/infrastructure/event_set_repository.rs
@@ -5,6 +5,7 @@ use uuid::Uuid;
 
 use crate::domain::{
     entity::{
+        event::EventSetOperation,
         event_set::{EventSet, EventSetId},
         user::UserId,
     },
@@ -24,7 +25,8 @@ fn row_to_event_set(row: EventSetRow) -> Result<EventSet, DomainError> {
     Ok(EventSet {
         id: EventSetId::from(row.id),
         user_id: UserId::new(row.user_id)?,
-        operation: row.operation,
+        operation: EventSetOperation::try_from(row.operation.as_str())
+            .map_err(DomainError::Unexpected)?,
         created_at: row.created_at,
     })
 }
@@ -185,8 +187,8 @@ mod tests {
         let event_sets = event_set_repo.find_all(&user_id).await?;
         assert_eq!(event_sets.len(), 2);
         // Newest first: the book creation event set precedes the author one.
-        assert_eq!(event_sets[0].operation, "create_book");
-        assert_eq!(event_sets[1].operation, "create_author");
+        assert_eq!(event_sets[0].operation, EventSetOperation::CreateBook);
+        assert_eq!(event_sets[1].operation, EventSetOperation::CreateAuthor);
         assert!(event_sets[0].created_at >= event_sets[1].created_at);
 
         Ok(())
@@ -231,7 +233,7 @@ mod tests {
         assert!(event_set.is_some());
         let event_set = event_set.unwrap();
         assert_eq!(event_set.id, event_set_id);
-        assert_eq!(event_set.operation, "create_author");
+        assert_eq!(event_set.operation, EventSetOperation::CreateAuthor);
 
         Ok(())
     }

--- a/src/use_case/dto/event_set.rs
+++ b/src/use_case/dto/event_set.rs
@@ -16,7 +16,7 @@ impl From<EventSet> for EventSetDto {
     fn from(e: EventSet) -> Self {
         Self {
             id: e.id.to_string(),
-            operation: e.operation,
+            operation: e.operation.as_str().to_string(),
             created_at: e.created_at,
         }
     }
@@ -39,7 +39,7 @@ impl EventSetDetailDto {
     ) -> Self {
         Self {
             id: event_set.id.to_string(),
-            operation: event_set.operation,
+            operation: event_set.operation.as_str().to_string(),
             created_at: event_set.created_at,
             book_events,
             author_events,

--- a/src/use_case/interactor/query.rs
+++ b/src/use_case/interactor/query.rs
@@ -203,7 +203,7 @@ mod tests {
             entity::{
                 author::{Author, AuthorId, AuthorName},
                 book::{Book, BookId, BookTitle, Isbn, OwnedFlag, Priority, ReadFlag},
-                event::{AuthorEvent, BookEvent, EventOperation},
+                event::{AuthorEvent, BookEvent, EventOperation, EventSetOperation},
                 event_set::{EventSet, EventSetId},
                 user::{User, UserId},
             },
@@ -730,7 +730,7 @@ mod tests {
         EventSet {
             id: EventSetId::from(Uuid::new_v4()),
             user_id: UserId::new("user1".to_string()).unwrap(),
-            operation: "create_book".to_string(),
+            operation: EventSetOperation::CreateBook,
             created_at: OffsetDateTime::now_utc(),
         }
     }


### PR DESCRIPTION
## Summary
Replace the untyped `String` representation of event set operations with a strongly-typed `EventSetOperation` enum throughout the codebase. This improves type safety and makes operation values compile-time verifiable.

## Key Changes
- **Domain model**: Changed `EventSet.operation` field from `String` to `EventSetOperation` enum
- **Event enum**: Added `SnapshotAll` variant to `EventSetOperation` and implemented `as_str()` and `TryFrom<&str>` conversions
- **Repository layer**: Updated `row_to_event_set()` to parse string values from the database into `EventSetOperation` enum variants using `TryFrom`, with proper error handling
- **DTO layer**: Updated `EventSetDto` and `EventSetDetailDto` to convert enum back to string representation for serialization
- **Tests**: Updated all test assertions to use enum variants instead of string literals
- **Documentation**: Added `import_books` operation to the database schema documentation

## Implementation Details
- The `EventSetOperation` enum now serves as the single source of truth for valid operation types
- Database values are parsed at the repository boundary, ensuring invalid operations are caught early
- DTOs convert the enum back to strings for API responses, maintaining backward compatibility
- All existing operations (`CreateBook`, `CreateAuthor`, `UpdateAuthor`, `DeleteAuthor`, `RestoreAuthor`, `ImportBooks`) are preserved, with `SnapshotAll` added as a new variant

https://claude.ai/code/session_01SjCDhdHzX6DRMqvjgT2fnU