### PR TITLE
Remove sqlx-cli installation and database migration steps

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -115,16 +115,6 @@ jobs:
       - name: Create DB
         run: sudo -u postgres createdb --owner=bookshelf bookshelf
 
-      - name: Install sqlx-cli
-        run: cargo install sqlx-cli --locked --no-default-features --features postgres,rustls
-
-      - name: Run migrations
-        env:
-          DATABASE_URL: postgres://bookshelf:password@localhost:5432/bookshelf
-        run: |
-          sqlx database create
-          sqlx migrate run
-
       - name: Start JWKS server
         run: |
           node bookshelf-src/e2e-integration/jwks-server.mjs > /tmp/jwks.log 2>&1 &

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -32,14 +32,6 @@ jobs:
         run: sudo -u postgres psql --command="CREATE USER bookshelf WITH SUPERUSER PASSWORD 'password'" --command="\du" postgres
       - name: Create DB
         run: sudo -u postgres createdb --owner=bookshelf bookshelf
-      - name: Install sqlx-cli
-        run: cargo install sqlx-cli --locked --no-default-features --features postgres,rustls
-      - name: Prepare database
-        env:
-          DATABASE_URL: ${{ env.DATABASE_URL }}
-        run: |
-          sqlx database create
-          sqlx migrate run
       - name: Start JWKS server
         run: |
           cargo run --locked -p bookshelf-e2e --bin bookshelf-jwks-server > jwks_server.log 2>&1 &
@@ -127,12 +119,6 @@ jobs:
         run: sudo -u postgres psql --command="CREATE USER bookshelf WITH SUPERUSER PASSWORD 'password'" --command="\du" postgres
       - name: Create DB
         run: sudo -u postgres createdb --owner=bookshelf bookshelf
-      - name: Install sqlx-cli
-        run: cargo install sqlx-cli --locked --no-default-features --features postgres,rustls
-      - name: Prepare database
-        run: |
-          sqlx database create
-          sqlx migrate run
       - name: Start JWKS server
         run: |
           node bookshelf-src/e2e-integration/jwks-server.mjs > /tmp/jwks.log 2>&1 &


### PR DESCRIPTION
## Summary
Remove the manual installation of `sqlx-cli` and explicit database migration execution steps from CI/CD workflows. These steps are no longer needed, likely because database migrations are now handled automatically during application startup or through a different mechanism.

## Changes
- Removed `sqlx-cli` installation step from `e2e.yml` (Rust E2E tests job)
- Removed `sqlx database create` and `sqlx migrate run` commands from `e2e.yml` (Rust E2E tests job)
- Removed `sqlx-cli` installation step from `e2e.yml` (Node.js E2E tests job)
- Removed `sqlx database create` and `sqlx migrate run` commands from `e2e.yml` (Node.js E2E tests job)
- Removed `sqlx-cli` installation step from `deploy.yml`
- Removed `sqlx database create` and `sqlx migrate run` commands from `deploy.yml`

## Implementation Details
The database is still created via `createdb` command, but migrations are no longer explicitly run in the workflow. This suggests the application now handles migrations automatically (e.g., on startup or through embedded migration logic).

https://claude.ai/code/session_015cpckW3qnEE8pJDFMsZypD