### PR TITLE
Add transactional book lookup and use it in UpdateBook interactor

### DIFF
--- a/src/domain/repository/book_repository.rs
+++ b/src/domain/repository/book_repository.rs
@@ -25,7 +25,7 @@ pub trait BookRepository: Send + Sync + 'static {
         user_id: &UserId,
         book_id: &BookId,
     ) -> Result<Option<Book>, DomainError>;
-    async fn find_by_id_in_transaction(
+    async fn find_by_id_with_tx(
         &self,
         tx: &mut Self::Transaction,
         user_id: &UserId,

--- a/src/domain/repository/book_repository.rs
+++ b/src/domain/repository/book_repository.rs
@@ -25,7 +25,7 @@ pub trait BookRepository: Send + Sync + 'static {
         user_id: &UserId,
         book_id: &BookId,
     ) -> Result<Option<Book>, DomainError>;
-    async fn find_by_id_in_tx(
+    async fn find_by_id_in_transaction(
         &self,
         tx: &mut Self::Transaction,
         user_id: &UserId,

--- a/src/domain/repository/book_repository.rs
+++ b/src/domain/repository/book_repository.rs
@@ -25,6 +25,12 @@ pub trait BookRepository: Send + Sync + 'static {
         user_id: &UserId,
         book_id: &BookId,
     ) -> Result<Option<Book>, DomainError>;
+    async fn find_by_id_in_tx(
+        &self,
+        tx: &mut Self::Transaction,
+        user_id: &UserId,
+        book_id: &BookId,
+    ) -> Result<Option<Book>, DomainError>;
     async fn find_all(&self, user_id: &UserId) -> Result<Vec<Book>, DomainError>;
     async fn update(
         &self,

--- a/src/infrastructure/book_repository.rs
+++ b/src/infrastructure/book_repository.rs
@@ -211,7 +211,7 @@ impl BookRepository for PgBookRepository {
         Ok(book)
     }
 
-    async fn find_by_id_in_transaction(
+    async fn find_by_id_with_tx(
         &self,
         tx: &mut Self::Transaction,
         user_id: &UserId,

--- a/src/infrastructure/book_repository.rs
+++ b/src/infrastructure/book_repository.rs
@@ -211,7 +211,7 @@ impl BookRepository for PgBookRepository {
         Ok(book)
     }
 
-    async fn find_by_id_in_tx(
+    async fn find_by_id_in_transaction(
         &self,
         tx: &mut Self::Transaction,
         user_id: &UserId,

--- a/src/infrastructure/book_repository.rs
+++ b/src/infrastructure/book_repository.rs
@@ -211,6 +211,80 @@ impl BookRepository for PgBookRepository {
         Ok(book)
     }
 
+    async fn find_by_id_in_tx(
+        &self,
+        tx: &mut Self::Transaction,
+        user_id: &UserId,
+        book_id: &BookId,
+    ) -> Result<Option<Book>, DomainError> {
+        tx.ensure_user(user_id)?;
+        let book_row: Option<BookRow> = sqlx::query_as(
+            "WITH book_of_user AS(
+                SELECT
+                    *
+                FROM
+                    book
+                WHERE
+                    book.user_id = $1
+            ),
+            authors_of_book_and_user AS(
+                SELECT
+                    book_id,
+                    array_agg(author_id) AS author_ids
+                FROM
+                    book_author
+                WHERE
+                    book_author.user_id = $1
+                GROUP BY
+                    book_author.book_id
+            )
+            SELECT
+                *
+            FROM
+                book_of_user
+                LEFT OUTER JOIN
+                    authors_of_book_and_user
+                ON  book_of_user.id = authors_of_book_and_user.book_id
+            WHERE book_of_user.id = $2",
+        )
+        .bind(user_id.as_str())
+        .bind(book_id.to_uuid())
+        .fetch_optional(tx.as_mut())
+        .await?;
+
+        let book = book_row.map(|row| {
+            let book_id = BookId::new(row.id)?;
+            let title = BookTitle::new(row.title)?;
+            let author_ids: Vec<AuthorId> = row
+                .author_ids
+                .map(|author_ids| author_ids.into_iter().map(AuthorId::new).collect())
+                .unwrap_or_default();
+            let isbn = Isbn::new(row.isbn)?;
+            let read = ReadFlag::new(row.read);
+            let owned = OwnedFlag::new(row.owned);
+            let priority = Priority::new(row.priority)?;
+            let format = BookFormat::try_from(row.format.as_str())?;
+            let store = BookStore::try_from(row.store.as_str())?;
+
+            Book::new(
+                book_id,
+                title,
+                author_ids,
+                isbn,
+                read,
+                owned,
+                priority,
+                format,
+                store,
+                row.created_at,
+                row.updated_at,
+            )
+        });
+        let book = book.transpose()?;
+
+        Ok(book)
+    }
+
     async fn find_all(&self, user_id: &UserId) -> Result<Vec<Book>, DomainError> {
         let books: Result<Vec<Book>, DomainError> = sqlx::query_as(
             "WITH book_of_user AS(

--- a/src/infrastructure/book_repository.rs
+++ b/src/infrastructure/book_repository.rs
@@ -687,15 +687,12 @@ mod tests {
     }
 
     #[sqlx::test]
-    async fn test_find_by_id_with_tx_matches_find_by_id_and_checks_user(
-        pool: PgPool,
-    ) -> anyhow::Result<()> {
+    async fn test_find_by_id_with_tx_matches_find_by_id(pool: PgPool) -> anyhow::Result<()> {
         let user_repository = PgUserRepository::new(pool.clone());
         let author_repository = PgAuthorRepository::new(pool.clone());
         let book_repository = PgBookRepository::new(pool.clone());
 
         let user_id = prepare_user(&user_repository, "user1").await?;
-        let other_user_id = UserId::new(String::from("user2"))?;
         let author_ids = prepare_authors1(&pool, &user_id, &author_repository).await?;
         let book = book_entity1(&author_ids)?;
         create_book(&pool, &book_repository, &user_id, &book).await?;
@@ -710,6 +707,24 @@ mod tests {
         assert_eq!(actual, expected);
         tm.commit(tx).await?;
 
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn test_find_by_id_with_tx_rejects_user_mismatched_transaction(
+        pool: PgPool,
+    ) -> anyhow::Result<()> {
+        let user_repository = PgUserRepository::new(pool.clone());
+        let author_repository = PgAuthorRepository::new(pool.clone());
+        let book_repository = PgBookRepository::new(pool.clone());
+
+        let user_id = prepare_user(&user_repository, "user1").await?;
+        let other_user_id = UserId::new(String::from("user2"))?;
+        let author_ids = prepare_authors1(&pool, &user_id, &author_repository).await?;
+        let book = book_entity1(&author_ids)?;
+        create_book(&pool, &book_repository, &user_id, &book).await?;
+
+        let tm = PgTransactionManager::new(pool.clone());
         let mut tx = tm.begin(&user_id, EventSetOperation::UpdateBook).await?;
         let result = book_repository
             .find_by_id_with_tx(&mut tx, &other_user_id, book.id())

--- a/src/infrastructure/book_repository.rs
+++ b/src/infrastructure/book_repository.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use futures_util::{StreamExt, TryStreamExt};
 use serde_json::json;
-use sqlx::PgPool;
+use sqlx::{Executor, PgPool, Postgres};
 use time::OffsetDateTime;
 use uuid::Uuid;
 
@@ -61,6 +61,51 @@ fn book_from_row(row: BookRow) -> Result<Book, DomainError> {
         row.created_at,
         row.updated_at,
     )
+}
+
+async fn find_book_by_id_with_executor<'e, E>(
+    executor: E,
+    user_id: &UserId,
+    book_id: &BookId,
+) -> Result<Option<Book>, DomainError>
+where
+    E: Executor<'e, Database = Postgres>,
+{
+    let book_row: Option<BookRow> = sqlx::query_as(
+        "WITH book_of_user AS(
+            SELECT
+                *
+            FROM
+                book
+            WHERE
+                book.user_id = $1
+        ),
+        authors_of_book_and_user AS(
+            SELECT
+                book_id,
+                array_agg(author_id) AS author_ids
+            FROM
+                book_author
+            WHERE
+                book_author.user_id = $1
+            GROUP BY
+                book_author.book_id
+        )
+        SELECT
+            *
+        FROM
+            book_of_user
+            LEFT OUTER JOIN
+                authors_of_book_and_user
+            ON  book_of_user.id = authors_of_book_and_user.book_id
+        WHERE book_of_user.id = $2",
+    )
+    .bind(user_id.as_str())
+    .bind(book_id.to_uuid())
+    .fetch_optional(executor)
+    .await?;
+
+    book_row.map(book_from_row).transpose()
 }
 
 #[derive(Debug, Clone)]
@@ -173,41 +218,7 @@ impl BookRepository for PgBookRepository {
         user_id: &UserId,
         book_id: &BookId,
     ) -> Result<Option<Book>, DomainError> {
-        let book_row: Option<BookRow> = sqlx::query_as(
-            "WITH book_of_user AS(
-                SELECT
-                    *
-                FROM
-                    book
-                WHERE
-                    book.user_id = $1
-            ),
-            authors_of_book_and_user AS(
-                SELECT
-                    book_id,
-                    array_agg(author_id) AS author_ids
-                FROM
-                    book_author
-                WHERE
-                    book_author.user_id = $1
-                GROUP BY
-                    book_author.book_id
-            )
-            SELECT
-                *
-            FROM
-                book_of_user
-                LEFT OUTER JOIN
-                    authors_of_book_and_user
-                ON  book_of_user.id = authors_of_book_and_user.book_id
-            WHERE book_of_user.id = $2",
-        )
-        .bind(user_id.as_str())
-        .bind(book_id.to_uuid())
-        .fetch_optional(&self.pool)
-        .await?;
-
-        book_row.map(book_from_row).transpose()
+        find_book_by_id_with_executor(&self.pool, user_id, book_id).await
     }
 
     async fn find_by_id_with_tx(
@@ -217,41 +228,7 @@ impl BookRepository for PgBookRepository {
         book_id: &BookId,
     ) -> Result<Option<Book>, DomainError> {
         tx.ensure_user(user_id)?;
-        let book_row: Option<BookRow> = sqlx::query_as(
-            "WITH book_of_user AS(
-                SELECT
-                    *
-                FROM
-                    book
-                WHERE
-                    book.user_id = $1
-            ),
-            authors_of_book_and_user AS(
-                SELECT
-                    book_id,
-                    array_agg(author_id) AS author_ids
-                FROM
-                    book_author
-                WHERE
-                    book_author.user_id = $1
-                GROUP BY
-                    book_author.book_id
-            )
-            SELECT
-                *
-            FROM
-                book_of_user
-                LEFT OUTER JOIN
-                    authors_of_book_and_user
-                ON  book_of_user.id = authors_of_book_and_user.book_id
-            WHERE book_of_user.id = $2",
-        )
-        .bind(user_id.as_str())
-        .bind(book_id.to_uuid())
-        .fetch_optional(tx.as_mut())
-        .await?;
-
-        book_row.map(book_from_row).transpose()
+        find_book_by_id_with_executor(tx.as_mut(), user_id, book_id).await
     }
 
     async fn find_all(&self, user_id: &UserId) -> Result<Vec<Book>, DomainError> {

--- a/src/infrastructure/book_repository.rs
+++ b/src/infrastructure/book_repository.rs
@@ -34,6 +34,35 @@ struct BookRow {
     updated_at: OffsetDateTime,
 }
 
+fn book_from_row(row: BookRow) -> Result<Book, DomainError> {
+    let book_id = BookId::new(row.id)?;
+    let title = BookTitle::new(row.title)?;
+    let author_ids: Vec<AuthorId> = row
+        .author_ids
+        .map(|author_ids| author_ids.into_iter().map(AuthorId::new).collect())
+        .unwrap_or_default();
+    let isbn = Isbn::new(row.isbn)?;
+    let read = ReadFlag::new(row.read);
+    let owned = OwnedFlag::new(row.owned);
+    let priority = Priority::new(row.priority)?;
+    let format = BookFormat::try_from(row.format.as_str())?;
+    let store = BookStore::try_from(row.store.as_str())?;
+
+    Book::new(
+        book_id,
+        title,
+        author_ids,
+        isbn,
+        read,
+        owned,
+        priority,
+        format,
+        store,
+        row.created_at,
+        row.updated_at,
+    )
+}
+
 #[derive(Debug, Clone)]
 pub struct PgBookRepository {
     pool: PgPool,
@@ -178,37 +207,7 @@ impl BookRepository for PgBookRepository {
         .fetch_optional(&self.pool)
         .await?;
 
-        let book = book_row.map(|row| {
-            let book_id = BookId::new(row.id)?;
-            let title = BookTitle::new(row.title)?;
-            let author_ids: Vec<AuthorId> = row
-                .author_ids
-                .map(|author_ids| author_ids.into_iter().map(AuthorId::new).collect())
-                .unwrap_or_default();
-            let isbn = Isbn::new(row.isbn)?;
-            let read = ReadFlag::new(row.read);
-            let owned = OwnedFlag::new(row.owned);
-            let priority = Priority::new(row.priority)?;
-            let format = BookFormat::try_from(row.format.as_str())?;
-            let store = BookStore::try_from(row.store.as_str())?;
-
-            Book::new(
-                book_id,
-                title,
-                author_ids,
-                isbn,
-                read,
-                owned,
-                priority,
-                format,
-                store,
-                row.created_at,
-                row.updated_at,
-            )
-        });
-        let book = book.transpose()?;
-
-        Ok(book)
+        book_row.map(book_from_row).transpose()
     }
 
     async fn find_by_id_with_tx(
@@ -252,37 +251,7 @@ impl BookRepository for PgBookRepository {
         .fetch_optional(tx.as_mut())
         .await?;
 
-        let book = book_row.map(|row| {
-            let book_id = BookId::new(row.id)?;
-            let title = BookTitle::new(row.title)?;
-            let author_ids: Vec<AuthorId> = row
-                .author_ids
-                .map(|author_ids| author_ids.into_iter().map(AuthorId::new).collect())
-                .unwrap_or_default();
-            let isbn = Isbn::new(row.isbn)?;
-            let read = ReadFlag::new(row.read);
-            let owned = OwnedFlag::new(row.owned);
-            let priority = Priority::new(row.priority)?;
-            let format = BookFormat::try_from(row.format.as_str())?;
-            let store = BookStore::try_from(row.store.as_str())?;
-
-            Book::new(
-                book_id,
-                title,
-                author_ids,
-                isbn,
-                read,
-                owned,
-                priority,
-                format,
-                store,
-                row.created_at,
-                row.updated_at,
-            )
-        });
-        let book = book.transpose()?;
-
-        Ok(book)
+        book_row.map(book_from_row).transpose()
     }
 
     async fn find_all(&self, user_id: &UserId) -> Result<Vec<Book>, DomainError> {
@@ -318,33 +287,7 @@ impl BookRepository for PgBookRepository {
         .fetch(&self.pool)
         .map(
             |row: Result<BookRow, sqlx::Error>| -> Result<Book, DomainError> {
-                let row = row?;
-                let book_id = BookId::new(row.id)?;
-                let title = BookTitle::new(row.title)?;
-                let author_ids: Vec<AuthorId> = row
-                    .author_ids
-                    .map(|author_ids| author_ids.into_iter().map(AuthorId::new).collect())
-                    .unwrap_or_else(std::vec::Vec::new);
-                let isbn = Isbn::new(row.isbn)?;
-                let read = ReadFlag::new(row.read);
-                let owned = OwnedFlag::new(row.owned);
-                let priority = Priority::new(row.priority)?;
-                let format = BookFormat::try_from(row.format.as_str())?;
-                let store = BookStore::try_from(row.store.as_str())?;
-
-                Book::new(
-                    book_id,
-                    title,
-                    author_ids,
-                    isbn,
-                    read,
-                    owned,
-                    priority,
-                    format,
-                    store,
-                    row.created_at,
-                    row.updated_at,
-                )
+                book_from_row(row?)
             },
         )
         .try_collect()
@@ -762,6 +705,40 @@ mod tests {
 
         let actual = book_repository.find_by_id(&user_id, book.id()).await?;
         assert_eq!(actual, Some(book));
+
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn test_find_by_id_with_tx_matches_find_by_id_and_checks_user(
+        pool: PgPool,
+    ) -> anyhow::Result<()> {
+        let user_repository = PgUserRepository::new(pool.clone());
+        let author_repository = PgAuthorRepository::new(pool.clone());
+        let book_repository = PgBookRepository::new(pool.clone());
+
+        let user_id = prepare_user(&user_repository, "user1").await?;
+        let other_user_id = UserId::new(String::from("user2"))?;
+        let author_ids = prepare_authors1(&pool, &user_id, &author_repository).await?;
+        let book = book_entity1(&author_ids)?;
+        create_book(&pool, &book_repository, &user_id, &book).await?;
+
+        let expected = book_repository.find_by_id(&user_id, book.id()).await?;
+
+        let tm = PgTransactionManager::new(pool.clone());
+        let mut tx = tm.begin(&user_id, EventSetOperation::UpdateBook).await?;
+        let actual = book_repository
+            .find_by_id_with_tx(&mut tx, &user_id, book.id())
+            .await?;
+        assert_eq!(actual, expected);
+        tm.commit(tx).await?;
+
+        let mut tx = tm.begin(&user_id, EventSetOperation::UpdateBook).await?;
+        let result = book_repository
+            .find_by_id_with_tx(&mut tx, &other_user_id, book.id())
+            .await;
+        assert!(matches!(result, Err(DomainError::Unexpected(_))));
+        drop(tx);
 
         Ok(())
     }

--- a/src/use_case/interactor/book.rs
+++ b/src/use_case/interactor/book.rs
@@ -116,7 +116,15 @@ where
     ) -> Result<BookDto, UseCaseError> {
         let user_id = UserId::new(user_id.to_string())?;
         let book_id = BookId::try_from(book_data.id.as_str())?;
-        let book = self.book_repository.find_by_id(&user_id, &book_id).await?;
+
+        let mut tx = self
+            .transaction_manager
+            .begin(&user_id, EventSetOperation::UpdateBook)
+            .await?;
+        let book = self
+            .book_repository
+            .find_by_id_in_tx(&mut tx, &user_id, &book_id)
+            .await?;
         let mut book = match book {
             Some(book) => book,
             None => {
@@ -152,10 +160,6 @@ where
         book.set_store(store);
         book.set_updated_at(OffsetDateTime::now_utc());
 
-        let mut tx = self
-            .transaction_manager
-            .begin(&user_id, EventSetOperation::UpdateBook)
-            .await?;
         self.book_repository
             .update(&mut tx, &user_id, &book)
             .await?;
@@ -384,6 +388,13 @@ mod tests {
         tm
     }
 
+    fn make_begin_only_transaction_manager() -> MockTransactionManager {
+        let mut tm = MockTransactionManager::new();
+        tm.expect_begin().returning(|_, _| Ok(()));
+        tm.expect_commit().times(0);
+        tm
+    }
+
     fn make_book(uuid: Uuid) -> Book {
         Book::new(
             BookId::new(uuid).unwrap(),
@@ -464,9 +475,9 @@ mod tests {
 
         let mut book_repository = MockBookRepository::new();
         book_repository
-            .expect_find_by_id()
-            .with(always(), always())
-            .returning(move |_, _| Ok(Some(book.clone())));
+            .expect_find_by_id_in_tx()
+            .with(always(), always(), always())
+            .returning(move |_, _, _| Ok(Some(book.clone())));
         book_repository
             .expect_update()
             .with(always(), always(), always())
@@ -503,11 +514,12 @@ mod tests {
 
         let mut book_repository = MockBookRepository::new();
         book_repository
-            .expect_find_by_id()
-            .with(always(), always())
-            .returning(|_, _| Ok(None));
+            .expect_find_by_id_in_tx()
+            .with(always(), always(), always())
+            .returning(|_, _, _| Ok(None));
 
-        let interactor = UpdateBookInteractor::new(book_repository, MockTransactionManager::new());
+        let interactor =
+            UpdateBookInteractor::new(book_repository, make_begin_only_transaction_manager());
         let book_data = UpdateBookDto::new(
             book_id_str,
             "Updated Book".to_string(),

--- a/src/use_case/interactor/book.rs
+++ b/src/use_case/interactor/book.rs
@@ -115,7 +115,29 @@ where
         book_data: UpdateBookDto,
     ) -> Result<BookDto, UseCaseError> {
         let user_id = UserId::new(user_id.to_string())?;
-        let book_id = BookId::try_from(book_data.id.as_str())?;
+        let UpdateBookDto {
+            id,
+            title,
+            author_ids,
+            isbn,
+            read,
+            owned,
+            priority,
+            format,
+            store,
+        } = book_data;
+
+        let book_id = BookId::try_from(id.as_str())?;
+        let title = BookTitle::new(title)?;
+        let author_ids: Result<Vec<AuthorId>, DomainError> = author_ids
+            .into_iter()
+            .map(|author_id| AuthorId::try_from(author_id.as_str()))
+            .collect();
+        let author_ids = author_ids?;
+        let isbn = Isbn::new(isbn)?;
+        let read = ReadFlag::new(read);
+        let owned = OwnedFlag::new(owned);
+        let priority = Priority::new(priority)?;
 
         let mut tx = self
             .transaction_manager
@@ -130,25 +152,11 @@ where
             None => {
                 return Err(UseCaseError::NotFound {
                     entity_type: "book",
-                    entity_id: book_data.id,
+                    entity_id: id,
                     user_id: user_id.into_string(),
                 });
             }
         };
-
-        let title = BookTitle::new(book_data.title)?;
-        let author_ids: Result<Vec<AuthorId>, DomainError> = book_data
-            .author_ids
-            .into_iter()
-            .map(|author_id| AuthorId::try_from(author_id.as_str()))
-            .collect();
-        let author_ids = author_ids?;
-        let isbn = Isbn::new(book_data.isbn)?;
-        let read = ReadFlag::new(book_data.read);
-        let owned = OwnedFlag::new(book_data.owned);
-        let priority = Priority::new(book_data.priority)?;
-        let format = book_data.format;
-        let store = book_data.store;
 
         book.set_title(title);
         book.set_author_ids(author_ids);
@@ -504,6 +512,33 @@ mod tests {
         let dto = result.unwrap();
         assert_eq!(dto.title, "Updated Book");
         assert_eq!(dto.priority, 70);
+    }
+
+    #[tokio::test]
+    async fn update_book_fails_with_empty_title_before_transaction() {
+        // Given
+        let book_uuid = Uuid::new_v4();
+        let book_id_str = book_uuid.hyphenated().to_string();
+        let book_repository = MockBookRepository::new();
+
+        let interactor = UpdateBookInteractor::new(book_repository, MockTransactionManager::new());
+        let book_data = UpdateBookDto::new(
+            book_id_str,
+            "".to_string(),
+            vec![],
+            "".to_string(),
+            false,
+            false,
+            0,
+            BookFormat::Unknown,
+            BookStore::Unknown,
+        );
+
+        // When
+        let result = interactor.update("user1", book_data).await;
+
+        // Then
+        assert!(matches!(result, Err(UseCaseError::Validation(_))));
     }
 
     #[tokio::test]

--- a/src/use_case/interactor/book.rs
+++ b/src/use_case/interactor/book.rs
@@ -123,7 +123,7 @@ where
             .await?;
         let book = self
             .book_repository
-            .find_by_id_in_tx(&mut tx, &user_id, &book_id)
+            .find_by_id_in_transaction(&mut tx, &user_id, &book_id)
             .await?;
         let mut book = match book {
             Some(book) => book,
@@ -475,7 +475,7 @@ mod tests {
 
         let mut book_repository = MockBookRepository::new();
         book_repository
-            .expect_find_by_id_in_tx()
+            .expect_find_by_id_in_transaction()
             .with(always(), always(), always())
             .returning(move |_, _, _| Ok(Some(book.clone())));
         book_repository
@@ -514,7 +514,7 @@ mod tests {
 
         let mut book_repository = MockBookRepository::new();
         book_repository
-            .expect_find_by_id_in_tx()
+            .expect_find_by_id_in_transaction()
             .with(always(), always(), always())
             .returning(|_, _, _| Ok(None));
 

--- a/src/use_case/interactor/book.rs
+++ b/src/use_case/interactor/book.rs
@@ -123,7 +123,7 @@ where
             .await?;
         let book = self
             .book_repository
-            .find_by_id_in_transaction(&mut tx, &user_id, &book_id)
+            .find_by_id_with_tx(&mut tx, &user_id, &book_id)
             .await?;
         let mut book = match book {
             Some(book) => book,
@@ -475,7 +475,7 @@ mod tests {
 
         let mut book_repository = MockBookRepository::new();
         book_repository
-            .expect_find_by_id_in_transaction()
+            .expect_find_by_id_with_tx()
             .with(always(), always(), always())
             .returning(move |_, _, _| Ok(Some(book.clone())));
         book_repository
@@ -514,7 +514,7 @@ mod tests {
 
         let mut book_repository = MockBookRepository::new();
         book_repository
-            .expect_find_by_id_in_transaction()
+            .expect_find_by_id_with_tx()
             .with(always(), always(), always())
             .returning(|_, _, _| Ok(None));
 


### PR DESCRIPTION
### Motivation

- Ensure book lookups performed as part of an active database transaction so user checks and subsequent updates occur within the same transaction.

### Description

- Add `find_by_id_in_tx` to the `BookRepository` trait to support querying a book within an existing transaction.
- Implement `find_by_id_in_tx` in `PgBookRepository`, using `tx.ensure_user`, a CTE query, and `fetch_optional(tx.as_mut())` to return an `Option<Book>`.
- Modify `UpdateBookInteractor::update` to begin a transaction with `transaction_manager.begin(...)` before fetching the book and to call `find_by_id_in_tx` using the started transaction.
- Update unit tests to expect `find_by_id_in_tx` calls, and add `make_begin_only_transaction_manager` helper to mock a transaction manager that begins but does not commit for the not-found test case.

### Testing

- Ran the updated unit tests for the book interactors (including `update_book_success` and `update_book_returns_not_found_error_when_book_missing`) which exercise the new transactional lookup and mocks, and they passed.
- Ran the full test suite via `cargo test` after changes and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f32bab33c8321bf088ce81221ad77)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * ブック更新時の取得処理を、更新と同じ処理の流れの中で行うようになり、データの不整合が起きにくくなりました。
  * あるブックが存在しない場合は、従来どおり適切に見つからない結果が返るようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->