### PR TITLE
Address e2e split review fixes

### DIFF
--- a/e2e/src/lib.rs
+++ b/e2e/src/lib.rs
@@ -144,17 +144,16 @@ pub async fn ensure_user_registered(token: &str) -> Result<()> {
 
     // Always check for GraphQL errors, regardless of HTTP status
     if let Some(errors) = response.get("errors") {
-        let error_message = errors
-            .as_array()
-            .and_then(|arr| arr.first())
-            .and_then(|e| e.get("message"))
-            .and_then(|m| m.as_str())
-            .unwrap_or("");
+        let is_conflict = errors.as_array().is_some_and(|errors| {
+            errors
+                .iter()
+                .any(|error| graphql_error_code(error) == Some("CONFLICT"))
+        });
 
-        if !error_message.contains("duplicate key") {
-            anyhow::bail!("registerUser failed with error: {}", error_message);
+        if !is_conflict {
+            anyhow::bail!("registerUser failed with error: {}", errors);
         }
-        // Duplicate key means user already exists - that's OK
+        // A conflict means user already exists - that's OK.
         return Ok(());
     }
 
@@ -180,6 +179,7 @@ pub async fn create_test_author(name: &str, token: &str) -> Result<String> {
         name
     );
     let (_, response) = graphql_request(&query, Some(token)).await?;
+    bail_on_graphql_errors(&response, "createAuthor")?;
     let id = response["data"]["createAuthor"]["id"]
         .as_str()
         .context("createAuthor id should be a string")?
@@ -206,11 +206,88 @@ pub async fn create_test_book(title: &str, author_id: &str, token: &str) -> Resu
         title, author_id
     );
     let (_, response) = graphql_request(&query, Some(token)).await?;
+    bail_on_graphql_errors(&response, "createBook")?;
     let id = response["data"]["createBook"]["id"]
         .as_str()
         .context("createBook id should be a string")?
         .to_owned();
     Ok(id)
+}
+
+pub async fn update_test_book(
+    book_id: &str,
+    title: &str,
+    author_id: &str,
+    isbn: &str,
+    read: bool,
+    owned: bool,
+    priority: i32,
+    format: &str,
+    store: &str,
+    token: &str,
+) -> Result<serde_json::Value> {
+    let query = format!(
+        r#"
+        mutation {{
+            updateBook(bookData: {{
+                id: "{}"
+                title: "{}"
+                authorIds: ["{}"]
+                isbn: "{}"
+                read: {}
+                owned: {}
+                priority: {}
+                format: {}
+                store: {}
+            }}) {{
+                id
+                title
+                authorIds
+                isbn
+                read
+                owned
+                priority
+                format
+                store
+            }}
+        }}
+        "#,
+        book_id, title, author_id, isbn, read, owned, priority, format, store
+    );
+    let (_, response) = graphql_request(&query, Some(token)).await?;
+    bail_on_graphql_errors(&response, "updateBook")?;
+    Ok(response["data"]["updateBook"].clone())
+}
+
+pub async fn find_event_set_by_operation(
+    operation: &str,
+    token: &str,
+) -> Result<serde_json::Value> {
+    let (_, response) = graphql_request(r#"{ eventSets { id operation } }"#, Some(token)).await?;
+    bail_on_graphql_errors(&response, "eventSets")?;
+    let event_set_id = response["data"]["eventSets"]
+        .as_array()
+        .context("eventSets should be an array")?
+        .iter()
+        .find(|set| set["operation"].as_str() == Some(operation))
+        .and_then(|set| set["id"].as_str())
+        .context("matching event set should exist")?;
+
+    let event_set_query = format!(
+        r#"{{ eventSet(id: "{}") {{
+            operation
+            bookEvents {{ bookId operation }}
+            authorEvents {{ name operation }}
+        }} }}"#,
+        event_set_id
+    );
+    let (_, response) = graphql_request(&event_set_query, Some(token)).await?;
+    bail_on_graphql_errors(&response, "eventSet")?;
+    let event_set = response["data"]["eventSet"].clone();
+    if event_set.is_null() {
+        anyhow::bail!("matching event set should be found");
+    }
+    Ok(event_set)
 }
 
 pub fn assert_graphql_errors(response: &serde_json::Value, context: &str) {
@@ -226,4 +303,18 @@ pub fn assert_no_graphql_errors(response: &serde_json::Value, context: &str) {
         "{context} should not return GraphQL errors: {:?}",
         response.get("errors")
     );
+}
+
+pub fn bail_on_graphql_errors(response: &serde_json::Value, context: &str) -> Result<()> {
+    if let Some(errors) = response.get("errors") {
+        anyhow::bail!("{context} returned GraphQL errors: {errors}");
+    }
+    Ok(())
+}
+
+fn graphql_error_code(error: &serde_json::Value) -> Option<&str> {
+    error
+        .get("extensions")
+        .and_then(|extensions| extensions.get("code"))
+        .and_then(|code| code.as_str())
 }

--- a/e2e/src/lib.rs
+++ b/e2e/src/lib.rs
@@ -242,7 +242,10 @@ pub async fn update_test_book(
             }}) {{
                 id
                 title
-                authorIds
+                authors {{
+                    id
+                    name
+                }}
                 isbn
                 read
                 owned

--- a/e2e/tests/graphql_authors.rs
+++ b/e2e/tests/graphql_authors.rs
@@ -121,9 +121,9 @@ async fn e2e_graphql_delete_author_with_associated_books_fails() -> Result<()> {
     // Attempt to delete the author — must fail
     let delete_author_query = format!(r#"mutation {{ deleteAuthor(authorId: "{}") }}"#, author_id);
     let (_, response) = graphql_request(&delete_author_query, Some(&token)).await?;
-    assert!(
-        response.get("errors").is_some(),
-        "deleteAuthor should return errors when author has associated books"
+    assert_graphql_errors(
+        &response,
+        "deleteAuthor should return errors when author has associated books",
     );
 
     // Verify the author still exists
@@ -159,10 +159,7 @@ async fn e2e_graphql_update_author() -> Result<()> {
         author_id, updated_name
     );
     let (_, response) = graphql_request(&update_query, Some(&token)).await?;
-    assert!(
-        response.get("errors").is_none(),
-        "updateAuthor should not return errors"
-    );
+    assert_no_graphql_errors(&response, "updateAuthor should not return errors");
     let update_result = &response["data"]["updateAuthor"];
     assert_eq!(
         update_result["id"].as_str(),
@@ -201,9 +198,9 @@ async fn e2e_graphql_update_nonexistent_author_returns_error() -> Result<()> {
         nonexistent_id
     );
     let (_, response) = graphql_request(&query, Some(&token)).await?;
-    assert!(
-        response.get("errors").is_some(),
-        "updateAuthor should return errors for a non-existent author"
+    assert_graphql_errors(
+        &response,
+        "updateAuthor should return errors for a non-existent author",
     );
     Ok(())
 }
@@ -219,9 +216,9 @@ async fn e2e_graphql_delete_nonexistent_author_returns_error() -> Result<()> {
         nonexistent_id
     );
     let (_, response) = graphql_request(&query, Some(&token)).await?;
-    assert!(
-        response.get("errors").is_some(),
-        "deleteAuthor should return errors for a non-existent author"
+    assert_graphql_errors(
+        &response,
+        "deleteAuthor should return errors for a non-existent author",
     );
     Ok(())
 }

--- a/e2e/tests/graphql_books.rs
+++ b/e2e/tests/graphql_books.rs
@@ -101,34 +101,19 @@ async fn e2e_graphql_crud_book() -> Result<()> {
         .context("id must be string")?;
 
     // Update book
-    let update_query = format!(
-        r#"
-        mutation {{
-            updateBook(bookData: {{
-                id: "{}"
-                title: "Updated Test Book"
-                authorIds: ["{}"]
-                isbn: "9783161484100"
-                read: true
-                owned: true
-                priority: 2
-                format: PRINTED
-                store: KINDLE
-            }}) {{
-                id
-                title
-                read
-                priority
-            }}
-        }}
-        "#,
-        book_id, author_id
-    );
-    let (_, response) = graphql_request(&update_query, Some(&token)).await?;
-    let data = response.get("data").context("data field must exist")?;
-    let update_result = data
-        .get("updateBook")
-        .context("updateBook field must exist")?;
+    let update_result = update_test_book(
+        book_id,
+        "Updated Test Book",
+        author_id,
+        "9783161484100",
+        true,
+        true,
+        2,
+        "PRINTED",
+        "KINDLE",
+        &token,
+    )
+    .await?;
     assert_eq!(
         update_result
             .get("title")
@@ -564,7 +549,3 @@ async fn e2e_graphql_create_mutations_validate_input() -> Result<()> {
 
     Ok(())
 }
-
-// ============================================
-// Change History E2E Tests
-// ============================================

--- a/e2e/tests/graphql_history.rs
+++ b/e2e/tests/graphql_history.rs
@@ -24,11 +24,7 @@ async fn e2e_book_events_records_create_operation() -> Result<()> {
         book_id
     );
     let (_, response) = graphql_request(&query, Some(&token)).await?;
-    assert!(
-        response.get("errors").is_none(),
-        "bookEvents should not return errors: {:?}",
-        response.get("errors")
-    );
+    assert_no_graphql_errors(&response, "bookEvents");
 
     let entries = response["data"]["bookEvents"]
         .as_array()
@@ -112,29 +108,19 @@ async fn e2e_book_events_records_update_operation() -> Result<()> {
     let book_id = create_test_book("Original Title", &author_id, &token).await?;
 
     // Update the book
-    let update_query = format!(
-        r#"
-        mutation {{
-            updateBook(bookData: {{
-                id: "{}"
-                title: "Updated Title"
-                authorIds: ["{}"]
-                isbn: ""
-                read: false
-                owned: false
-                priority: 50
-                format: E_BOOK
-                store: KINDLE
-            }}) {{ id title }}
-        }}
-        "#,
-        book_id, author_id
-    );
-    let (_, response) = graphql_request(&update_query, Some(&token)).await?;
-    assert!(
-        response.get("errors").is_none(),
-        "updateBook should not return errors"
-    );
+    update_test_book(
+        &book_id,
+        "Updated Title",
+        &author_id,
+        "",
+        false,
+        false,
+        50,
+        "E_BOOK",
+        "KINDLE",
+        &token,
+    )
+    .await?;
 
     let query = format!(
         r#"{{ bookEvents(bookId: "{}") {{
@@ -262,11 +248,7 @@ async fn e2e_author_events_records_create_operation() -> Result<()> {
         author_id
     );
     let (_, response) = graphql_request(&query, Some(&token)).await?;
-    assert!(
-        response.get("errors").is_none(),
-        "authorEvents should not return errors: {:?}",
-        response.get("errors")
-    );
+    assert_no_graphql_errors(&response, "authorEvents");
 
     let entries = response["data"]["authorEvents"]
         .as_array()
@@ -326,10 +308,7 @@ async fn e2e_author_events_records_update_operation() -> Result<()> {
         author_id, updated_name
     );
     let (_, response) = graphql_request(&update_query, Some(&token)).await?;
-    assert!(
-        response.get("errors").is_none(),
-        "updateAuthor should not return errors"
-    );
+    assert_no_graphql_errors(&response, "updateAuthor");
 
     let query = format!(
         r#"{{ authorEvents(authorId: "{}") {{

--- a/e2e/tests/graphql_import.rs
+++ b/e2e/tests/graphql_import.rs
@@ -48,11 +48,7 @@ async fn e2e_import_books() -> Result<()> {
         }
     "#;
     let (_, response) = graphql_request(import_query, Some(&token)).await?;
-    assert!(
-        response.get("errors").is_none(),
-        "importBooks should not return errors: {:?}",
-        response.get("errors")
-    );
+    assert_no_graphql_errors(&response, "importBooks");
 
     let imported_books = response["data"]["importBooks"]
         .as_array()
@@ -97,31 +93,8 @@ async fn e2e_import_books() -> Result<()> {
     );
     assert_ne!(book_one_id, book_two_id, "book ids should be distinct");
 
-    // Locate the single event set produced by the import via eventSets, then
-    // inspect it directly. This replaces the old workaround of comparing the
-    // eventSetId across separate per-book bookEvents queries.
-    let (_, response) = graphql_request(r#"{ eventSets { id operation } }"#, Some(&token)).await?;
-    let event_sets = response["data"]["eventSets"]
-        .as_array()
-        .context("eventSets should be an array")?;
-    let import_set_id = event_sets
-        .iter()
-        .find(|s| s["operation"].as_str() == Some("import_books"))
-        .and_then(|s| s["id"].as_str())
-        .context("there should be an import_books event set")?;
-
     // The shared event set groups both book creates and the new author create.
-    let event_set_query = format!(
-        r#"{{ eventSet(id: "{}") {{
-            operation
-            bookEvents {{ bookId operation }}
-            authorEvents {{ name operation }}
-        }} }}"#,
-        import_set_id
-    );
-    let (_, response) = graphql_request(&event_set_query, Some(&token)).await?;
-    let event_set = &response["data"]["eventSet"];
-    assert!(!event_set.is_null(), "import event set should be found");
+    let event_set = find_event_set_by_operation("import_books", &token).await?;
     assert_eq!(
         event_set["operation"].as_str(),
         Some("import_books"),
@@ -286,11 +259,7 @@ async fn e2e_import_books_many_entries() -> Result<()> {
         "#
     );
     let (_, response) = graphql_request(&import_query, Some(&token)).await?;
-    assert!(
-        response.get("errors").is_none(),
-        "bulk importBooks should not return errors: {:?}",
-        response.get("errors")
-    );
+    assert_no_graphql_errors(&response, "bulk importBooks");
 
     let imported_books = response["data"]["importBooks"]
         .as_array()
@@ -324,26 +293,7 @@ async fn e2e_import_books_many_entries() -> Result<()> {
         }));
     }
 
-    let (_, response) = graphql_request(r#"{ eventSets { id operation } }"#, Some(&token)).await?;
-    let event_sets = response["data"]["eventSets"]
-        .as_array()
-        .context("eventSets should be an array")?;
-    let import_set_id = event_sets
-        .iter()
-        .find(|s| s["operation"].as_str() == Some("import_books"))
-        .and_then(|s| s["id"].as_str())
-        .context("there should be an import_books event set")?;
-
-    let event_set_query = format!(
-        r#"{{ eventSet(id: "{}") {{
-            operation
-            bookEvents {{ bookId operation }}
-            authorEvents {{ name operation }}
-        }} }}"#,
-        import_set_id
-    );
-    let (_, response) = graphql_request(&event_set_query, Some(&token)).await?;
-    let event_set = &response["data"]["eventSet"];
+    let event_set = find_event_set_by_operation("import_books", &token).await?;
     assert_eq!(event_set["operation"].as_str(), Some("import_books"));
     let grouped_book_events = event_set["bookEvents"]
         .as_array()
@@ -628,27 +578,16 @@ async fn e2e_import_books_deduplicates_shared_new_author() -> Result<()> {
         .as_str()
         .context("shared author id should be a string")?;
 
-    let import_set_id = response["data"]["eventSets"]
-        .as_array()
-        .context("eventSets should be an array")?
-        .iter()
-        .find(|set| set["operation"].as_str() == Some("import_books"))
-        .and_then(|set| set["id"].as_str())
-        .context("there should be an import_books event set")?;
-    let event_set_query = format!(
-        r#"{{ eventSet(id: "{}") {{ bookEvents {{ bookId operation }} authorEvents {{ name operation }} }} }}"#,
-        import_set_id
-    );
-    let (_, response) = graphql_request(&event_set_query, Some(&token)).await?;
+    let event_set = find_event_set_by_operation("import_books", &token).await?;
     assert_eq!(
-        response["data"]["eventSet"]["bookEvents"]
+        event_set["bookEvents"]
             .as_array()
             .context("bookEvents should be an array")?
             .len(),
         titles.len(),
         "each imported book should have a create event"
     );
-    let author_events = response["data"]["eventSet"]["authorEvents"]
+    let author_events = event_set["authorEvents"]
         .as_array()
         .context("authorEvents should be an array")?;
     assert_eq!(
@@ -676,11 +615,14 @@ async fn e2e_import_books_empty_returns_error() -> Result<()> {
 
     let import_query = r#"mutation { importBooks(books: []) { id } }"#;
     let (_, response) = graphql_request(import_query, Some(&token)).await?;
-    assert!(
-        response.get("errors").is_some(),
-        "importBooks with empty list should return errors: {:?}",
-        response.get("errors")
-    );
+    assert_graphql_errors(&response, "importBooks with empty list");
+    let error_message = response["errors"]
+        .as_array()
+        .and_then(|errors| errors.first())
+        .and_then(|error| error.get("message"))
+        .and_then(|message| message.as_str())
+        .context("importBooks empty error should include a message")?;
+    assert_eq!(error_message, "books cannot be empty");
 
     Ok(())
 }

--- a/e2e/tests/graphql_restore.rs
+++ b/e2e/tests/graphql_restore.rs
@@ -30,25 +30,19 @@ async fn e2e_restore_book_reverts_to_snapshot() -> Result<()> {
         .to_owned();
 
     // Update the book
-    let update_query = format!(
-        r#"
-        mutation {{
-            updateBook(bookData: {{
-                id: "{}"
-                title: "After Update"
-                authorIds: ["{}"]
-                isbn: ""
-                read: true
-                owned: false
-                priority: 50
-                format: E_BOOK
-                store: KINDLE
-            }}) {{ id title }}
-        }}
-        "#,
-        book_id, author_id
-    );
-    graphql_request(&update_query, Some(&token)).await?;
+    update_test_book(
+        &book_id,
+        "After Update",
+        &author_id,
+        "",
+        true,
+        false,
+        50,
+        "E_BOOK",
+        "KINDLE",
+        &token,
+    )
+    .await?;
 
     // Verify current title is "After Update"
     let book_query = format!(r#"{{ book(id: "{}") {{ title read }} }}"#, book_id);
@@ -65,11 +59,7 @@ async fn e2e_restore_book_reverts_to_snapshot() -> Result<()> {
         create_event_id
     );
     let (_, response) = graphql_request(&restore_query, Some(&token)).await?;
-    assert!(
-        response.get("errors").is_none(),
-        "restoreBook should not return errors: {:?}",
-        response.get("errors")
-    );
+    assert_no_graphql_errors(&response, "restoreBook");
     assert_eq!(
         response["data"]["restoreBook"]["title"].as_str(),
         Some("Before Restore"),
@@ -124,10 +114,7 @@ async fn e2e_restore_author_reverts_to_snapshot() -> Result<()> {
         author_id, updated_name
     );
     let (_, update_response) = graphql_request(&update_query, Some(&token)).await?;
-    assert!(
-        update_response.get("errors").is_none(),
-        "updateAuthor should not return errors"
-    );
+    assert_no_graphql_errors(&update_response, "updateAuthor");
     assert_eq!(
         update_response["data"]["updateAuthor"]["name"].as_str(),
         Some(updated_name.as_str()),
@@ -140,11 +127,7 @@ async fn e2e_restore_author_reverts_to_snapshot() -> Result<()> {
         create_event_id
     );
     let (_, response) = graphql_request(&restore_query, Some(&token)).await?;
-    assert!(
-        response.get("errors").is_none(),
-        "restoreAuthor should not return errors: {:?}",
-        response.get("errors")
-    );
+    assert_no_graphql_errors(&response, "restoreAuthor");
     assert_eq!(
         response["data"]["restoreAuthor"]["name"].as_str(),
         Some(original_name.as_str()),
@@ -304,6 +287,8 @@ async fn e2e_restore_mutations_reject_invalid_or_missing_event_ids() -> Result<(
         r#"mutation { restoreAuthor(eventId: "not-an-int") { id } }"#,
         r#"mutation { restoreBook(eventId: "999999999") { id } }"#,
         r#"mutation { restoreAuthor(eventId: "999999999") { id } }"#,
+        r#"mutation { restoreBook { id } }"#,
+        r#"mutation { restoreAuthor { id } }"#,
     ];
 
     for query in invalid_queries {

--- a/e2e/tests/health.rs
+++ b/e2e/tests/health.rs
@@ -5,13 +5,17 @@
 use anyhow::{Context, Result};
 use bookshelf_e2e::get_server_url;
 use reqwest::Client;
+use std::time::Duration;
 
 #[tokio::test]
 async fn e2e_health_check() -> Result<()> {
     let base_url = get_server_url()?;
     let addr = format!("{}/health", base_url);
 
-    let client = Client::new();
+    let client = Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .context("failed to build HTTP client")?;
     let res = client.get(&addr).send().await.context("request failed")?;
     assert!(res.status().is_success(), "health check should succeed");
     Ok(())

--- a/e2e/tests/me.rs
+++ b/e2e/tests/me.rs
@@ -164,7 +164,3 @@ async fn e2e_me_endpoint_response_contains_required_fields() -> Result<()> {
     assert!(!id.is_empty(), "Response 'id' field must not be empty");
     Ok(())
 }
-
-// ============================================
-// GraphQL E2E Tests
-// ============================================

--- a/src/presentation/error.rs
+++ b/src/presentation/error.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use async_graphql::{ErrorExtensionValues, ErrorExtensions};
 use thiserror::Error;
 
 use crate::use_case::error::UseCaseError;
@@ -29,5 +30,25 @@ impl From<UseCaseError> for PresentationalError {
             }
             UseCaseError::Unexpected(message) => PresentationalError::Unexpected(message),
         }
+    }
+}
+
+impl ErrorExtensions for PresentationalError {
+    fn extend(&self) -> async_graphql::Error {
+        let mut error = async_graphql::Error::new(self.to_string());
+        error.extensions = Some(ErrorExtensionValues::default());
+        error = error.extend_with(|_, extensions| {
+            extensions.set(
+                "code",
+                match self {
+                    PresentationalError::NotFound(_) => "NOT_FOUND",
+                    PresentationalError::Validation(_) => "VALIDATION_ERROR",
+                    PresentationalError::Conflict(_) => "CONFLICT",
+                    PresentationalError::OtherError(_) => "OTHER_ERROR",
+                    PresentationalError::Unexpected(_) => "UNEXPECTED_ERROR",
+                },
+            );
+        });
+        error
     }
 }

--- a/src/use_case/interactor/user.rs
+++ b/src/use_case/interactor/user.rs
@@ -25,6 +25,12 @@ where
 {
     async fn register_user(&self, user_id: &str) -> Result<UserDto, UseCaseError> {
         let user_id = UserId::new(user_id.to_string())?;
+        if self.user_repository.find_by_id(&user_id).await?.is_some() {
+            return Err(UseCaseError::Conflict(format!(
+                r#"user "{}" already exists"#,
+                user_id.as_str()
+            )));
+        }
         let user = DomainUser::new(user_id);
         self.user_repository.create(&user).await?;
         Ok(UserDto::new(user.id.into_string()))
@@ -47,6 +53,10 @@ mod tests {
     async fn register_user_success() {
         // Given
         let mut user_repository = MockUserRepository::new();
+        user_repository
+            .expect_find_by_id()
+            .with(always())
+            .returning(|_| Ok(None));
         user_repository
             .expect_create()
             .with(always())
@@ -73,5 +83,23 @@ mod tests {
 
         // Then
         assert!(matches!(result, Err(UseCaseError::Validation(_))));
+    }
+
+    #[tokio::test]
+    async fn register_user_fails_when_user_already_exists() {
+        // Given
+        let mut user_repository = MockUserRepository::new();
+        user_repository
+            .expect_find_by_id()
+            .with(always())
+            .returning(|id| Ok(Some(crate::domain::entity::user::User::new(id.clone()))));
+
+        let interactor = RegisterUserInteractor::new(user_repository);
+
+        // When
+        let result = interactor.register_user("user1").await;
+
+        // Then
+        assert!(matches!(result, Err(UseCaseError::Conflict(_))));
     }
 }


### PR DESCRIPTION
## What changed
- Refines the e2e split work and folds in review feedback across the repository, transaction, and use-case layers.
- Updates E2E tests for authors, books, import, restore, history, health, and me flows.
- Adjusts event-recording documentation and removes the no-longer-needed plan artifact.

## Why
- The previous split surfaced mismatches around transaction-owned user identity handling and repository/event behavior.
- The code now aligns the domain and infrastructure layers with the updated event-recording flow.

## Impact
- E2E coverage now matches the current workflow-focused test layout.
- Author/book/event operations use the revised transaction and repository semantics.
- Error handling includes the new failure cases needed by the updated flow.

## Validation
- Not rerun in this publish step; the branch was reviewed locally before publication.