### PR TITLE
Speed up GitHub Actions: add concurrency, drop redundant check job

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -3,6 +3,10 @@ name: actionlint
 on:
   push:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   actionlint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,19 +10,6 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
-  check:
-    name: Check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-      - uses: ./.github/actions/setup-rust-toolchain
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-      - run: cargo check --all-targets --locked
-        env:
-          RUSTFLAGS: "-D warnings"
-
   test:
     name: Test Suite
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on: [push]
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   check:
     name: Check

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -2,6 +2,10 @@ name: E2E tests
 
 on: [push]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   e2e:
     name: End-to-end tests

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -2,6 +2,10 @@ name: zizmor
 
 on: [push]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   zizmor:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Two low-risk, high-impact CI speedups.

### 1. Add `concurrency` to cancel superseded runs
Added to the push-triggered workflows (`ci.yml`, `e2e.yml`, `actionlint.yml`, `zizmor.yml`):

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
```

- Feature branches: a newer push cancels in-progress runs, cutting wasted runner time and queue latency.
- `main`: `cancel-in-progress` stays disabled, so every commit on `main` is still fully verified.
- Not applied to `release-drafter.yml`, `deploy.yml`, `renovate-config-validation.yml` (should not be interrupted / low frequency).

### 2. Remove the redundant `check` job
`cargo clippy --all-targets -- -D warnings` denies the `warnings` lint group (including rustc warnings) and is a strict superset of `cargo check`. The separate `check` job duplicated a full compilation with no added coverage, so it was dropped. No job depended on it (`needs: check`).

## Verification
- All workflow YAML parses successfully.
- YAML-only change; no Rust sources modified, so `cargo fmt/clippy/test` results are unaffected.
- The repo's `actionlint` workflow validates the YAML in CI.

Expected effect: the `Check` job disappears (clippy covers it), and rapid successive pushes no longer pile up full CI runs.

https://claude.ai/code/session_01YFS8cYu9fSrfuvuhwpFCUN

---
_Generated by [Claude Code](https://claude.ai/code/session_01YFS8cYu9fSrfuvuhwpFCUN)_