### PR TITLE
Remove Actions concurrency limits

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -3,10 +3,6 @@ name: actionlint
 on:
   push:
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
-
 jobs:
   actionlint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,6 @@ on: [push]
 permissions:
   contents: read
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
-
 jobs:
   test:
     name: Test Suite

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -2,10 +2,6 @@ name: E2E tests
 
 on: [push]
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
-
 jobs:
   e2e:
     name: End-to-end tests

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -2,10 +2,6 @@ name: zizmor
 
 on: [push]
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
-
 jobs:
   zizmor:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- remove workflow-level concurrency settings from CI, E2E, actionlint, and zizmor
- allow every push-triggered workflow run to complete

## Why

Feature branches can briefly point at the current `main` commit before their
own commit is pushed. The branch-level concurrency groups cancel the first
run, attaching cancelled checks to the shared commit SHA and making a
successful `main` commit appear unsuccessful.

GitHub Actions standard runners are free and unlimited for this public
repository, so retaining all push runs is preferable to the misleading
cancelled checks.

## Validation

- `actionlint -color`
- `git diff --check`

Cargo checks were skipped with explicit approval because this change only
modifies GitHub Actions workflow scheduling.
