### PR TITLE
Fix duplicate Rust Renovate updates

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -4,16 +4,6 @@
     "config:best-practices",
   ],
   "minimumReleaseAge": "3 days",
-  "customManagers": [
-    {
-      "customType": "regex",
-      "managerFilePatterns": ["/(^|/)rust-toolchain(\\.toml)?$/"],
-      "matchStrings": ["channel\\s*=\\s*\"(?<currentValue>\\d+\\.\\d+\\.\\d+)\""],
-      "depNameTemplate": "rust",
-      "packageNameTemplate": "rust-lang/rust",
-      "datasourceTemplate": "github-releases",
-    },
-  ],
   "packageRules": [
     {
       // Group minor/patch updates by manager (e.g. npm, github-actions).
@@ -40,7 +30,7 @@
     {
       // Keep rust-toolchain.toml and Dockerfile rust base image in sync
       "matchDepNames": ["rust"],
-      "matchManagers": ["custom.regex", "dockerfile"],
+      "matchManagers": ["rust-toolchain", "dockerfile"],
       "minimumReleaseAge": null,
       "groupName": "rust version"
     },


### PR DESCRIPTION
## Summary

Fix duplicate Renovate PRs for Rust patch updates by removing the custom regex manager for `rust-toolchain.toml`.

Renovate now uses its native `rust-toolchain` manager for `rust-toolchain.toml` and groups it with Dockerfile Rust image updates under `rust version`.

## Root Cause

`rust-toolchain.toml` was detected twice: once by the custom regex manager and once by Renovate's native Rust toolchain manager. This produced separate PRs for the same Rust version bump.

## Validation

- `renovate-config-validator`
- `cargo fmt --check`
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo test --locked`
