### PR TITLE
Align author update with book

### DIFF
--- a/src/domain/entity/author.rs
+++ b/src/domain/entity/author.rs
@@ -94,7 +94,7 @@ impl Author {
 #[cfg(test)]
 mod tests {
     use crate::domain::{
-        entity::author::{AuthorId, AuthorName},
+        entity::author::{Author, AuthorId, AuthorName, AuthorUpdate},
         error::DomainError,
     };
 
@@ -103,6 +103,21 @@ mod tests {
         let uuid_str = "c6ea22c8-7b70-470c-a713-c7aade5693bd";
         let author_id = AuthorId::try_from(uuid_str).unwrap();
         assert_eq!(author_id.to_string(), uuid_str);
+    }
+
+    #[test]
+    fn update_changes_name() {
+        let mut author = Author::new(
+            AuthorId::try_from("c6ea22c8-7b70-470c-a713-c7aade5693bd").unwrap(),
+            AuthorName::new(String::from("author1")).unwrap(),
+        )
+        .unwrap();
+
+        author.update(AuthorUpdate {
+            name: AuthorName::new(String::from("author2")).unwrap(),
+        });
+
+        assert_eq!(author.name().as_str(), "author2");
     }
 
     #[test]

--- a/src/domain/entity/author.rs
+++ b/src/domain/entity/author.rs
@@ -69,9 +69,18 @@ pub struct DestructureAuthor {
     pub name: AuthorName,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuthorUpdate {
+    pub name: AuthorName,
+}
+
 impl Author {
     pub fn new(id: AuthorId, name: AuthorName) -> Result<Author, DomainError> {
         Ok(Author { id, name })
+    }
+
+    pub fn update(&mut self, update: AuthorUpdate) {
+        self.name = update.name;
     }
 
     pub fn destructure(self) -> DestructureAuthor {

--- a/src/domain/repository/author_repository.rs
+++ b/src/domain/repository/author_repository.rs
@@ -27,6 +27,12 @@ pub trait AuthorRepository: Send + Sync + 'static {
         user_id: &UserId,
         author_id: &AuthorId,
     ) -> Result<Option<Author>, DomainError>;
+    async fn find_by_id_with_tx(
+        &self,
+        tx: &mut Self::Transaction,
+        user_id: &UserId,
+        author_id: &AuthorId,
+    ) -> Result<Option<Author>, DomainError>;
     async fn find_all(&self, user_id: &UserId) -> Result<Vec<Author>, DomainError>;
     async fn find_by_ids_as_hash_map(
         &self,

--- a/src/infrastructure/author_repository.rs
+++ b/src/infrastructure/author_repository.rs
@@ -571,6 +571,53 @@ mod tests {
     }
 
     #[sqlx::test]
+    async fn find_by_id_with_tx_matches_find_by_id(pool: PgPool) -> anyhow::Result<()> {
+        let user_repository = PgUserRepository::new(pool.clone());
+        let author_repository = PgAuthorRepository::new(pool.clone());
+
+        let user_id = prepare_user(&user_repository, "user1").await?;
+        let author_id = AuthorId::try_from("e324be11-5b77-4ba6-8423-9f27e2d228f1")?;
+        let author = Author::new(author_id.clone(), AuthorName::new(String::from("author1"))?)?;
+        create_author(&pool, &author_repository, &user_id, &author).await?;
+
+        let expected = author_repository.find_by_id(&user_id, &author_id).await?;
+
+        let tm = PgTransactionManager::new(pool.clone());
+        let mut tx = tm.begin(&user_id, EventSetOperation::UpdateAuthor).await?;
+        let actual = author_repository
+            .find_by_id_with_tx(&mut tx, &user_id, &author_id)
+            .await?;
+        assert_eq!(actual, expected);
+        tm.commit(tx).await?;
+
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn find_by_id_with_tx_rejects_user_mismatched_transaction(
+        pool: PgPool,
+    ) -> anyhow::Result<()> {
+        let user_repository = PgUserRepository::new(pool.clone());
+        let author_repository = PgAuthorRepository::new(pool.clone());
+
+        let user_id = prepare_user(&user_repository, "user1").await?;
+        let other_user_id = UserId::new(String::from("user2"))?;
+        let author_id = AuthorId::try_from("e324be11-5b77-4ba6-8423-9f27e2d228f1")?;
+        let author = Author::new(author_id.clone(), AuthorName::new(String::from("author1"))?)?;
+        create_author(&pool, &author_repository, &user_id, &author).await?;
+
+        let tm = PgTransactionManager::new(pool.clone());
+        let mut tx = tm.begin(&user_id, EventSetOperation::UpdateAuthor).await?;
+        let result = author_repository
+            .find_by_id_with_tx(&mut tx, &other_user_id, &author_id)
+            .await;
+        assert!(matches!(result, Err(DomainError::Unexpected(_))));
+        drop(tx);
+
+        Ok(())
+    }
+
+    #[sqlx::test]
     async fn create_and_find_all(pool: PgPool) -> anyhow::Result<()> {
         let user_repository = PgUserRepository::new(pool.clone());
         let author_repository = PgAuthorRepository::new(pool.clone());

--- a/src/infrastructure/author_repository.rs
+++ b/src/infrastructure/author_repository.rs
@@ -160,19 +160,17 @@ impl AuthorRepository for PgAuthorRepository {
         user_id: &UserId,
         author_id: &AuthorId,
     ) -> Result<Option<Author>, DomainError> {
-        let row: Option<AuthorRow> =
-            sqlx::query_as("SELECT * FROM author WHERE id = $1 AND user_id = $2")
-                .bind(author_id.to_uuid())
-                .bind(user_id.as_str())
-                .fetch_optional(&self.pool)
-                .await?;
+        find_author_by_id_with_executor(&self.pool, user_id, author_id).await
+    }
 
-        row.map(|row| -> Result<Author, DomainError> {
-            let author_id: AuthorId = row.id.into();
-            let author_name = AuthorName::new(row.name)?;
-            Author::new(author_id, author_name)
-        })
-        .transpose()
+    async fn find_by_id_with_tx(
+        &self,
+        tx: &mut Self::Transaction,
+        user_id: &UserId,
+        author_id: &AuthorId,
+    ) -> Result<Option<Author>, DomainError> {
+        tx.ensure_user(user_id)?;
+        find_author_by_id_with_executor(tx.as_mut(), user_id, author_id).await
     }
 
     async fn find_all(&self, user_id: &UserId) -> Result<Vec<Author>, DomainError> {
@@ -444,6 +442,29 @@ impl AuthorRepository for PgAuthorRepository {
 
         Ok(authors_map)
     }
+}
+
+async fn find_author_by_id_with_executor<'e, E>(
+    executor: E,
+    user_id: &UserId,
+    author_id: &AuthorId,
+) -> Result<Option<Author>, DomainError>
+where
+    E: sqlx::Executor<'e, Database = sqlx::Postgres>,
+{
+    let row: Option<AuthorRow> =
+        sqlx::query_as("SELECT * FROM author WHERE id = $1 AND user_id = $2")
+            .bind(author_id.to_uuid())
+            .bind(user_id.as_str())
+            .fetch_optional(executor)
+            .await?;
+
+    row.map(|row| -> Result<Author, DomainError> {
+        let author_id: AuthorId = row.id.into();
+        let author_name = AuthorName::new(row.name)?;
+        Author::new(author_id, author_name)
+    })
+    .transpose()
 }
 
 #[cfg(feature = "test-with-database")]

--- a/src/use_case/interactor/author.rs
+++ b/src/use_case/interactor/author.rs
@@ -4,7 +4,7 @@ use uuid::Uuid;
 use crate::{
     domain::{
         entity::{
-            author::{Author, AuthorId, AuthorName},
+            author::{Author, AuthorId, AuthorName, AuthorUpdate},
             event::EventSetOperation,
             user::UserId,
         },
@@ -89,12 +89,28 @@ where
         let user_id = UserId::new(user_id.to_string())?;
         let author_id = AuthorId::try_from(author_data.id.as_str())?;
         let author_name = AuthorName::new(author_data.name)?;
-        let author = Author::new(author_id, author_name)?;
 
         let mut tx = self
             .transaction_manager
             .begin(&user_id, EventSetOperation::UpdateAuthor)
             .await?;
+        let author = self
+            .author_repository
+            .find_by_id_with_tx(&mut tx, &user_id, &author_id)
+            .await?;
+        let mut author = match author {
+            Some(author) => author,
+            None => {
+                return Err(UseCaseError::NotFound {
+                    entity_type: "author",
+                    entity_id: author_data.id,
+                    user_id: user_id.into_string(),
+                });
+            }
+        };
+
+        author.update(AuthorUpdate { name: author_name });
+
         self.author_repository
             .update(&mut tx, &user_id, &author)
             .await?;
@@ -147,6 +163,7 @@ mod tests {
 
     use crate::{
         domain::{
+            entity::author::{Author, AuthorId, AuthorName},
             error::DomainError,
             repository::{
                 author_repository::MockAuthorRepository, transaction::MockTransactionManager,
@@ -227,7 +244,17 @@ mod tests {
         // Given
         let author_id_str = "006099b4-6c42-4ec4-8645-f6bd5b63eddc";
 
+        let existing_author = Author::new(
+            AuthorId::try_from(author_id_str).unwrap(),
+            AuthorName::new("Old Name".to_string()).unwrap(),
+        )
+        .unwrap();
+
         let mut author_repository = MockAuthorRepository::new();
+        author_repository
+            .expect_find_by_id_with_tx()
+            .with(always(), always(), always())
+            .returning(move |_, _, _| Ok(Some(existing_author.clone())));
         author_repository
             .expect_update()
             .with(always(), always(), always())
@@ -251,17 +278,15 @@ mod tests {
 
         let mut author_repository = MockAuthorRepository::new();
         author_repository
-            .expect_update()
+            .expect_find_by_id_with_tx()
             .with(always(), always(), always())
-            .returning(|_, _, _| {
-                Err(DomainError::NotFound {
-                    entity_type: "author",
-                    entity_id: "006099b4-6c42-4ec4-8645-f6bd5b63eddc".to_string(),
-                    user_id: "user1".to_string(),
-                })
-            });
+            .returning(|_, _, _| Ok(None));
 
-        let interactor = UpdateAuthorInteractor::new(author_repository, make_transaction_manager());
+        let interactor = UpdateAuthorInteractor::new(author_repository, {
+            let mut tm = MockTransactionManager::new();
+            tm.expect_begin().returning(|_, _| Ok(()));
+            tm
+        });
         let author_data = UpdateAuthorDto::new(author_id_str.to_string(), "New Name".to_string());
 
         // When


### PR DESCRIPTION
### Motivation

- Make author update flow consistent with book update by performing read-modify-write inside the same transaction. 
- Prevent lost-update / missing-state issues by loading the current author record under the transaction before applying changes. 
- Reuse the same repository/DB-helper pattern used by book to keep infrastructure code uniform.

### Description

- Add `AuthorUpdate` and `Author::update` to the domain model to apply updates on the aggregate. 
- Extend `AuthorRepository` with `find_by_id_with_tx` and implement a reusable `find_author_by_id_with_executor` helper in `PgAuthorRepository` so lookups can run both inside and outside transactions. 
- Change `UpdateAuthorInteractor` to begin a transaction, load the existing author via `find_by_id_with_tx`, return `UseCaseError::NotFound` when absent, call the domain `update` method, then `update` the repository and commit. 
- Update unit tests for the author interactor to cover the new find-before-update success and not-found cases.

### Testing

- Ran formatting, lints and full test suite with `cargo fmt --check`, `cargo clippy --all-targets --locked -- -D warnings`, and `cargo test --locked`, and all checks passed. 
- Ran the author update unit tests (`cargo test --locked update_author --lib`) which passed. 
- No failures observed in the automated test run (`138 passed; 0 failed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4871437e0c8321bcaa41b5ec81a9f8)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 著者情報の更新時に、既存の著者データを取得したうえで名前を更新できるようになりました。

* **Bug Fixes**
  * 存在しない著者を更新しようとした場合、正しく「見つからない」エラーを返すようになりました。
  * 更新処理で、ユーザーや対象データの不一致による不整合を防ぐよう改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->