### PR TITLE
Restore bookshelf integration target

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,9 +28,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: hiterm/bookshelf
-          # Temporary compatibility check; restore the following ref when complete.
-          # ref: main
-          ref: fix/mutation-payload-compatibility
+          ref: main
           path: bookshelf-src
           persist-credentials: false
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -88,9 +88,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: hiterm/bookshelf
-          # Temporary compatibility check; restore the following ref when complete.
-          # ref: main
-          ref: fix/mutation-payload-compatibility
+          ref: main
           path: bookshelf-src
           persist-credentials: false
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9


### PR DESCRIPTION
## Summary

- restore the `hiterm/bookshelf` integration target to `main` in the deploy workflow
- restore the same integration target in the e2e workflow
- remove the temporary compatibility-check comments and branch reference

## Why

The integration workflows were temporarily pointed at
`fix/mutation-payload-compatibility` for a compatibility check. That check is
complete, so CI should consume the default `main` branch again.

## Impact

Deploy and e2e integration jobs will test against the current `main` branch of
`hiterm/bookshelf`.

## Validation

- `git diff --check`
- Full Rust pre-commit checks were skipped with explicit user approval because
  this change only updates CI workflow configuration.
