### PR TITLE
[codex] Update clippy pre-commit check

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,8 +71,8 @@ If any command fails, fix the issue before committing. Do not commit with failur
 
 ```bash
 cargo fmt --check
-cargo clippy --all-targets -- -D warnings
-cargo test
+cargo clippy --all-targets --locked -- -D warnings
+cargo test --locked
 ```
 
 If `cargo fmt --check` fails, run `cargo fmt` to fix formatting, then re-run the check.
@@ -81,7 +81,7 @@ If the fixes appear safe to apply, you may run the following command and inspect
 the diff again before re-running the checks:
 
 ```bash
-cargo clippy --fix --allow-dirty --allow-staged --all-targets -- -D warnings
+cargo clippy --fix --allow-dirty --allow-staged --all-targets --locked -- -D warnings
 ```
 
 ## ExecPlans

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,11 +71,18 @@ If any command fails, fix the issue before committing. Do not commit with failur
 
 ```bash
 cargo fmt --check
-cargo clippy --fix --all-targets -- -D warnings
+cargo clippy --all-targets -- -D warnings
 cargo test
 ```
 
 If `cargo fmt --check` fails, run `cargo fmt` to fix formatting, then re-run the check.
+If `cargo clippy` reports machine-applicable fixes, inspect the current diff first.
+If the fixes appear safe to apply, you may run the following command and inspect
+the diff again before re-running the checks:
+
+```bash
+cargo clippy --fix --allow-dirty --allow-staged --all-targets -- -D warnings
+```
 
 ## ExecPlans
 


### PR DESCRIPTION
## Summary

- Make the mandatory pre-commit clippy check non-mutating.
- Document the optional `cargo clippy --fix` flow for machine-applicable fixes when they appear safe to apply.
- Require inspecting the diff before and after running the optional fix command.

## Validation

- `git diff --check`
- Cargo checks not run because this is a documentation-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * 開発前のチェック手順が更新され、整形・静的解析・テストの実行順が明確になりました。
  * 警告はエラーとして扱うようになり、必要に応じて自動修正を確認して反映する流れが追加されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->