### PR TITLE
Speed up test image workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,7 @@ jobs:
           load: true
           tags: bookshelf-api:tls-check
           target: tls-check
+          cache-from: type=gha
       - name: Verify HTTPS connectivity via reqwest
         run: docker run --rm bookshelf-api:tls-check
 
@@ -101,7 +102,7 @@ jobs:
           for i in {1..20}; do
             if curl --fail http://localhost:8080/health 2>/dev/null; then
               echo "Health check passed after ${i} seconds"
-              docker stop test-container postgres
+              docker stop -t 1 test-container postgres
               docker network remove test-network
               exit 0
             fi
@@ -111,7 +112,7 @@ jobs:
           echo "Health check failed after 20 seconds"
           echo "=== Container Logs ==="
           docker logs test-container
-          docker stop test-container postgres
+          docker stop -t 1 test-container postgres
           docker network remove test-network
           exit 1
 


### PR DESCRIPTION
### Motivation
- Reduce CI run time for the `Test Image Building` job by allowing BuildKit to reuse previously built layers via the GitHub Actions cache.
- Avoid long container stop delays during the workflow's health-check cleanup by using a short stop timeout so failure logs are preserved while teardown is fast.

### Description
- Update `.github/workflows/ci.yml` to add `cache-from: type=gha` to the `Build tls-check image` `docker/build-push-action` step so BuildKit can import GHA cache layers.
- Replace `docker stop test-container postgres` with `docker stop -t 1 test-container postgres` in both the success and failure cleanup paths to reduce teardown latency.
- Commit the workflow-only change and open this PR to apply the CI improvements.

### Testing
- Ran `cargo fmt --check` and it succeeded.
- Ran `cargo clippy --all-targets --locked -- -D warnings` and it succeeded.
- Ran `cargo test --locked` and unit tests passed (`137 passed; 0 failed`).
- Ran `git --no-pager diff --check` and there were no diff-check issues.
- `actionlint .github/workflows/ci.yml` was not run because `actionlint` is not installed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4860bc05388321845dd73034a48d1a)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * テスト用イメージのビルドでキャッシュを活用するようになり、実行時間の短縮が期待できます。
  * コンテナ停止時の待機時間を明示し、CIの後片付けをより安定して行えるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->