### PR TITLE
Return event set IDs from mutations

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,9 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: hiterm/bookshelf
-          ref: main
+          # Temporary compatibility check; restore the following ref when complete.
+          # ref: main
+          ref: fix/mutation-payload-compatibility
           path: bookshelf-src
           persist-credentials: false
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -92,7 +92,9 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: hiterm/bookshelf
-          ref: main
+          # Temporary compatibility check; restore the following ref when complete.
+          # ref: main
+          ref: fix/mutation-payload-compatibility
           path: bookshelf-src
           persist-credentials: false
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9

--- a/docs/architecture/event-recording.md
+++ b/docs/architecture/event-recording.md
@@ -23,15 +23,16 @@ the user from the transaction opened by `begin`; callers do not pass a second
 repositories (e.g. the bulk import composes `BookRepository` and
 `AuthorRepository`) inside one transaction.
 
-The only event concept that crosses into the use-case layer is the choice of
-`EventSetOperation` passed to `begin`. Everything else about event recording
-remains exclusively in the infrastructure layer.
+The use-case layer knows two event concepts: the `EventSetOperation` passed
+to `begin`, and the generated `event_set.id` exposed by the transaction so
+mutation results can return an `eventSetId` after a successful commit. Event
+row creation and persistence details remain in the infrastructure layer.
 
 ## Infrastructure responsibilities
 
 - `PgTransactionManager::begin` generates the `event_set` UUID, binds the
-  transaction to the user, and inserts the single `event_set` row (the one
-  place `event_set` rows are created).
+  transaction to the user, exposes that id on the transaction, and inserts the
+  single `event_set` row (the one place `event_set` rows are created).
 - Each mutating `Pg*` repository method reads `tx.user_id()` for row ownership,
   reads `tx.event_set_id()` for event recording, and inserts the per-event
   `<entity>_event` rows. Domain repository traits expose only an associated

--- a/e2e/src/lib.rs
+++ b/e2e/src/lib.rs
@@ -81,7 +81,10 @@ pub async fn graphql_request(query: &str, token: Option<&str>) -> Result<(u16, s
 }
 
 pub async fn delete_test_author(author_id: &str, token: &str) -> Result<()> {
-    let query = format!(r#"mutation {{ deleteAuthor(authorId: "{}") }}"#, author_id);
+    let query = format!(
+        r#"mutation {{ deleteAuthor(authorId: "{}") {{ authorId }} }}"#,
+        author_id
+    );
     let (status, response) = graphql_request(&query, Some(token)).await?;
 
     if status != 200 {
@@ -97,9 +100,9 @@ pub async fn delete_test_author(author_id: &str, token: &str) -> Result<()> {
         .get("deleteAuthor")
         .context("deleteAuthor field must exist")?;
 
-    let delete_result_str = delete_result
+    let delete_result_str = delete_result["authorId"]
         .as_str()
-        .context("deleteAuthor result should be a string")?;
+        .context("deleteAuthor authorId should be a string")?;
 
     assert_eq!(
         delete_result_str, author_id,
@@ -110,7 +113,10 @@ pub async fn delete_test_author(author_id: &str, token: &str) -> Result<()> {
 }
 
 pub async fn delete_test_book(book_id: &str, token: &str) -> Result<()> {
-    let query = format!(r#"mutation {{ deleteBook(bookId: "{}") }}"#, book_id);
+    let query = format!(
+        r#"mutation {{ deleteBook(bookId: "{}") {{ bookId }} }}"#,
+        book_id
+    );
     let (status, response) = graphql_request(&query, Some(token)).await?;
 
     if status != 200 {
@@ -126,9 +132,9 @@ pub async fn delete_test_book(book_id: &str, token: &str) -> Result<()> {
         .get("deleteBook")
         .context("deleteBook field must exist")?;
 
-    let delete_result_str = delete_result
+    let delete_result_str = delete_result["bookId"]
         .as_str()
-        .context("deleteResult should be a string")?;
+        .context("deleteBook bookId should be a string")?;
 
     assert_eq!(
         delete_result_str, book_id,
@@ -176,11 +182,11 @@ pub async fn create_test_user() -> Result<(String, String)> {
 
 pub async fn create_test_author(name: &str, token: &str) -> Result<String> {
     let query = format!(
-        r#"mutation {{ createAuthor(authorData: {{ name: "{}" }}) {{ id }} }}"#,
+        r#"mutation {{ createAuthor(authorData: {{ name: "{}" }}) {{ author {{ id }} }} }}"#,
         name
     );
     let (_, response) = graphql_request(&query, Some(token)).await?;
-    let id = response["data"]["createAuthor"]["id"]
+    let id = response["data"]["createAuthor"]["author"]["id"]
         .as_str()
         .context("createAuthor id should be a string")?
         .to_owned();
@@ -200,13 +206,13 @@ pub async fn create_test_book(title: &str, author_id: &str, token: &str) -> Resu
                 priority: 50
                 format: E_BOOK
                 store: KINDLE
-            }}) {{ id }}
+            }}) {{ book {{ id }} }}
         }}
         "#,
         title, author_id
     );
     let (_, response) = graphql_request(&query, Some(token)).await?;
-    let id = response["data"]["createBook"]["id"]
+    let id = response["data"]["createBook"]["book"]["id"]
         .as_str()
         .context("createBook id should be a string")?
         .to_owned();

--- a/e2e/tests/graphql_authors.rs
+++ b/e2e/tests/graphql_authors.rs
@@ -44,7 +44,7 @@ async fn e2e_graphql_create_author() -> Result<()> {
     let random_name = format!("Test Author {}", uuid::Uuid::new_v4());
 
     let query = format!(
-        r#"mutation {{ createAuthor(authorData: {{ name: "{}" }}) {{ id name }} }}"#,
+        r#"mutation {{ createAuthor(authorData: {{ name: "{}" }}) {{ author {{ id name }} eventSetId }} }}"#,
         random_name
     );
     let (_, response) = graphql_request(&query, Some(&token)).await?;
@@ -52,7 +52,9 @@ async fn e2e_graphql_create_author() -> Result<()> {
     let data = response.get("data").context("data field must exist")?;
     let create_result = data
         .get("createAuthor")
-        .context("createAuthor field must exist")?;
+        .context("createAuthor field must exist")?
+        .get("author")
+        .context("author field must exist")?;
     let author_id = create_result
         .get("id")
         .context("id field must exist")?
@@ -119,7 +121,10 @@ async fn e2e_graphql_delete_author_with_associated_books_fails() -> Result<()> {
     let book_id = create_test_book("Book Blocking Author Delete", &author_id, &token).await?;
 
     // Attempt to delete the author — must fail
-    let delete_author_query = format!(r#"mutation {{ deleteAuthor(authorId: "{}") }}"#, author_id);
+    let delete_author_query = format!(
+        r#"mutation {{ deleteAuthor(authorId: "{}") {{ authorId }} }}"#,
+        author_id
+    );
     let (_, response) = graphql_request(&delete_author_query, Some(&token)).await?;
     assert!(
         response.get("errors").is_some(),
@@ -155,7 +160,7 @@ async fn e2e_graphql_update_author() -> Result<()> {
     // Update author name while the author has an associated book
     let updated_name = format!("Author After Update {}", uuid::Uuid::new_v4());
     let update_query = format!(
-        r#"mutation {{ updateAuthor(authorData: {{ id: "{}", name: "{}" }}) {{ id name }} }}"#,
+        r#"mutation {{ updateAuthor(authorData: {{ id: "{}", name: "{}" }}) {{ author {{ id name }} eventSetId }} }}"#,
         author_id, updated_name
     );
     let (_, response) = graphql_request(&update_query, Some(&token)).await?;
@@ -163,7 +168,7 @@ async fn e2e_graphql_update_author() -> Result<()> {
         response.get("errors").is_none(),
         "updateAuthor should not return errors"
     );
-    let update_result = &response["data"]["updateAuthor"];
+    let update_result = &response["data"]["updateAuthor"]["author"];
     assert_eq!(
         update_result["id"].as_str(),
         Some(author_id.as_str()),
@@ -197,7 +202,7 @@ async fn e2e_graphql_update_nonexistent_author_returns_error() -> Result<()> {
 
     let nonexistent_id = uuid::Uuid::new_v4().to_string();
     let query = format!(
-        r#"mutation {{ updateAuthor(authorData: {{ id: "{}", name: "Ghost" }}) {{ id name }} }}"#,
+        r#"mutation {{ updateAuthor(authorData: {{ id: "{}", name: "Ghost" }}) {{ author {{ id name }} eventSetId }} }}"#,
         nonexistent_id
     );
     let (_, response) = graphql_request(&query, Some(&token)).await?;
@@ -215,7 +220,7 @@ async fn e2e_graphql_delete_nonexistent_author_returns_error() -> Result<()> {
 
     let nonexistent_id = uuid::Uuid::new_v4().to_string();
     let query = format!(
-        r#"mutation {{ deleteAuthor(authorId: "{}") }}"#,
+        r#"mutation {{ deleteAuthor(authorId: "{}") {{ authorId }} }}"#,
         nonexistent_id
     );
     let (_, response) = graphql_request(&query, Some(&token)).await?;

--- a/e2e/tests/graphql_books.rs
+++ b/e2e/tests/graphql_books.rs
@@ -33,14 +33,16 @@ async fn e2e_graphql_crud_book() -> Result<()> {
     // Create author first
     let author_name = format!("Test Author for CRUD {}", uuid::Uuid::new_v4());
     let create_author_query = format!(
-        r#"mutation {{ createAuthor(authorData: {{ name: "{}" }}) {{ id }} }}"#,
+        r#"mutation {{ createAuthor(authorData: {{ name: "{}" }}) {{ author {{ id }} eventSetId }} }}"#,
         author_name
     );
     let (_, response) = graphql_request(&create_author_query, Some(&token)).await?;
     let data = response.get("data").context("data field must exist")?;
     let author_result = data
         .get("createAuthor")
-        .context("createAuthor field must exist")?;
+        .context("createAuthor field must exist")?
+        .get("author")
+        .context("author field must exist")?;
     let author_id = author_result
         .get("id")
         .context("id field must exist")?
@@ -77,13 +79,16 @@ async fn e2e_graphql_crud_book() -> Result<()> {
                 format: E_BOOK
                 store: KINDLE
             }}) {{
-                id
-                title
-                read
-                owned
-                priority
-                createdAt
-                updatedAt
+                book {{
+                    id
+                    title
+                    read
+                    owned
+                    priority
+                    createdAt
+                    updatedAt
+                }}
+                eventSetId
             }}
         }}
         "#,
@@ -93,7 +98,9 @@ async fn e2e_graphql_crud_book() -> Result<()> {
     let data = response.get("data").context("data field must exist")?;
     let create_result = data
         .get("createBook")
-        .context("createBook field must exist")?;
+        .context("createBook field must exist")?
+        .get("book")
+        .context("book field must exist")?;
     let book_id = create_result
         .get("id")
         .context("id field must exist")?
@@ -115,10 +122,13 @@ async fn e2e_graphql_crud_book() -> Result<()> {
                 format: PRINTED
                 store: KINDLE
             }}) {{
-                id
-                title
-                read
-                priority
+                book {{
+                    id
+                    title
+                    read
+                    priority
+                }}
+                eventSetId
             }}
         }}
         "#,
@@ -128,7 +138,9 @@ async fn e2e_graphql_crud_book() -> Result<()> {
     let data = response.get("data").context("data field must exist")?;
     let update_result = data
         .get("updateBook")
-        .context("updateBook field must exist")?;
+        .context("updateBook field must exist")?
+        .get("book")
+        .context("book field must exist")?;
     assert_eq!(
         update_result
             .get("title")
@@ -224,14 +236,16 @@ async fn e2e_graphql_book_by_id() -> Result<()> {
     // Create author first
     let author_name = format!("Test Author for BookByID {}", uuid::Uuid::new_v4());
     let create_author_query = format!(
-        r#"mutation {{ createAuthor(authorData: {{ name: "{}" }}) {{ id }} }}"#,
+        r#"mutation {{ createAuthor(authorData: {{ name: "{}" }}) {{ author {{ id }} eventSetId }} }}"#,
         author_name
     );
     let (_, response) = graphql_request(&create_author_query, Some(&token)).await?;
     let data = response.get("data").context("data field must exist")?;
     let author_result = data
         .get("createAuthor")
-        .context("createAuthor field must exist")?;
+        .context("createAuthor field must exist")?
+        .get("author")
+        .context("author field must exist")?;
     let author_id = author_result
         .get("id")
         .context("id field must exist")?
@@ -252,8 +266,11 @@ async fn e2e_graphql_book_by_id() -> Result<()> {
                 format: E_BOOK
                 store: KINDLE
             }}) {{
-                id
-                title
+                book {{
+                    id
+                    title
+                }}
+                eventSetId
             }}
         }}
         "#,
@@ -263,7 +280,9 @@ async fn e2e_graphql_book_by_id() -> Result<()> {
     let data = response.get("data").context("data field must exist")?;
     let create_result = data
         .get("createBook")
-        .context("createBook field must exist")?;
+        .context("createBook field must exist")?
+        .get("book")
+        .context("book field must exist")?;
     let book_id = create_result
         .get("id")
         .context("id field must exist")?
@@ -325,7 +344,7 @@ async fn e2e_graphql_create_book_without_auth() -> Result<()> {
                 format: E_BOOK
                 store: KINDLE
             }) {
-                id
+                book { id }
             }
         }
     "#;
@@ -352,7 +371,7 @@ async fn e2e_graphql_update_nonexistent_book_returns_error() -> Result<()> {
                 priority: 50
                 format: E_BOOK
                 store: KINDLE
-            }}) {{ id title }}
+            }}) {{ book {{ id title }} eventSetId }}
         }}
         "#,
         nonexistent_id
@@ -367,7 +386,10 @@ async fn e2e_graphql_update_nonexistent_book_returns_error() -> Result<()> {
 async fn e2e_graphql_delete_nonexistent_book_returns_error() -> Result<()> {
     let (_user_id, token) = create_test_user().await?;
     let nonexistent_id = uuid::Uuid::new_v4().to_string();
-    let query = format!(r#"mutation {{ deleteBook(bookId: "{}") }}"#, nonexistent_id);
+    let query = format!(
+        r#"mutation {{ deleteBook(bookId: "{}") {{ bookId }} }}"#,
+        nonexistent_id
+    );
     let (_, response) = graphql_request(&query, Some(&token)).await?;
     assert_graphql_errors(&response, "deleteBook for a non-existent book");
     Ok(())
@@ -431,7 +453,7 @@ async fn e2e_graphql_books_authors_are_user_isolated() -> Result<()> {
                 priority: 1
                 format: PRINTED
                 store: KINDLE
-            }}) {{ id }}
+            }}) {{ book {{ id }} eventSetId }}
         }}
         "#,
         book_id
@@ -439,18 +461,24 @@ async fn e2e_graphql_books_authors_are_user_isolated() -> Result<()> {
     let (_, response) = graphql_request(&update_book_query, Some(&other_token)).await?;
     assert_graphql_errors(&response, "other user's updateBook");
 
-    let delete_book_query = format!(r#"mutation {{ deleteBook(bookId: "{}") }}"#, book_id);
+    let delete_book_query = format!(
+        r#"mutation {{ deleteBook(bookId: "{}") {{ bookId }} }}"#,
+        book_id
+    );
     let (_, response) = graphql_request(&delete_book_query, Some(&other_token)).await?;
     assert_graphql_errors(&response, "other user's deleteBook");
 
     let update_author_query = format!(
-        r#"mutation {{ updateAuthor(authorData: {{ id: "{}", name: "Hijacked Author" }}) {{ id }} }}"#,
+        r#"mutation {{ updateAuthor(authorData: {{ id: "{}", name: "Hijacked Author" }}) {{ author {{ id }} eventSetId }} }}"#,
         author_id
     );
     let (_, response) = graphql_request(&update_author_query, Some(&other_token)).await?;
     assert_graphql_errors(&response, "other user's updateAuthor");
 
-    let delete_author_query = format!(r#"mutation {{ deleteAuthor(authorId: "{}") }}"#, author_id);
+    let delete_author_query = format!(
+        r#"mutation {{ deleteAuthor(authorId: "{}") {{ authorId }} }}"#,
+        author_id
+    );
     let (_, response) = graphql_request(&delete_author_query, Some(&other_token)).await?;
     assert_graphql_errors(&response, "other user's deleteAuthor");
 
@@ -480,7 +508,7 @@ async fn e2e_graphql_create_mutations_validate_input() -> Result<()> {
     let (_user_id, token) = create_test_user().await?;
 
     let (_, response) = graphql_request(
-        r#"mutation { createAuthor(authorData: { name: "" }) { id } }"#,
+        r#"mutation { createAuthor(authorData: { name: "" }) { author { id } } }"#,
         Some(&token),
     )
     .await?;
@@ -498,7 +526,7 @@ async fn e2e_graphql_create_mutations_validate_input() -> Result<()> {
                 priority: 50
                 format: E_BOOK
                 store: KINDLE
-            }) { id }
+            }) { book { id } eventSetId }
         }
         "#,
         r#"
@@ -512,7 +540,7 @@ async fn e2e_graphql_create_mutations_validate_input() -> Result<()> {
                 priority: 50
                 format: E_BOOK
                 store: KINDLE
-            }) { id }
+            }) { book { id } eventSetId }
         }
         "#,
         r#"
@@ -526,7 +554,7 @@ async fn e2e_graphql_create_mutations_validate_input() -> Result<()> {
                 priority: 101
                 format: E_BOOK
                 store: KINDLE
-            }) { id }
+            }) { book { id } eventSetId }
         }
         "#,
     ];

--- a/e2e/tests/graphql_history.rs
+++ b/e2e/tests/graphql_history.rs
@@ -125,7 +125,7 @@ async fn e2e_book_events_records_update_operation() -> Result<()> {
                 priority: 50
                 format: E_BOOK
                 store: KINDLE
-            }}) {{ id title }}
+            }}) {{ book {{ id title }} eventSetId }}
         }}
         "#,
         book_id, author_id
@@ -322,7 +322,7 @@ async fn e2e_author_events_records_update_operation() -> Result<()> {
 
     let updated_name = format!("Author After Update History {}", uuid::Uuid::new_v4());
     let update_query = format!(
-        r#"mutation {{ updateAuthor(authorData: {{ id: "{}", name: "{}" }}) {{ id name }} }}"#,
+        r#"mutation {{ updateAuthor(authorData: {{ id: "{}", name: "{}" }}) {{ author {{ id name }} eventSetId }} }}"#,
         author_id, updated_name
     );
     let (_, response) = graphql_request(&update_query, Some(&token)).await?;

--- a/e2e/tests/graphql_import.rs
+++ b/e2e/tests/graphql_import.rs
@@ -39,10 +39,13 @@ async fn e2e_import_books() -> Result<()> {
                     store: KINDLE
                 }
             ]) {
-                id
-                title
-                authors {
-                    name
+                eventSetId
+                books {
+                    id
+                    title
+                    authors {
+                        name
+                    }
                 }
             }
         }
@@ -54,7 +57,7 @@ async fn e2e_import_books() -> Result<()> {
         response.get("errors")
     );
 
-    let imported_books = response["data"]["importBooks"]
+    let imported_books = response["data"]["importBooks"]["books"]
         .as_array()
         .context("importBooks should return an array")?;
     assert_eq!(imported_books.len(), 2, "should import exactly 2 books");
@@ -100,15 +103,9 @@ async fn e2e_import_books() -> Result<()> {
     // Locate the single event set produced by the import via eventSets, then
     // inspect it directly. This replaces the old workaround of comparing the
     // eventSetId across separate per-book bookEvents queries.
-    let (_, response) = graphql_request(r#"{ eventSets { id operation } }"#, Some(&token)).await?;
-    let event_sets = response["data"]["eventSets"]
-        .as_array()
-        .context("eventSets should be an array")?;
-    let import_set_id = event_sets
-        .iter()
-        .find(|s| s["operation"].as_str() == Some("import_books"))
-        .and_then(|s| s["id"].as_str())
-        .context("there should be an import_books event set")?;
+    let import_set_id = response["data"]["importBooks"]["eventSetId"]
+        .as_str()
+        .context("importBooks should return eventSetId")?;
 
     // The shared event set groups both book creates and the new author create.
     let event_set_query = format!(
@@ -278,9 +275,12 @@ async fn e2e_import_books_many_entries() -> Result<()> {
         r#"
         mutation {{
             importBooks(books: [{imported_entries}]) {{
-                id
-                title
-                authors {{ name }}
+                eventSetId
+                books {{
+                    id
+                    title
+                    authors {{ name }}
+                }}
             }}
         }}
         "#
@@ -292,7 +292,7 @@ async fn e2e_import_books_many_entries() -> Result<()> {
         response.get("errors")
     );
 
-    let imported_books = response["data"]["importBooks"]
+    let imported_books = response["data"]["importBooks"]["books"]
         .as_array()
         .context("importBooks should return an array")?;
     assert_eq!(
@@ -324,15 +324,9 @@ async fn e2e_import_books_many_entries() -> Result<()> {
         }));
     }
 
-    let (_, response) = graphql_request(r#"{ eventSets { id operation } }"#, Some(&token)).await?;
-    let event_sets = response["data"]["eventSets"]
-        .as_array()
-        .context("eventSets should be an array")?;
-    let import_set_id = event_sets
-        .iter()
-        .find(|s| s["operation"].as_str() == Some("import_books"))
-        .and_then(|s| s["id"].as_str())
-        .context("there should be an import_books event set")?;
+    let import_set_id = response["data"]["importBooks"]["eventSetId"]
+        .as_str()
+        .context("importBooks should return eventSetId")?;
 
     let event_set_query = format!(
         r#"{{ eventSet(id: "{}") {{
@@ -521,7 +515,7 @@ async fn e2e_import_books_rejects_more_than_max_batch() -> Result<()> {
         .collect::<Vec<_>>()
         .join(",\n");
     let import_query =
-        format!(r#"mutation {{ importBooks(books: [{imported_entries}]) {{ id }} }}"#);
+        format!(r#"mutation {{ importBooks(books: [{imported_entries}]) {{ books {{ id }} }} }}"#);
 
     let (_, response) = graphql_request(&import_query, Some(&token)).await?;
     assert_graphql_errors(&response, "importBooks above the max batch size");
@@ -578,9 +572,12 @@ async fn e2e_import_books_deduplicates_shared_new_author() -> Result<()> {
         r#"
         mutation {{
             importBooks(books: [{imported_entries}]) {{
-                id
-                title
-                authors {{ name }}
+                eventSetId
+                books {{
+                    id
+                    title
+                    authors {{ name }}
+                }}
             }}
         }}
         "#
@@ -588,7 +585,7 @@ async fn e2e_import_books_deduplicates_shared_new_author() -> Result<()> {
     let (_, response) = graphql_request(&import_query, Some(&token)).await?;
     assert_no_graphql_errors(&response, "importBooks with a shared new author");
 
-    let imported_books = response["data"]["importBooks"]
+    let imported_books = response["data"]["importBooks"]["books"]
         .as_array()
         .context("importBooks should return an array")?;
     assert_eq!(imported_books.len(), titles.len());
@@ -607,11 +604,12 @@ async fn e2e_import_books_deduplicates_shared_new_author() -> Result<()> {
         })
         .collect::<Result<Vec<_>>>()?;
 
-    let (_, response) = graphql_request(
-        r#"{ authors { id name } eventSets { id operation } }"#,
-        Some(&token),
-    )
-    .await?;
+    let import_set_id = response["data"]["importBooks"]["eventSetId"]
+        .as_str()
+        .context("importBooks should return eventSetId")?
+        .to_owned();
+
+    let (_, response) = graphql_request(r#"{ authors { id name } }"#, Some(&token)).await?;
     let authors = response["data"]["authors"]
         .as_array()
         .context("authors should be an array")?;
@@ -628,13 +626,7 @@ async fn e2e_import_books_deduplicates_shared_new_author() -> Result<()> {
         .as_str()
         .context("shared author id should be a string")?;
 
-    let import_set_id = response["data"]["eventSets"]
-        .as_array()
-        .context("eventSets should be an array")?
-        .iter()
-        .find(|set| set["operation"].as_str() == Some("import_books"))
-        .and_then(|set| set["id"].as_str())
-        .context("there should be an import_books event set")?;
+    let import_set_id = import_set_id.as_str();
     let event_set_query = format!(
         r#"{{ eventSet(id: "{}") {{ bookEvents {{ bookId operation }} authorEvents {{ name operation }} }} }}"#,
         import_set_id
@@ -674,7 +666,7 @@ async fn e2e_import_books_deduplicates_shared_new_author() -> Result<()> {
 async fn e2e_import_books_empty_returns_error() -> Result<()> {
     let (_user_id, token) = create_test_user().await?;
 
-    let import_query = r#"mutation { importBooks(books: []) { id } }"#;
+    let import_query = r#"mutation { importBooks(books: []) { books { id } } }"#;
     let (_, response) = graphql_request(import_query, Some(&token)).await?;
     assert!(
         response.get("errors").is_some(),

--- a/e2e/tests/graphql_restore.rs
+++ b/e2e/tests/graphql_restore.rs
@@ -43,7 +43,7 @@ async fn e2e_restore_book_reverts_to_snapshot() -> Result<()> {
                 priority: 50
                 format: E_BOOK
                 store: KINDLE
-            }}) {{ id title }}
+            }}) {{ book {{ id title }} eventSetId }}
         }}
         "#,
         book_id, author_id
@@ -61,7 +61,7 @@ async fn e2e_restore_book_reverts_to_snapshot() -> Result<()> {
 
     // Restore to the create event state
     let restore_query = format!(
-        r#"mutation {{ restoreBook(eventId: "{}") {{ id title read }} }}"#,
+        r#"mutation {{ restoreBook(eventId: "{}") {{ book {{ id title read }} eventSetId }} }}"#,
         create_event_id
     );
     let (_, response) = graphql_request(&restore_query, Some(&token)).await?;
@@ -71,12 +71,12 @@ async fn e2e_restore_book_reverts_to_snapshot() -> Result<()> {
         response.get("errors")
     );
     assert_eq!(
-        response["data"]["restoreBook"]["title"].as_str(),
+        response["data"]["restoreBook"]["book"]["title"].as_str(),
         Some("Before Restore"),
         "restored book should have create-event title"
     );
     assert_eq!(
-        response["data"]["restoreBook"]["read"].as_bool(),
+        response["data"]["restoreBook"]["book"]["read"].as_bool(),
         Some(false),
         "restored book should have create-event read flag"
     );
@@ -120,7 +120,7 @@ async fn e2e_restore_author_reverts_to_snapshot() -> Result<()> {
     // Update the author
     let updated_name = format!("Restore Author Updated {}", uuid::Uuid::new_v4());
     let update_query = format!(
-        r#"mutation {{ updateAuthor(authorData: {{ id: "{}", name: "{}" }}) {{ id name }} }}"#,
+        r#"mutation {{ updateAuthor(authorData: {{ id: "{}", name: "{}" }}) {{ author {{ id name }} eventSetId }} }}"#,
         author_id, updated_name
     );
     let (_, update_response) = graphql_request(&update_query, Some(&token)).await?;
@@ -129,14 +129,14 @@ async fn e2e_restore_author_reverts_to_snapshot() -> Result<()> {
         "updateAuthor should not return errors"
     );
     assert_eq!(
-        update_response["data"]["updateAuthor"]["name"].as_str(),
+        update_response["data"]["updateAuthor"]["author"]["name"].as_str(),
         Some(updated_name.as_str()),
         "updateAuthor should return updated name"
     );
 
     // Restore to the create event state
     let restore_query = format!(
-        r#"mutation {{ restoreAuthor(eventId: "{}") {{ id name }} }}"#,
+        r#"mutation {{ restoreAuthor(eventId: "{}") {{ author {{ id name }} eventSetId }} }}"#,
         create_event_id
     );
     let (_, response) = graphql_request(&restore_query, Some(&token)).await?;
@@ -146,7 +146,7 @@ async fn e2e_restore_author_reverts_to_snapshot() -> Result<()> {
         response.get("errors")
     );
     assert_eq!(
-        response["data"]["restoreAuthor"]["name"].as_str(),
+        response["data"]["restoreAuthor"]["author"]["name"].as_str(),
         Some(original_name.as_str()),
         "restored author should have create-event name"
     );
@@ -192,7 +192,7 @@ async fn e2e_restore_book_records_restore_event() -> Result<()> {
 
     // Restore to the create event
     let restore_query = format!(
-        r#"mutation {{ restoreBook(eventId: "{}") {{ id title }} }}"#,
+        r#"mutation {{ restoreBook(eventId: "{}") {{ book {{ id title }} eventSetId }} }}"#,
         create_event_id
     );
     graphql_request(&restore_query, Some(&token)).await?;
@@ -256,7 +256,7 @@ async fn e2e_restore_author_records_restore_event() -> Result<()> {
 
     // Restore to the create event
     let restore_query = format!(
-        r#"mutation {{ restoreAuthor(eventId: "{}") {{ id name }} }}"#,
+        r#"mutation {{ restoreAuthor(eventId: "{}") {{ author {{ id name }} eventSetId }} }}"#,
         create_event_id
     );
     graphql_request(&restore_query, Some(&token)).await?;
@@ -300,10 +300,10 @@ async fn e2e_restore_mutations_reject_invalid_or_missing_event_ids() -> Result<(
     let (_user_id, token) = create_test_user().await?;
 
     let invalid_queries = [
-        r#"mutation { restoreBook(eventId: "not-an-int") { id } }"#,
-        r#"mutation { restoreAuthor(eventId: "not-an-int") { id } }"#,
-        r#"mutation { restoreBook(eventId: "999999999") { id } }"#,
-        r#"mutation { restoreAuthor(eventId: "999999999") { id } }"#,
+        r#"mutation { restoreBook(eventId: "not-an-int") { book { id } } }"#,
+        r#"mutation { restoreAuthor(eventId: "not-an-int") { author { id } } }"#,
+        r#"mutation { restoreBook(eventId: "999999999") { book { id } } }"#,
+        r#"mutation { restoreAuthor(eventId: "999999999") { author { id } } }"#,
     ];
 
     for query in invalid_queries {
@@ -345,14 +345,14 @@ async fn e2e_restore_mutations_are_user_isolated() -> Result<()> {
         .to_owned();
 
     let restore_book_query = format!(
-        r#"mutation {{ restoreBook(eventId: "{}") {{ id }} }}"#,
+        r#"mutation {{ restoreBook(eventId: "{}") {{ book {{ id }} eventSetId }} }}"#,
         book_event_id
     );
     let (_, response) = graphql_request(&restore_book_query, Some(&other_token)).await?;
     assert_graphql_errors(&response, "other user's restoreBook");
 
     let restore_author_query = format!(
-        r#"mutation {{ restoreAuthor(eventId: "{}") {{ id }} }}"#,
+        r#"mutation {{ restoreAuthor(eventId: "{}") {{ author {{ id }} eventSetId }} }}"#,
         author_event_id
     );
     let (_, response) = graphql_request(&restore_author_query, Some(&other_token)).await?;

--- a/schema.graphql
+++ b/schema.graphql
@@ -16,6 +16,11 @@ type AuthorEventEntry {
 	extra: JSON
 }
 
+type AuthorMutationPayload {
+	author: Author!
+	eventSetId: ID!
+}
+
 type Book {
 	id: String!
 	title: String!
@@ -55,6 +60,11 @@ enum BookFormat {
 	UNKNOWN
 }
 
+type BookMutationPayload {
+	book: Book!
+	eventSetId: ID!
+}
+
 enum BookStore {
 	KINDLE
 	UNKNOWN
@@ -73,6 +83,16 @@ input CreateBookInput {
 	priority: Int!
 	format: BookFormat!
 	store: BookStore!
+}
+
+type DeleteAuthorPayload {
+	authorId: ID!
+	eventSetId: ID!
+}
+
+type DeleteBookPayload {
+	bookId: ID!
+	eventSetId: ID!
 }
 
 type EventSetDetail {
@@ -124,6 +144,11 @@ input ImportBookInput {
 	store: BookStore!
 }
 
+type ImportBooksPayload {
+	books: [Book!]!
+	eventSetId: ID!
+}
+
 """
 A scalar that can represent any JSON value.
 """
@@ -131,18 +156,18 @@ scalar JSON
 
 type Mutation {
 	registerUser: User!
-	createBook(bookData: CreateBookInput!): Book!
-	updateBook(bookData: UpdateBookInput!): Book!
-	deleteBook(bookId: ID!): String!
-	createAuthor(authorData: CreateAuthorInput!): Author!
-	updateAuthor(authorData: UpdateAuthorInput!): Author!
-	deleteAuthor(authorId: ID!): String!
-	restoreBook(eventId: ID!): Book
-	restoreAuthor(eventId: ID!): Author
+	createBook(bookData: CreateBookInput!): BookMutationPayload!
+	updateBook(bookData: UpdateBookInput!): BookMutationPayload!
+	deleteBook(bookId: ID!): DeleteBookPayload!
+	createAuthor(authorData: CreateAuthorInput!): AuthorMutationPayload!
+	updateAuthor(authorData: UpdateAuthorInput!): AuthorMutationPayload!
+	deleteAuthor(authorId: ID!): DeleteAuthorPayload!
+	restoreBook(eventId: ID!): RestoreBookPayload!
+	restoreAuthor(eventId: ID!): RestoreAuthorPayload!
 	"""
 	Imports multiple books. Creates authors if they do not exist.
 	"""
-	importBooks(books: [ImportBookInput!]!): [Book!]!
+	importBooks(books: [ImportBookInput!]!): ImportBooksPayload!
 }
 
 type Query {
@@ -169,6 +194,16 @@ type Query {
 	Returns a single event set with nested events, or null if not found.
 	"""
 	eventSet(id: ID!): EventSetDetail
+}
+
+type RestoreAuthorPayload {
+	author: Author
+	eventSetId: ID!
+}
+
+type RestoreBookPayload {
+	book: Book
+	eventSetId: ID!
 }
 
 input UpdateAuthorInput {

--- a/schema.graphql
+++ b/schema.graphql
@@ -19,6 +19,8 @@ type AuthorEventEntry {
 type AuthorMutationPayload {
 	author: Author!
 	eventSetId: ID!
+	id: ID!
+	name: String!
 }
 
 type Book {
@@ -63,6 +65,16 @@ enum BookFormat {
 type BookMutationPayload {
 	book: Book!
 	eventSetId: ID!
+	id: String!
+	title: String!
+	isbn: String!
+	read: Boolean!
+	owned: Boolean!
+	priority: Int!
+	format: BookFormat!
+	store: BookStore!
+	createdAt: Int!
+	updatedAt: Int!
 }
 
 enum BookStore {

--- a/schema.graphql
+++ b/schema.graphql
@@ -100,11 +100,13 @@ input CreateBookInput {
 type DeleteAuthorPayload {
 	authorId: ID!
 	eventSetId: ID!
+	id: ID!
 }
 
 type DeleteBookPayload {
 	bookId: ID!
 	eventSetId: ID!
+	id: ID!
 }
 
 type EventSetDetail {

--- a/src/domain/repository/transaction.rs
+++ b/src/domain/repository/transaction.rs
@@ -1,16 +1,28 @@
 use async_trait::async_trait;
 use mockall::automock;
 
+use uuid::Uuid;
+
 use crate::domain::{
     entity::{event::EventSetOperation, user::UserId},
     error::DomainError,
 };
 
+pub trait TransactionEventSet {
+    fn event_set_id(&self) -> Uuid;
+}
+
+impl TransactionEventSet for () {
+    fn event_set_id(&self) -> Uuid {
+        Uuid::nil()
+    }
+}
+
 #[automock(type Transaction = ();)]
 #[async_trait]
 pub trait TransactionManager: Send + Sync + 'static {
     // `Send` is required so the async_trait-generated futures are `Send`.
-    type Transaction: Send;
+    type Transaction: Send + TransactionEventSet;
 
     async fn begin(
         &self,

--- a/src/infrastructure/transaction.rs
+++ b/src/infrastructure/transaction.rs
@@ -5,7 +5,7 @@ use uuid::Uuid;
 use crate::domain::{
     entity::{event::EventSetOperation, user::UserId},
     error::DomainError,
-    repository::transaction::TransactionManager,
+    repository::transaction::{TransactionEventSet, TransactionManager},
 };
 
 /// A PostgreSQL transaction carrying the `event_set` id generated when the
@@ -19,9 +19,15 @@ pub struct PgTransaction {
     user_id: UserId,
 }
 
+impl TransactionEventSet for PgTransaction {
+    fn event_set_id(&self) -> Uuid {
+        self.event_set_id
+    }
+}
+
 impl PgTransaction {
     pub fn event_set_id(&self) -> Uuid {
-        self.event_set_id
+        <Self as TransactionEventSet>::event_set_id(self)
     }
 
     /// Returns the user passed to `begin`, which is the single source of

--- a/src/presentation/graphql/mutation.rs
+++ b/src/presentation/graphql/mutation.rs
@@ -79,8 +79,10 @@ where
             .delete_book(&claims.sub, book_id.as_str())
             .await?;
 
+        let book_id = ID(result.value);
         Ok(DeleteBookPayload {
-            book_id: ID(result.value),
+            book_id: book_id.clone(),
+            id: book_id,
             event_set_id: ID(result.event_set_id),
         })
     }
@@ -127,8 +129,10 @@ where
             .mutation_use_case
             .delete_author(&claims.sub, author_id.as_str())
             .await?;
+        let author_id = ID(result.value);
         Ok(DeleteAuthorPayload {
-            author_id: ID(result.value),
+            author_id: author_id.clone(),
+            id: author_id,
             event_set_id: ID(result.event_set_id),
         })
     }

--- a/src/presentation/graphql/mutation.rs
+++ b/src/presentation/graphql/mutation.rs
@@ -45,10 +45,10 @@ where
             .create_book(&claims.sub, book_data.into())
             .await?;
 
-        Ok(BookMutationPayload {
-            book: book.value.into(),
-            event_set_id: ID(book.event_set_id),
-        })
+        Ok(BookMutationPayload::new(
+            book.value.into(),
+            ID(book.event_set_id),
+        ))
     }
 
     async fn update_book(
@@ -62,10 +62,10 @@ where
             .update_book(&claims.sub, book_data.into())
             .await?;
 
-        Ok(BookMutationPayload {
-            book: book.value.into(),
-            event_set_id: ID(book.event_set_id),
-        })
+        Ok(BookMutationPayload::new(
+            book.value.into(),
+            ID(book.event_set_id),
+        ))
     }
 
     async fn delete_book(
@@ -95,10 +95,10 @@ where
             .mutation_use_case
             .create_author(&claims.sub, author_data.into())
             .await?;
-        Ok(AuthorMutationPayload {
-            author: author.value.into(),
-            event_set_id: ID(author.event_set_id),
-        })
+        Ok(AuthorMutationPayload::new(
+            author.value.into(),
+            ID(author.event_set_id),
+        ))
     }
 
     async fn update_author(
@@ -111,10 +111,10 @@ where
             .mutation_use_case
             .update_author(&claims.sub, author_data.into())
             .await?;
-        Ok(AuthorMutationPayload {
-            author: author.value.into(),
-            event_set_id: ID(author.event_set_id),
-        })
+        Ok(AuthorMutationPayload::new(
+            author.value.into(),
+            ID(author.event_set_id),
+        ))
     }
 
     async fn delete_author(

--- a/src/presentation/graphql/mutation.rs
+++ b/src/presentation/graphql/mutation.rs
@@ -8,8 +8,9 @@ use crate::{
 };
 
 use super::object::{
-    Author, Book, CreateAuthorInput, CreateBookInput, ImportBookInput, UpdateAuthorInput,
-    UpdateBookInput, User,
+    Author, AuthorMutationPayload, Book, BookMutationPayload, CreateAuthorInput, CreateBookInput,
+    DeleteAuthorPayload, DeleteBookPayload, ImportBookInput, ImportBooksPayload,
+    RestoreAuthorPayload, RestoreBookPayload, UpdateAuthorInput, UpdateBookInput, User,
 };
 
 pub struct Mutation<MUC> {
@@ -37,86 +38,106 @@ where
         &self,
         ctx: &Context<'_>,
         book_data: CreateBookInput,
-    ) -> Result<Book, PresentationalError> {
+    ) -> Result<BookMutationPayload, PresentationalError> {
         let claims = get_claims(ctx)?;
         let book = self
             .mutation_use_case
             .create_book(&claims.sub, book_data.into())
             .await?;
 
-        Ok(book.into())
+        Ok(BookMutationPayload {
+            book: book.value.into(),
+            event_set_id: ID(book.event_set_id),
+        })
     }
 
     async fn update_book(
         &self,
         ctx: &Context<'_>,
         book_data: UpdateBookInput,
-    ) -> Result<Book, PresentationalError> {
+    ) -> Result<BookMutationPayload, PresentationalError> {
         let claims = get_claims(ctx)?;
         let book = self
             .mutation_use_case
             .update_book(&claims.sub, book_data.into())
             .await?;
 
-        Ok(book.into())
+        Ok(BookMutationPayload {
+            book: book.value.into(),
+            event_set_id: ID(book.event_set_id),
+        })
     }
 
     async fn delete_book(
         &self,
         ctx: &Context<'_>,
         book_id: ID,
-    ) -> Result<String, PresentationalError> {
+    ) -> Result<DeleteBookPayload, PresentationalError> {
         let claims = get_claims(ctx)?;
-        self.mutation_use_case
+        let result = self
+            .mutation_use_case
             .delete_book(&claims.sub, book_id.as_str())
             .await?;
 
-        Ok(book_id.to_string())
+        Ok(DeleteBookPayload {
+            book_id: ID(result.value),
+            event_set_id: ID(result.event_set_id),
+        })
     }
 
     async fn create_author(
         &self,
         ctx: &Context<'_>,
         author_data: CreateAuthorInput,
-    ) -> Result<Author, PresentationalError> {
+    ) -> Result<AuthorMutationPayload, PresentationalError> {
         let claims = get_claims(ctx)?;
         let author = self
             .mutation_use_case
             .create_author(&claims.sub, author_data.into())
             .await?;
-        Ok(author.into())
+        Ok(AuthorMutationPayload {
+            author: author.value.into(),
+            event_set_id: ID(author.event_set_id),
+        })
     }
 
     async fn update_author(
         &self,
         ctx: &Context<'_>,
         author_data: UpdateAuthorInput,
-    ) -> Result<Author, PresentationalError> {
+    ) -> Result<AuthorMutationPayload, PresentationalError> {
         let claims = get_claims(ctx)?;
         let author = self
             .mutation_use_case
             .update_author(&claims.sub, author_data.into())
             .await?;
-        Ok(author.into())
+        Ok(AuthorMutationPayload {
+            author: author.value.into(),
+            event_set_id: ID(author.event_set_id),
+        })
     }
 
     async fn delete_author(
         &self,
         ctx: &Context<'_>,
         author_id: ID,
-    ) -> Result<String, PresentationalError> {
+    ) -> Result<DeleteAuthorPayload, PresentationalError> {
         let claims = get_claims(ctx)?;
-        self.mutation_use_case
+        let result = self
+            .mutation_use_case
             .delete_author(&claims.sub, author_id.as_str())
             .await?;
-        Ok(author_id.to_string())
+        Ok(DeleteAuthorPayload {
+            author_id: ID(result.value),
+            event_set_id: ID(result.event_set_id),
+        })
     }
 
     async fn restore_book(
         &self,
         ctx: &Context<'_>,
         event_id: ID,
-    ) -> Result<Option<Book>, PresentationalError> {
+    ) -> Result<RestoreBookPayload, PresentationalError> {
         let claims = get_claims(ctx)?;
         let eid: i64 = event_id.parse().map_err(|_| {
             PresentationalError::OtherError(std::sync::Arc::new(anyhow::anyhow!(
@@ -127,14 +148,17 @@ where
             .mutation_use_case
             .restore_book(&claims.sub, eid)
             .await?;
-        Ok(book.map(Book::from))
+        Ok(RestoreBookPayload {
+            book: book.value.map(Book::from),
+            event_set_id: ID(book.event_set_id),
+        })
     }
 
     async fn restore_author(
         &self,
         ctx: &Context<'_>,
         event_id: ID,
-    ) -> Result<Option<Author>, PresentationalError> {
+    ) -> Result<RestoreAuthorPayload, PresentationalError> {
         let claims = get_claims(ctx)?;
         let eid: i64 = event_id.parse().map_err(|_| {
             PresentationalError::OtherError(std::sync::Arc::new(anyhow::anyhow!(
@@ -145,7 +169,10 @@ where
             .mutation_use_case
             .restore_author(&claims.sub, eid)
             .await?;
-        Ok(author.map(Author::from))
+        Ok(RestoreAuthorPayload {
+            author: author.value.map(Author::from),
+            event_set_id: ID(author.event_set_id),
+        })
     }
 
     /// Imports multiple books. Creates authors if they do not exist.
@@ -153,13 +180,16 @@ where
         &self,
         ctx: &Context<'_>,
         books: Vec<ImportBookInput>,
-    ) -> Result<Vec<Book>, PresentationalError> {
+    ) -> Result<ImportBooksPayload, PresentationalError> {
         let claims = get_claims(ctx)?;
         let books = self
             .mutation_use_case
             .import_books(&claims.sub, books.into_iter().map(Into::into).collect())
             .await?;
-        Ok(books.into_iter().map(Book::from).collect())
+        Ok(ImportBooksPayload {
+            books: books.value.into_iter().map(Book::from).collect(),
+            event_set_id: ID(books.event_set_id),
+        })
     }
 }
 

--- a/src/presentation/graphql/object.rs
+++ b/src/presentation/graphql/object.rs
@@ -436,3 +436,45 @@ impl From<EventSetDetailDto> for EventSetDetail {
         }
     }
 }
+
+#[derive(SimpleObject)]
+pub struct BookMutationPayload {
+    pub book: Book,
+    pub event_set_id: ID,
+}
+
+#[derive(SimpleObject)]
+pub struct AuthorMutationPayload {
+    pub author: Author,
+    pub event_set_id: ID,
+}
+
+#[derive(SimpleObject)]
+pub struct DeleteBookPayload {
+    pub book_id: ID,
+    pub event_set_id: ID,
+}
+
+#[derive(SimpleObject)]
+pub struct DeleteAuthorPayload {
+    pub author_id: ID,
+    pub event_set_id: ID,
+}
+
+#[derive(SimpleObject)]
+pub struct ImportBooksPayload {
+    pub books: Vec<Book>,
+    pub event_set_id: ID,
+}
+
+#[derive(SimpleObject)]
+pub struct RestoreBookPayload {
+    pub book: Option<Book>,
+    pub event_set_id: ID,
+}
+
+#[derive(SimpleObject)]
+pub struct RestoreAuthorPayload {
+    pub author: Option<Author>,
+    pub event_set_id: ID,
+}

--- a/src/presentation/graphql/object.rs
+++ b/src/presentation/graphql/object.rs
@@ -495,12 +495,14 @@ impl AuthorMutationPayload {
 pub struct DeleteBookPayload {
     pub book_id: ID,
     pub event_set_id: ID,
+    pub id: ID,
 }
 
 #[derive(SimpleObject)]
 pub struct DeleteAuthorPayload {
     pub author_id: ID,
     pub event_set_id: ID,
+    pub id: ID,
 }
 
 #[derive(SimpleObject)]

--- a/src/presentation/graphql/object.rs
+++ b/src/presentation/graphql/object.rs
@@ -441,12 +441,54 @@ impl From<EventSetDetailDto> for EventSetDetail {
 pub struct BookMutationPayload {
     pub book: Book,
     pub event_set_id: ID,
+    pub id: String,
+    pub title: String,
+    pub isbn: String,
+    pub read: bool,
+    pub owned: bool,
+    pub priority: i32,
+    pub format: BookFormat,
+    pub store: BookStore,
+    pub created_at: i64,
+    pub updated_at: i64,
+}
+
+impl BookMutationPayload {
+    pub fn new(book: Book, event_set_id: ID) -> Self {
+        Self {
+            id: book.id.clone(),
+            title: book.title.clone(),
+            isbn: book.isbn.clone(),
+            read: book.read,
+            owned: book.owned,
+            priority: book.priority,
+            format: book.format,
+            store: book.store,
+            created_at: book.created_at,
+            updated_at: book.updated_at,
+            book,
+            event_set_id,
+        }
+    }
 }
 
 #[derive(SimpleObject)]
 pub struct AuthorMutationPayload {
     pub author: Author,
     pub event_set_id: ID,
+    pub id: ID,
+    pub name: String,
+}
+
+impl AuthorMutationPayload {
+    pub fn new(author: Author, event_set_id: ID) -> Self {
+        Self {
+            id: author.id.clone(),
+            name: author.name.clone(),
+            author,
+            event_set_id,
+        }
+    }
 }
 
 #[derive(SimpleObject)]

--- a/src/use_case/dto.rs
+++ b/src/use_case/dto.rs
@@ -2,4 +2,5 @@ pub mod author;
 pub mod book;
 pub mod event;
 pub mod event_set;
+pub mod mutation;
 pub mod user;

--- a/src/use_case/dto/mutation.rs
+++ b/src/use_case/dto/mutation.rs
@@ -1,0 +1,32 @@
+use super::{author::AuthorDto, book::BookDto};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MutationResultDto<T> {
+    pub value: T,
+    pub event_set_id: String,
+}
+
+impl<T> MutationResultDto<T> {
+    pub fn new(value: T, event_set_id: String) -> Self {
+        Self {
+            value,
+            event_set_id,
+        }
+    }
+}
+
+impl<T> std::ops::Deref for MutationResultDto<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.value
+    }
+}
+
+pub type BookMutationResultDto = MutationResultDto<BookDto>;
+pub type AuthorMutationResultDto = MutationResultDto<AuthorDto>;
+pub type DeleteBookResultDto = MutationResultDto<String>;
+pub type DeleteAuthorResultDto = MutationResultDto<String>;
+pub type ImportBooksResultDto = MutationResultDto<Vec<BookDto>>;
+pub type RestoreBookResultDto = MutationResultDto<Option<BookDto>>;
+pub type RestoreAuthorResultDto = MutationResultDto<Option<AuthorDto>>;

--- a/src/use_case/interactor/author.rs
+++ b/src/use_case/interactor/author.rs
@@ -8,10 +8,16 @@ use crate::{
             event::EventSetOperation,
             user::UserId,
         },
-        repository::{author_repository::AuthorRepository, transaction::TransactionManager},
+        repository::{
+            author_repository::AuthorRepository,
+            transaction::{TransactionEventSet, TransactionManager},
+        },
     },
     use_case::{
-        dto::author::{AuthorDto, CreateAuthorDto, UpdateAuthorDto},
+        dto::{
+            author::{CreateAuthorDto, UpdateAuthorDto},
+            mutation::{AuthorMutationResultDto, DeleteAuthorResultDto, MutationResultDto},
+        },
         error::UseCaseError,
         traits::author::{CreateAuthorUseCase, DeleteAuthorUseCase, UpdateAuthorUseCase},
     },
@@ -41,7 +47,7 @@ where
         &self,
         user_id: &str,
         author_data: CreateAuthorDto,
-    ) -> Result<AuthorDto, UseCaseError> {
+    ) -> Result<AuthorMutationResultDto, UseCaseError> {
         let user_id = UserId::new(user_id.to_string())?;
         let uuid = Uuid::new_v4();
         let author_id = AuthorId::new(uuid);
@@ -53,9 +59,10 @@ where
             .begin(&user_id, EventSetOperation::CreateAuthor)
             .await?;
         self.author_repository.create(&mut tx, &author).await?;
+        let event_set_id = tx.event_set_id().hyphenated().to_string();
         self.transaction_manager.commit(tx).await?;
 
-        Ok(author.into())
+        Ok(MutationResultDto::new(author.into(), event_set_id))
     }
 }
 
@@ -83,7 +90,7 @@ where
         &self,
         user_id: &str,
         author_data: UpdateAuthorDto,
-    ) -> Result<AuthorDto, UseCaseError> {
+    ) -> Result<AuthorMutationResultDto, UseCaseError> {
         let user_id = UserId::new(user_id.to_string())?;
         let author_id = AuthorId::try_from(author_data.id.as_str())?;
         let author_name = AuthorName::new(author_data.name)?;
@@ -110,9 +117,10 @@ where
         author.update(AuthorUpdate { name: author_name });
 
         self.author_repository.update(&mut tx, &author).await?;
+        let event_set_id = tx.event_set_id().hyphenated().to_string();
         self.transaction_manager.commit(tx).await?;
 
-        Ok(author.into())
+        Ok(MutationResultDto::new(author.into(), event_set_id))
     }
 }
 
@@ -136,8 +144,13 @@ where
     TM: TransactionManager,
     AR: AuthorRepository<Transaction = TM::Transaction>,
 {
-    async fn delete(&self, user_id: &str, author_id: &str) -> Result<(), UseCaseError> {
+    async fn delete(
+        &self,
+        user_id: &str,
+        author_id: &str,
+    ) -> Result<DeleteAuthorResultDto, UseCaseError> {
         let user_id = UserId::new(user_id.to_string())?;
+        let author_id_value = author_id.to_string();
         let author_id = AuthorId::try_from(author_id)?;
 
         let mut tx = self
@@ -145,9 +158,10 @@ where
             .begin(&user_id, EventSetOperation::DeleteAuthor)
             .await?;
         self.author_repository.delete(&mut tx, &author_id).await?;
+        let event_set_id = tx.event_set_id().hyphenated().to_string();
         self.transaction_manager.commit(tx).await?;
 
-        Ok(())
+        Ok(MutationResultDto::new(author_id_value, event_set_id))
     }
 }
 

--- a/src/use_case/interactor/book.rs
+++ b/src/use_case/interactor/book.rs
@@ -15,12 +15,18 @@ use crate::{
         },
         error::DomainError,
         repository::{
-            author_repository::AuthorRepository, book_repository::BookRepository,
-            transaction::TransactionManager,
+            author_repository::AuthorRepository,
+            book_repository::BookRepository,
+            transaction::{TransactionEventSet, TransactionManager},
         },
     },
     use_case::{
-        dto::book::{BookDto, CreateBookDto, ImportBookEntryDto, TimeInfo, UpdateBookDto},
+        dto::{
+            book::{BookDto, CreateBookDto, ImportBookEntryDto, TimeInfo, UpdateBookDto},
+            mutation::{
+                BookMutationResultDto, DeleteBookResultDto, ImportBooksResultDto, MutationResultDto,
+            },
+        },
         error::UseCaseError,
         traits::book::{
             CreateBookUseCase, DeleteBookUseCase, ImportBooksUseCase, UpdateBookUseCase,
@@ -70,7 +76,7 @@ where
         &self,
         user_id: &str,
         book_data: CreateBookDto,
-    ) -> Result<BookDto, UseCaseError> {
+    ) -> Result<BookMutationResultDto, UseCaseError> {
         let user_id = UserId::new(user_id.to_string())?;
         let uuid = Uuid::new_v4();
         let time_info = TimeInfo::new(OffsetDateTime::now_utc(), OffsetDateTime::now_utc());
@@ -81,9 +87,10 @@ where
             .begin(&user_id, EventSetOperation::CreateBook)
             .await?;
         self.book_repository.create(&mut tx, &book).await?;
+        let event_set_id = tx.event_set_id().hyphenated().to_string();
         self.transaction_manager.commit(tx).await?;
 
-        Ok(book.into())
+        Ok(MutationResultDto::new(book.into(), event_set_id))
     }
 }
 
@@ -111,7 +118,7 @@ where
         &self,
         user_id: &str,
         book_data: UpdateBookDto,
-    ) -> Result<BookDto, UseCaseError> {
+    ) -> Result<BookMutationResultDto, UseCaseError> {
         let user_id = UserId::new(user_id.to_string())?;
         let UpdateBookDto {
             id,
@@ -169,9 +176,10 @@ where
         book.update(update, OffsetDateTime::now_utc());
 
         self.book_repository.update(&mut tx, &book).await?;
+        let event_set_id = tx.event_set_id().hyphenated().to_string();
         self.transaction_manager.commit(tx).await?;
 
-        Ok(book.into())
+        Ok(MutationResultDto::new(book.into(), event_set_id))
     }
 }
 
@@ -195,8 +203,13 @@ where
     TM: TransactionManager,
     BR: BookRepository<Transaction = TM::Transaction>,
 {
-    async fn delete(&self, user_id: &str, book_id: &str) -> Result<(), UseCaseError> {
+    async fn delete(
+        &self,
+        user_id: &str,
+        book_id: &str,
+    ) -> Result<DeleteBookResultDto, UseCaseError> {
         let user_id = UserId::new(user_id.to_string())?;
+        let book_id_value = book_id.to_string();
         let book_id = BookId::try_from(book_id)?;
 
         let mut tx = self
@@ -204,9 +217,10 @@ where
             .begin(&user_id, EventSetOperation::DeleteBook)
             .await?;
         self.book_repository.delete(&mut tx, &book_id).await?;
+        let event_set_id = tx.event_set_id().hyphenated().to_string();
         self.transaction_manager.commit(tx).await?;
 
-        Ok(())
+        Ok(MutationResultDto::new(book_id_value, event_set_id))
     }
 }
 
@@ -237,7 +251,7 @@ where
         &self,
         user_id: &str,
         books: Vec<ImportBookEntryDto>,
-    ) -> Result<Vec<BookDto>, UseCaseError> {
+    ) -> Result<ImportBooksResultDto, UseCaseError> {
         if books.is_empty() {
             return Err(UseCaseError::Validation(
                 "books cannot be empty".to_string(),
@@ -343,9 +357,13 @@ where
             result_books.push(book);
         }
 
+        let event_set_id = tx.event_set_id().hyphenated().to_string();
         self.transaction_manager.commit(tx).await?;
 
-        Ok(result_books.into_iter().map(BookDto::from).collect())
+        Ok(MutationResultDto::new(
+            result_books.into_iter().map(BookDto::from).collect(),
+            event_set_id,
+        ))
     }
 }
 

--- a/src/use_case/interactor/event.rs
+++ b/src/use_case/interactor/event.rs
@@ -9,9 +9,11 @@ use crate::{
             user::UserId,
         },
         repository::{
-            author_event_repository::AuthorEventRepository, author_repository::AuthorRepository,
-            book_event_repository::BookEventRepository, book_repository::BookRepository,
-            transaction::TransactionManager,
+            author_event_repository::AuthorEventRepository,
+            author_repository::AuthorRepository,
+            book_event_repository::BookEventRepository,
+            book_repository::BookRepository,
+            transaction::{TransactionEventSet, TransactionManager},
         },
     },
     use_case::{
@@ -19,6 +21,7 @@ use crate::{
             author::AuthorDto,
             book::BookDto,
             event::{AuthorEventDto, BookEventDto},
+            mutation::{MutationResultDto, RestoreAuthorResultDto, RestoreBookResultDto},
         },
         error::UseCaseError,
         traits::event::{
@@ -111,7 +114,11 @@ where
     BR: BookRepository<Transaction = TM::Transaction>,
     BER: BookEventRepository,
 {
-    async fn restore(&self, user_id: &str, event_id: i64) -> Result<Option<BookDto>, UseCaseError> {
+    async fn restore(
+        &self,
+        user_id: &str,
+        event_id: i64,
+    ) -> Result<RestoreBookResultDto, UseCaseError> {
         let user_id = UserId::new(user_id.to_string())?;
         let event = self
             .book_event_repository
@@ -168,8 +175,9 @@ where
                 self.book_repository
                     .restore(&mut tx, event_id, Some(book))
                     .await?;
+                let event_set_id = tx.event_set_id().hyphenated().to_string();
                 self.transaction_manager.commit(tx).await?;
-                Ok(Some(dto))
+                Ok(MutationResultDto::new(Some(dto), event_set_id))
             }
             EventOperation::Delete => {
                 let mut tx = self
@@ -179,8 +187,9 @@ where
                 self.book_repository
                     .restore(&mut tx, event_id, None)
                     .await?;
+                let event_set_id = tx.event_set_id().hyphenated().to_string();
                 self.transaction_manager.commit(tx).await?;
-                Ok(None)
+                Ok(MutationResultDto::new(None, event_set_id))
             }
         }
     }
@@ -217,7 +226,7 @@ where
         &self,
         user_id: &str,
         event_id: i64,
-    ) -> Result<Option<AuthorDto>, UseCaseError> {
+    ) -> Result<RestoreAuthorResultDto, UseCaseError> {
         let user_id = UserId::new(user_id.to_string())?;
         let event = self
             .author_event_repository
@@ -248,8 +257,9 @@ where
                 self.author_repository
                     .restore(&mut tx, event_id, Some(author))
                     .await?;
+                let event_set_id = tx.event_set_id().hyphenated().to_string();
                 self.transaction_manager.commit(tx).await?;
-                Ok(Some(dto))
+                Ok(MutationResultDto::new(Some(dto), event_set_id))
             }
             EventOperation::Delete => {
                 let mut tx = self
@@ -259,8 +269,9 @@ where
                 self.author_repository
                     .restore(&mut tx, event_id, None)
                     .await?;
+                let event_set_id = tx.event_set_id().hyphenated().to_string();
                 self.transaction_manager.commit(tx).await?;
-                Ok(None)
+                Ok(MutationResultDto::new(None, event_set_id))
             }
         }
     }
@@ -473,7 +484,7 @@ mod tests {
         let result = interactor.restore("user1", 1).await;
 
         assert!(result.is_ok());
-        assert_eq!(result.unwrap().unwrap().title, "Old Title");
+        assert_eq!(result.unwrap().value.unwrap().title, "Old Title");
     }
 
     #[tokio::test]
@@ -565,7 +576,7 @@ mod tests {
         let result = interactor.restore("user1", 2).await;
 
         assert!(result.is_ok());
-        assert_eq!(result.unwrap().unwrap().name, "Old Name");
+        assert_eq!(result.unwrap().value.unwrap().name, "Old Name");
     }
 
     #[tokio::test]

--- a/src/use_case/interactor/mutation.rs
+++ b/src/use_case/interactor/mutation.rs
@@ -2,8 +2,13 @@ use async_trait::async_trait;
 
 use crate::use_case::{
     dto::{
-        author::{AuthorDto, CreateAuthorDto, UpdateAuthorDto},
-        book::{BookDto, CreateBookDto, ImportBookEntryDto, UpdateBookDto},
+        author::{CreateAuthorDto, UpdateAuthorDto},
+        book::{CreateBookDto, ImportBookEntryDto, UpdateBookDto},
+        mutation::{
+            AuthorMutationResultDto, BookMutationResultDto, DeleteAuthorResultDto,
+            DeleteBookResultDto, ImportBooksResultDto, RestoreAuthorResultDto,
+            RestoreBookResultDto,
+        },
         user::UserDto,
     },
     error::UseCaseError,
@@ -87,7 +92,7 @@ where
         &self,
         user_id: &str,
         book_data: CreateBookDto,
-    ) -> Result<BookDto, UseCaseError> {
+    ) -> Result<BookMutationResultDto, UseCaseError> {
         let book = self.create_book_use_case.create(user_id, book_data).await?;
         Ok(book)
     }
@@ -96,21 +101,25 @@ where
         &self,
         user_id: &str,
         book_data: UpdateBookDto,
-    ) -> Result<BookDto, UseCaseError> {
+    ) -> Result<BookMutationResultDto, UseCaseError> {
         let book = self.update_book_use_case.update(user_id, book_data).await?;
         Ok(book)
     }
 
-    async fn delete_book(&self, user_id: &str, book_id: &str) -> Result<(), UseCaseError> {
-        self.delete_book_use_case.delete(user_id, book_id).await?;
-        Ok(())
+    async fn delete_book(
+        &self,
+        user_id: &str,
+        book_id: &str,
+    ) -> Result<DeleteBookResultDto, UseCaseError> {
+        let result = self.delete_book_use_case.delete(user_id, book_id).await?;
+        Ok(result)
     }
 
     async fn create_author(
         &self,
         user_id: &str,
         author_data: CreateAuthorDto,
-    ) -> Result<AuthorDto, UseCaseError> {
+    ) -> Result<AuthorMutationResultDto, UseCaseError> {
         let author = self
             .create_author_use_case
             .create(user_id, author_data)
@@ -122,7 +131,7 @@ where
         &self,
         user_id: &str,
         author_data: UpdateAuthorDto,
-    ) -> Result<AuthorDto, UseCaseError> {
+    ) -> Result<AuthorMutationResultDto, UseCaseError> {
         let author = self
             .update_author_use_case
             .update(user_id, author_data)
@@ -130,18 +139,23 @@ where
         Ok(author)
     }
 
-    async fn delete_author(&self, user_id: &str, author_id: &str) -> Result<(), UseCaseError> {
-        self.delete_author_use_case
+    async fn delete_author(
+        &self,
+        user_id: &str,
+        author_id: &str,
+    ) -> Result<DeleteAuthorResultDto, UseCaseError> {
+        let result = self
+            .delete_author_use_case
             .delete(user_id, author_id)
             .await?;
-        Ok(())
+        Ok(result)
     }
 
     async fn restore_book(
         &self,
         user_id: &str,
         event_id: i64,
-    ) -> Result<Option<BookDto>, UseCaseError> {
+    ) -> Result<RestoreBookResultDto, UseCaseError> {
         self.restore_book_use_case.restore(user_id, event_id).await
     }
 
@@ -149,7 +163,7 @@ where
         &self,
         user_id: &str,
         event_id: i64,
-    ) -> Result<Option<AuthorDto>, UseCaseError> {
+    ) -> Result<RestoreAuthorResultDto, UseCaseError> {
         self.restore_author_use_case
             .restore(user_id, event_id)
             .await
@@ -159,7 +173,7 @@ where
         &self,
         user_id: &str,
         books: Vec<ImportBookEntryDto>,
-    ) -> Result<Vec<BookDto>, UseCaseError> {
+    ) -> Result<ImportBooksResultDto, UseCaseError> {
         self.import_books_use_case.import(user_id, books).await
     }
 }
@@ -169,6 +183,7 @@ mod tests {
     use mockall::predicate::{always, eq};
 
     use crate::common::types::{BookFormat, BookStore};
+    use crate::use_case::dto::mutation::MutationResultDto;
     use crate::use_case::error::UseCaseError;
     use crate::use_case::{
         dto::{
@@ -346,7 +361,12 @@ mod tests {
         mock_create_book
             .expect_create()
             .with(always(), always())
-            .returning(move |_, _| Ok(make_book_dto(&book_id)));
+            .returning(move |_, _| {
+                Ok(MutationResultDto::new(
+                    make_book_dto(&book_id),
+                    "event-set".to_string(),
+                ))
+            });
 
         let interactor = InteractorBuilder::new()
             .with_create_book(mock_create_book)
@@ -381,7 +401,12 @@ mod tests {
         mock_update_book
             .expect_update()
             .with(always(), always())
-            .returning(move |_, _| Ok(make_book_dto(&book_id)));
+            .returning(move |_, _| {
+                Ok(MutationResultDto::new(
+                    make_book_dto(&book_id),
+                    "event-set".to_string(),
+                ))
+            });
 
         let interactor = InteractorBuilder::new()
             .with_update_book(mock_update_book)
@@ -414,7 +439,12 @@ mod tests {
         mock_delete_book
             .expect_delete()
             .with(always(), always())
-            .returning(|_, _| Ok(()));
+            .returning(|_, _| {
+                Ok(MutationResultDto::new(
+                    "deleted-id".to_string(),
+                    "event-set".to_string(),
+                ))
+            });
 
         let interactor = InteractorBuilder::new()
             .with_delete_book(mock_delete_book)
@@ -437,10 +467,13 @@ mod tests {
             .expect_create()
             .with(always(), always())
             .returning(|_, data| {
-                Ok(AuthorDto {
-                    id: "006099b4-6c42-4ec4-8645-f6bd5b63eddc".to_string(),
-                    name: data.name.clone(),
-                })
+                Ok(MutationResultDto::new(
+                    AuthorDto {
+                        id: "006099b4-6c42-4ec4-8645-f6bd5b63eddc".to_string(),
+                        name: data.name.clone(),
+                    },
+                    "event-set".to_string(),
+                ))
             });
 
         let interactor = InteractorBuilder::new()
@@ -465,10 +498,13 @@ mod tests {
             .expect_update()
             .with(always(), always())
             .returning(|_, data| {
-                Ok(AuthorDto {
-                    id: "006099b4-6c42-4ec4-8645-f6bd5b63eddc".to_string(),
-                    name: data.name.clone(),
-                })
+                Ok(MutationResultDto::new(
+                    AuthorDto {
+                        id: "006099b4-6c42-4ec4-8645-f6bd5b63eddc".to_string(),
+                        name: data.name.clone(),
+                    },
+                    "event-set".to_string(),
+                ))
             });
 
         let interactor = InteractorBuilder::new()
@@ -495,7 +531,12 @@ mod tests {
         mock_delete_author
             .expect_delete()
             .with(always(), always())
-            .returning(|_, _| Ok(()));
+            .returning(|_, _| {
+                Ok(MutationResultDto::new(
+                    "deleted-id".to_string(),
+                    "event-set".to_string(),
+                ))
+            });
 
         let interactor = InteractorBuilder::new()
             .with_delete_author(mock_delete_author)
@@ -521,7 +562,12 @@ mod tests {
         mock_restore_book
             .expect_restore()
             .with(always(), always())
-            .returning(move |_, _| Ok(Some(make_book_dto(&book_id))));
+            .returning(move |_, _| {
+                Ok(MutationResultDto::new(
+                    Some(make_book_dto(&book_id)),
+                    "event-set".to_string(),
+                ))
+            });
 
         let interactor = InteractorBuilder::new()
             .with_restore_book(mock_restore_book)
@@ -532,7 +578,7 @@ mod tests {
 
         // Then
         assert!(result.is_ok());
-        assert_eq!(result.unwrap().unwrap().id, expected_id);
+        assert_eq!(result.unwrap().value.unwrap().id, expected_id);
     }
 
     #[tokio::test]
@@ -542,7 +588,7 @@ mod tests {
         mock_restore_book
             .expect_restore()
             .with(always(), always())
-            .returning(|_, _| Ok(None));
+            .returning(|_, _| Ok(MutationResultDto::new(None, "event-set".to_string())));
 
         let interactor = InteractorBuilder::new()
             .with_restore_book(mock_restore_book)
@@ -564,10 +610,13 @@ mod tests {
             .expect_restore()
             .with(always(), always())
             .returning(|_, _| {
-                Ok(Some(AuthorDto {
-                    id: "006099b4-6c42-4ec4-8645-f6bd5b63eddc".to_string(),
-                    name: "Test Author".to_string(),
-                }))
+                Ok(MutationResultDto::new(
+                    Some(AuthorDto {
+                        id: "006099b4-6c42-4ec4-8645-f6bd5b63eddc".to_string(),
+                        name: "Test Author".to_string(),
+                    }),
+                    "event-set".to_string(),
+                ))
             });
 
         let interactor = InteractorBuilder::new()
@@ -579,7 +628,7 @@ mod tests {
 
         // Then
         assert!(result.is_ok());
-        assert_eq!(result.unwrap().unwrap().name, "Test Author");
+        assert_eq!(result.unwrap().value.unwrap().name, "Test Author");
     }
 
     #[tokio::test]
@@ -589,7 +638,7 @@ mod tests {
         mock_restore_author
             .expect_restore()
             .with(always(), always())
-            .returning(|_, _| Ok(None));
+            .returning(|_, _| Ok(MutationResultDto::new(None, "event-set".to_string())));
 
         let interactor = InteractorBuilder::new()
             .with_restore_author(mock_restore_author)
@@ -610,7 +659,7 @@ mod tests {
         mock_restore_book
             .expect_restore()
             .with(eq("user1"), eq(42_i64))
-            .returning(|_, _| Ok(None));
+            .returning(|_, _| Ok(MutationResultDto::new(None, "event-set".to_string())));
 
         let interactor = InteractorBuilder::new()
             .with_restore_book(mock_restore_book)
@@ -656,7 +705,7 @@ mod tests {
         mock_restore_author
             .expect_restore()
             .with(eq("user1"), eq(99_i64))
-            .returning(|_, _| Ok(None));
+            .returning(|_, _| Ok(MutationResultDto::new(None, "event-set".to_string())));
 
         let interactor = InteractorBuilder::new()
             .with_restore_author(mock_restore_author)
@@ -705,7 +754,12 @@ mod tests {
         mock_import_books
             .expect_import()
             .with(eq("user1"), always())
-            .returning(move |_, _| Ok(vec![make_book_dto(&book_id)]));
+            .returning(move |_, _| {
+                Ok(MutationResultDto::new(
+                    vec![make_book_dto(&book_id)],
+                    "event-set".to_string(),
+                ))
+            });
 
         let interactor = InteractorBuilder::new()
             .with_import_books(mock_import_books)

--- a/src/use_case/traits/author.rs
+++ b/src/use_case/traits/author.rs
@@ -2,7 +2,10 @@ use async_trait::async_trait;
 use mockall::automock;
 
 use crate::use_case::{
-    dto::author::{AuthorDto, CreateAuthorDto, UpdateAuthorDto},
+    dto::{
+        author::{CreateAuthorDto, UpdateAuthorDto},
+        mutation::{AuthorMutationResultDto, DeleteAuthorResultDto},
+    },
     error::UseCaseError,
 };
 
@@ -13,7 +16,7 @@ pub trait CreateAuthorUseCase: Send + Sync + 'static {
         &self,
         user_id: &str,
         author_data: CreateAuthorDto,
-    ) -> Result<AuthorDto, UseCaseError>;
+    ) -> Result<AuthorMutationResultDto, UseCaseError>;
 }
 
 #[automock]
@@ -23,11 +26,15 @@ pub trait UpdateAuthorUseCase: Send + Sync + 'static {
         &self,
         user_id: &str,
         author_data: UpdateAuthorDto,
-    ) -> Result<AuthorDto, UseCaseError>;
+    ) -> Result<AuthorMutationResultDto, UseCaseError>;
 }
 
 #[automock]
 #[async_trait]
 pub trait DeleteAuthorUseCase: Send + Sync + 'static {
-    async fn delete(&self, user_id: &str, author_id: &str) -> Result<(), UseCaseError>;
+    async fn delete(
+        &self,
+        user_id: &str,
+        author_id: &str,
+    ) -> Result<DeleteAuthorResultDto, UseCaseError>;
 }

--- a/src/use_case/traits/book.rs
+++ b/src/use_case/traits/book.rs
@@ -2,7 +2,10 @@ use async_trait::async_trait;
 use mockall::automock;
 
 use crate::use_case::{
-    dto::book::{BookDto, CreateBookDto, ImportBookEntryDto, UpdateBookDto},
+    dto::{
+        book::{CreateBookDto, ImportBookEntryDto, UpdateBookDto},
+        mutation::{BookMutationResultDto, DeleteBookResultDto, ImportBooksResultDto},
+    },
     error::UseCaseError,
 };
 
@@ -13,7 +16,7 @@ pub trait CreateBookUseCase: Send + Sync + 'static {
         &self,
         user_id: &str,
         book_data: CreateBookDto,
-    ) -> Result<BookDto, UseCaseError>;
+    ) -> Result<BookMutationResultDto, UseCaseError>;
 }
 
 #[automock]
@@ -23,13 +26,17 @@ pub trait UpdateBookUseCase: Send + Sync + 'static {
         &self,
         user_id: &str,
         book_data: UpdateBookDto,
-    ) -> Result<BookDto, UseCaseError>;
+    ) -> Result<BookMutationResultDto, UseCaseError>;
 }
 
 #[automock]
 #[async_trait]
 pub trait DeleteBookUseCase: Send + Sync + 'static {
-    async fn delete(&self, user_id: &str, book_id: &str) -> Result<(), UseCaseError>;
+    async fn delete(
+        &self,
+        user_id: &str,
+        book_id: &str,
+    ) -> Result<DeleteBookResultDto, UseCaseError>;
 }
 
 #[automock]
@@ -39,5 +46,5 @@ pub trait ImportBooksUseCase: Send + Sync + 'static {
         &self,
         user_id: &str,
         books: Vec<ImportBookEntryDto>,
-    ) -> Result<Vec<BookDto>, UseCaseError>;
+    ) -> Result<ImportBooksResultDto, UseCaseError>;
 }

--- a/src/use_case/traits/event.rs
+++ b/src/use_case/traits/event.rs
@@ -3,9 +3,8 @@ use mockall::automock;
 
 use crate::use_case::{
     dto::{
-        author::AuthorDto,
-        book::BookDto,
         event::{AuthorEventDto, BookEventDto},
+        mutation::{RestoreAuthorResultDto, RestoreBookResultDto},
     },
     error::UseCaseError,
 };
@@ -29,7 +28,11 @@ pub trait ListAuthorEventsUseCase: Send + Sync + 'static {
 #[automock]
 #[async_trait]
 pub trait RestoreBookUseCase: Send + Sync + 'static {
-    async fn restore(&self, user_id: &str, event_id: i64) -> Result<Option<BookDto>, UseCaseError>;
+    async fn restore(
+        &self,
+        user_id: &str,
+        event_id: i64,
+    ) -> Result<RestoreBookResultDto, UseCaseError>;
 }
 
 #[automock]
@@ -39,5 +42,5 @@ pub trait RestoreAuthorUseCase: Send + Sync + 'static {
         &self,
         user_id: &str,
         event_id: i64,
-    ) -> Result<Option<AuthorDto>, UseCaseError>;
+    ) -> Result<RestoreAuthorResultDto, UseCaseError>;
 }

--- a/src/use_case/traits/mutation.rs
+++ b/src/use_case/traits/mutation.rs
@@ -3,8 +3,13 @@ use mockall::automock;
 
 use crate::use_case::{
     dto::{
-        author::{AuthorDto, CreateAuthorDto, UpdateAuthorDto},
-        book::{BookDto, CreateBookDto, ImportBookEntryDto, UpdateBookDto},
+        author::{CreateAuthorDto, UpdateAuthorDto},
+        book::{CreateBookDto, ImportBookEntryDto, UpdateBookDto},
+        mutation::{
+            AuthorMutationResultDto, BookMutationResultDto, DeleteAuthorResultDto,
+            DeleteBookResultDto, ImportBooksResultDto, RestoreAuthorResultDto,
+            RestoreBookResultDto,
+        },
         user::UserDto,
     },
     error::UseCaseError,
@@ -18,37 +23,45 @@ pub trait MutationUseCase: Send + Sync + 'static {
         &self,
         user_id: &str,
         book_data: CreateBookDto,
-    ) -> Result<BookDto, UseCaseError>;
+    ) -> Result<BookMutationResultDto, UseCaseError>;
     async fn update_book(
         &self,
         user_id: &str,
         book_data: UpdateBookDto,
-    ) -> Result<BookDto, UseCaseError>;
-    async fn delete_book(&self, user_id: &str, book_id: &str) -> Result<(), UseCaseError>;
+    ) -> Result<BookMutationResultDto, UseCaseError>;
+    async fn delete_book(
+        &self,
+        user_id: &str,
+        book_id: &str,
+    ) -> Result<DeleteBookResultDto, UseCaseError>;
     async fn create_author(
         &self,
         user_id: &str,
         author_data: CreateAuthorDto,
-    ) -> Result<AuthorDto, UseCaseError>;
+    ) -> Result<AuthorMutationResultDto, UseCaseError>;
     async fn update_author(
         &self,
         user_id: &str,
         author_data: UpdateAuthorDto,
-    ) -> Result<AuthorDto, UseCaseError>;
-    async fn delete_author(&self, user_id: &str, author_id: &str) -> Result<(), UseCaseError>;
+    ) -> Result<AuthorMutationResultDto, UseCaseError>;
+    async fn delete_author(
+        &self,
+        user_id: &str,
+        author_id: &str,
+    ) -> Result<DeleteAuthorResultDto, UseCaseError>;
     async fn restore_book(
         &self,
         user_id: &str,
         event_id: i64,
-    ) -> Result<Option<BookDto>, UseCaseError>;
+    ) -> Result<RestoreBookResultDto, UseCaseError>;
     async fn restore_author(
         &self,
         user_id: &str,
         event_id: i64,
-    ) -> Result<Option<AuthorDto>, UseCaseError>;
+    ) -> Result<RestoreAuthorResultDto, UseCaseError>;
     async fn import_books(
         &self,
         user_id: &str,
         books: Vec<ImportBookEntryDto>,
-    ) -> Result<Vec<BookDto>, UseCaseError>;
+    ) -> Result<ImportBooksResultDto, UseCaseError>;
 }


### PR DESCRIPTION
### Motivation
- Make mutation-driven E2E tests deterministic and easier to write by returning the committed `event_set.id` for every mutating operation so tests can directly inspect the corresponding `eventSet`. 
- Expose `event_set` identity at the use-case level (read-only) while keeping event-row insertion and other persistence details in infrastructure.

### Description
- Add a generic mutation result DTO `MutationResultDto<T>` and typed aliases (e.g. `BookMutationResultDto`, `ImportBooksResultDto`) in `src/use_case/dto/mutation.rs` to carry the domain result plus `event_set_id`.
- Expose transaction `event_set_id` via a `TransactionEventSet` trait and require `Transaction: TransactionEventSet` in `TransactionManager` so interactors can read the id before commit (`src/domain/repository/transaction.rs`, `src/infrastructure/transaction.rs`).
- Update use-case traits and interactors to return mutation DTOs and capture `tx.event_set_id()` before committing for create/update/delete/import/restore flows (`src/use_case/traits/*.rs`, `src/use_case/interactor/*.rs`).
- Change the GraphQL presentation layer to return payload objects that include `eventSetId` (e.g. `BookMutationPayload`, `ImportBooksPayload`, delete/restore payloads) and wire those in resolvers; regenerate `schema.graphql` (`src/presentation/graphql/object.rs`, `src/presentation/graphql/mutation.rs`, `schema.graphql`).
- Update E2E import tests to consume `importBooks.eventSetId` and use it to query `eventSet(id: ...)` instead of locating sets by operation (`e2e/tests/graphql_import.rs`).
- Document the adjusted event-recording boundary in `docs/architecture/event-recording.md`.

### Testing
- Ran formatting and lint checks: `cargo fmt --check` and `cargo clippy --all-targets --locked -- -D warnings` (both passed).
- Ran the unit test suite with `cargo test --locked` and all unit tests passed (139 passed).
- Regenerated the GraphQL SDL with the generator (`src/bin/gen_schema.rs`) and updated `schema.graphql` (build succeeded).
- Attempted E2E runs such as `cargo test -p bookshelf-e2e --test graphql_import --locked` and related E2E suites, but they failed/are blocked because the external test server URL is not configured (`TEST_SERVER_URL` environment variable is not set).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f95cad7788321b395257818c5155d)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 書籍・著者の作成、更新、削除、復元、インポート結果に、対象データとイベントセットIDを含むレスポンスを追加しました。
  * 削除操作で対象IDを、インポート操作で登録済み書籍一覧を直接取得できるようになりました。
* **変更**
  * GraphQLミューテーションのレスポンス形式を統一し、書籍・著者情報を入れ子構造で返すよう変更しました。
  * 既存のレスポンス形式を利用しているクライアントは、取得先の見直しが必要です。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->