### PR TITLE
Refactor Book updates to domain operation

### DIFF
--- a/src/domain/entity/book.rs
+++ b/src/domain/entity/book.rs
@@ -144,7 +144,7 @@ pub struct Book {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct BookDetailsUpdate {
+pub struct BookUpdate {
     pub title: BookTitle,
     pub author_ids: Vec<AuthorId>,
     pub isbn: Isbn,
@@ -200,7 +200,7 @@ impl Book {
         })
     }
 
-    pub fn update_details(&mut self, update: BookDetailsUpdate, updated_at: OffsetDateTime) {
+    pub fn update(&mut self, update: BookUpdate, updated_at: OffsetDateTime) {
         self.title = update.title;
         self.author_ids = update.author_ids;
         self.isbn = update.isbn;
@@ -236,11 +236,11 @@ mod test {
 
     use crate::common::types::{BookFormat, BookStore};
 
-    use super::{Book, BookDetailsUpdate, BookId, BookTitle, Isbn, OwnedFlag, Priority, ReadFlag};
+    use super::{Book, BookId, BookTitle, BookUpdate, Isbn, OwnedFlag, Priority, ReadFlag};
     use crate::domain::entity::author::AuthorId;
 
     #[test]
-    fn update_details_updates_editable_fields_and_updated_at() {
+    fn update_updates_editable_fields_and_updated_at() {
         let id = BookId::new(Uuid::new_v4()).expect("valid book id");
         let created_at = OffsetDateTime::from_unix_timestamp(1_700_000_000).expect("valid time");
         let original_updated_at =
@@ -264,7 +264,7 @@ mod test {
         )
         .expect("valid book");
 
-        let update = BookDetailsUpdate {
+        let update = BookUpdate {
             title: BookTitle::new("Updated title".to_owned()).expect("valid title"),
             author_ids: updated_author_ids.clone(),
             isbn: Isbn::new("978-4062758574".to_owned()).expect("valid isbn"),
@@ -275,7 +275,7 @@ mod test {
             store: BookStore::Kindle,
         };
 
-        book.update_details(update, updated_at);
+        book.update(update, updated_at);
 
         assert_eq!(book.title().as_str(), "Updated title");
         assert_eq!(book.author_ids(), &updated_author_ids);

--- a/src/domain/entity/book.rs
+++ b/src/domain/entity/book.rs
@@ -1,4 +1,4 @@
-use getset::{Getters, Setters};
+use getset::Getters;
 use regex::Regex;
 use std::sync::LazyLock;
 use time::OffsetDateTime;
@@ -117,30 +117,42 @@ impl Priority {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Getters, Setters)]
+#[derive(Debug, Clone, PartialEq, Eq, Getters)]
 pub struct Book {
     #[getset(get = "pub")]
     id: BookId,
-    #[getset(get = "pub", set = "pub")]
+    #[getset(get = "pub")]
     title: BookTitle,
-    #[getset(get = "pub", set = "pub")]
+    #[getset(get = "pub")]
     author_ids: Vec<AuthorId>,
-    #[getset(get = "pub", set = "pub")]
+    #[getset(get = "pub")]
     isbn: Isbn,
-    #[getset(get = "pub", set = "pub")]
+    #[getset(get = "pub")]
     read: ReadFlag,
-    #[getset(get = "pub", set = "pub")]
+    #[getset(get = "pub")]
     owned: OwnedFlag,
-    #[getset(get = "pub", set = "pub")]
+    #[getset(get = "pub")]
     priority: Priority,
-    #[getset(get = "pub", set = "pub")]
+    #[getset(get = "pub")]
     format: BookFormat,
-    #[getset(get = "pub", set = "pub")]
+    #[getset(get = "pub")]
     store: BookStore,
-    #[getset(get = "pub", set = "pub")]
+    #[getset(get = "pub")]
     created_at: OffsetDateTime,
-    #[getset(get = "pub", set = "pub")]
+    #[getset(get = "pub")]
     updated_at: OffsetDateTime,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BookDetailsUpdate {
+    pub title: BookTitle,
+    pub author_ids: Vec<AuthorId>,
+    pub isbn: Isbn,
+    pub read: ReadFlag,
+    pub owned: OwnedFlag,
+    pub priority: Priority,
+    pub format: BookFormat,
+    pub store: BookStore,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -188,6 +200,18 @@ impl Book {
         })
     }
 
+    pub fn update_details(&mut self, update: BookDetailsUpdate, updated_at: OffsetDateTime) {
+        self.title = update.title;
+        self.author_ids = update.author_ids;
+        self.isbn = update.isbn;
+        self.read = update.read;
+        self.owned = update.owned;
+        self.priority = update.priority;
+        self.format = update.format;
+        self.store = update.store;
+        self.updated_at = updated_at;
+    }
+
     pub fn destructure(self) -> DestructureBook {
         DestructureBook {
             id: self.id,
@@ -207,7 +231,64 @@ impl Book {
 
 #[cfg(test)]
 mod test {
-    use super::{Isbn, Priority};
+    use time::OffsetDateTime;
+    use uuid::Uuid;
+
+    use crate::common::types::{BookFormat, BookStore};
+
+    use super::{Book, BookDetailsUpdate, BookId, BookTitle, Isbn, OwnedFlag, Priority, ReadFlag};
+    use crate::domain::entity::author::AuthorId;
+
+    #[test]
+    fn update_details_updates_editable_fields_and_updated_at() {
+        let id = BookId::new(Uuid::new_v4()).expect("valid book id");
+        let created_at = OffsetDateTime::from_unix_timestamp(1_700_000_000).expect("valid time");
+        let original_updated_at =
+            OffsetDateTime::from_unix_timestamp(1_700_000_100).expect("valid time");
+        let updated_at = OffsetDateTime::from_unix_timestamp(1_700_000_200).expect("valid time");
+        let original_author_id = AuthorId::new(Uuid::new_v4());
+        let updated_author_ids = vec![AuthorId::new(Uuid::new_v4()), AuthorId::new(Uuid::new_v4())];
+
+        let mut book = Book::new(
+            id.clone(),
+            BookTitle::new("Original title".to_owned()).expect("valid title"),
+            vec![original_author_id],
+            Isbn::new("9784062758574".to_owned()).expect("valid isbn"),
+            ReadFlag::new(false),
+            OwnedFlag::new(false),
+            Priority::new(10).expect("valid priority"),
+            BookFormat::Printed,
+            BookStore::Unknown,
+            created_at,
+            original_updated_at,
+        )
+        .expect("valid book");
+
+        let update = BookDetailsUpdate {
+            title: BookTitle::new("Updated title".to_owned()).expect("valid title"),
+            author_ids: updated_author_ids.clone(),
+            isbn: Isbn::new("978-4062758574".to_owned()).expect("valid isbn"),
+            read: ReadFlag::new(true),
+            owned: OwnedFlag::new(true),
+            priority: Priority::new(99).expect("valid priority"),
+            format: BookFormat::EBook,
+            store: BookStore::Kindle,
+        };
+
+        book.update_details(update, updated_at);
+
+        assert_eq!(book.title().as_str(), "Updated title");
+        assert_eq!(book.author_ids(), &updated_author_ids);
+        assert_eq!(book.isbn().as_str(), "978-4062758574");
+        assert!(book.read().to_bool());
+        assert!(book.owned().to_bool());
+        assert_eq!(book.priority().to_i32(), 99);
+        assert_eq!(book.format(), &BookFormat::EBook);
+        assert_eq!(book.store(), &BookStore::Kindle);
+        assert_eq!(book.updated_at(), &updated_at);
+        assert_eq!(book.id(), &id);
+        assert_eq!(book.created_at(), &created_at);
+    }
 
     #[test]
     fn valid_isbn_with_hyphen() {

--- a/src/infrastructure/book_repository.rs
+++ b/src/infrastructure/book_repository.rs
@@ -579,6 +579,7 @@ mod tests {
         domain::{
             entity::{
                 author::{Author, AuthorName},
+                book::BookDetailsUpdate,
                 user::User,
             },
             error::DomainError,
@@ -805,7 +806,6 @@ mod tests {
         assert_eq!(actual, Some(book.clone()));
 
         // update
-        book.set_title(BookTitle::new("another_title".to_owned())?);
         author_ids.pop();
         let another_author_id = AuthorId::try_from("e30ce456-d34a-4c42-831c-b08d5f9ed81f")?;
         let another_author = Author::new(
@@ -814,7 +814,18 @@ mod tests {
         )?;
         create_author(&pool, &author_repository, &user_id, &another_author).await?;
         author_ids.push(another_author_id);
-        book.set_author_ids(author_ids);
+        let update = BookDetailsUpdate {
+            title: BookTitle::new("another_title".to_owned())?,
+            author_ids,
+            isbn: book.isbn().clone(),
+            read: book.read().clone(),
+            owned: book.owned().clone(),
+            priority: book.priority().clone(),
+            format: book.format().clone(),
+            store: book.store().clone(),
+        };
+        let updated_at = *book.updated_at();
+        book.update_details(update, updated_at);
         update_book(&pool, &book_repository, &user_id, &book).await?;
 
         let actual = book_repository.find_by_id(&user_id, book.id()).await?;

--- a/src/infrastructure/book_repository.rs
+++ b/src/infrastructure/book_repository.rs
@@ -579,7 +579,7 @@ mod tests {
         domain::{
             entity::{
                 author::{Author, AuthorName},
-                book::BookDetailsUpdate,
+                book::BookUpdate,
                 user::User,
             },
             error::DomainError,
@@ -814,7 +814,7 @@ mod tests {
         )?;
         create_author(&pool, &author_repository, &user_id, &another_author).await?;
         author_ids.push(another_author_id);
-        let update = BookDetailsUpdate {
+        let update = BookUpdate {
             title: BookTitle::new("another_title".to_owned())?,
             author_ids,
             isbn: book.isbn().clone(),
@@ -825,7 +825,7 @@ mod tests {
             store: book.store().clone(),
         };
         let updated_at = *book.updated_at();
-        book.update_details(update, updated_at);
+        book.update(update, updated_at);
         update_book(&pool, &book_repository, &user_id, &book).await?;
 
         let actual = book_repository.find_by_id(&user_id, book.id()).await?;

--- a/src/use_case/interactor/book.rs
+++ b/src/use_case/interactor/book.rs
@@ -9,7 +9,9 @@ use crate::{
     domain::{
         entity::{
             author::{AuthorId, AuthorName},
-            book::{Book, BookId, BookTitle, Isbn, OwnedFlag, Priority, ReadFlag},
+            book::{
+                Book, BookDetailsUpdate, BookId, BookTitle, Isbn, OwnedFlag, Priority, ReadFlag,
+            },
             event::EventSetOperation,
             user::UserId,
         },
@@ -158,15 +160,17 @@ where
             }
         };
 
-        book.set_title(title);
-        book.set_author_ids(author_ids);
-        book.set_isbn(isbn);
-        book.set_read(read);
-        book.set_owned(owned);
-        book.set_priority(priority);
-        book.set_format(format);
-        book.set_store(store);
-        book.set_updated_at(OffsetDateTime::now_utc());
+        let update = BookDetailsUpdate {
+            title,
+            author_ids,
+            isbn,
+            read,
+            owned,
+            priority,
+            format,
+            store,
+        };
+        book.update_details(update, OffsetDateTime::now_utc());
 
         self.book_repository
             .update(&mut tx, &user_id, &book)

--- a/src/use_case/interactor/book.rs
+++ b/src/use_case/interactor/book.rs
@@ -9,9 +9,7 @@ use crate::{
     domain::{
         entity::{
             author::{AuthorId, AuthorName},
-            book::{
-                Book, BookDetailsUpdate, BookId, BookTitle, Isbn, OwnedFlag, Priority, ReadFlag,
-            },
+            book::{Book, BookId, BookTitle, BookUpdate, Isbn, OwnedFlag, Priority, ReadFlag},
             event::EventSetOperation,
             user::UserId,
         },
@@ -160,7 +158,7 @@ where
             }
         };
 
-        let update = BookDetailsUpdate {
+        let update = BookUpdate {
             title,
             author_ids,
             isbn,
@@ -170,7 +168,7 @@ where
             format,
             store,
         };
-        book.update_details(update, OffsetDateTime::now_utc());
+        book.update(update, OffsetDateTime::now_utc());
 
         self.book_repository
             .update(&mut tx, &user_id, &book)


### PR DESCRIPTION
### Motivation
- Move Book state changes away from ad-hoc public setter sequences and into a single domain operation so callers do not need to remember to bump `updated_at` separately. 
- Make Book responsible for applying a consistent state transition while keeping time acquisition at the use-case layer.

### Description
- Add a domain `BookDetailsUpdate` value and implement `Book::update_details(&mut self, update: BookDetailsUpdate, updated_at: OffsetDateTime)` which applies editable fields and sets `updated_at` inside the entity. 
- Remove public `set = "pub"` setters on `Book` (keep getters) so external code uses the domain operation instead of multiple setters. 
- Migrate `UpdateBookInteractor` to construct a `BookDetailsUpdate` and call `book.update_details(update, OffsetDateTime::now_utc())` instead of calling many setters and `set_updated_at`. 
- Update repository integration tests to use the new domain operation and add a unit test for `Book::update_details(...)` verifying editable fields, `updated_at`, and preservation of `id` and `created_at`.

### Testing
- Ran `cargo test`, all unit tests passed (138 passed; 0 failed). 
- Ran formatting and linter checks; `cargo fmt --check` passed and `cargo clippy` was run (a `--fix` pass was attempted but required `--allow-dirty` due to local changes and the fix pass completed), with no remaining `-D warnings` failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a47e6944f8c8321bc82d534738252b1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 書籍情報の更新処理を見直し、編集可能な項目がまとめて正しく反映されるようになりました。
  * 更新後の更新日時が適切に再設定され、IDや作成日時は保持されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->