### PR TITLE
[codex] Add Rust toolchain components

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
 channel = "1.96.0"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Summary

- Add `rustfmt` and `clippy` to `rust-toolchain.toml` so rustup installs the required components from the project toolchain definition.

## Impact

This removes duplicated setup-script knowledge for Codex Cloud and local development. Toolchain setup can now rely on the repository's Rust toolchain file.

## Validation

- `cargo fmt --check`
- `cargo clippy --fix --all-targets --allow-dirty -- -D warnings`
- `cargo test`

Note: the exact `cargo clippy --fix --all-targets -- -D warnings` command was attempted first, but Cargo refused to run `--fix` with the intended uncommitted change present. The validation command was rerun with `--allow-dirty`; it completed with no issues and no additional changes.