### PR TITLE
Use cargo set-version in tagpr

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,9 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - uses: ./.github/actions/setup-rust-toolchain
+      - uses: taiki-e/install-action@2ca9b94c269419b7b0c711c09d0b21c4e1d51145 # v2.83.1
+        with:
+          tool: cargo-edit
       - name: Run tagpr
         id: tagpr
         uses: Songmu/tagpr@d1b8138b7a31075141b6cd64103de9485ced7ac9 # v1.20.1

--- a/.tagpr
+++ b/.tagpr
@@ -1,9 +1,9 @@
 [tagpr]
 	releaseBranch = main
-	versionFile = Cargo.toml,e2e/Cargo.toml,rendercom/Dockerfile
+	versionFile = rendercom/Dockerfile
 	vPrefix = false
 	changelog = true
-	postVersionCommand = cargo check --workspace
+	postVersionCommand = cargo set-version "${TAGPR_NEXT_VERSION}"
 	release = true
 	majorLabels = bump-major
 	minorLabels = bump-minor

--- a/.tagpr
+++ b/.tagpr
@@ -3,7 +3,7 @@
 	versionFile = rendercom/Dockerfile
 	vPrefix = false
 	changelog = true
-	postVersionCommand = cargo set-version "${TAGPR_NEXT_VERSION}"
+	postVersionCommand = cargo set-version --workspace "${TAGPR_NEXT_VERSION}"
 	release = true
 	majorLabels = bump-major
 	minorLabels = bump-minor


### PR DESCRIPTION
## Summary

- install `cargo-edit` before running tagpr
- use `cargo set-version` after tagpr updates the release version
- let tagpr directly update only the Render compatibility Dockerfile

## Why

The previous `postVersionCommand` ran `cargo check --workspace`, which downloaded dependencies and compiled the workspace merely to synchronize Cargo package versions and `Cargo.lock`. `cargo set-version` performs the intended version updates without an unnecessary Rust build.

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo test --locked` (139 tests passed)
- `cargo metadata --locked --no-deps --format-version 1`
- `actionlint .github/workflows/release.yml`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * リリース時に、プロジェクト全体のバージョン更新を自動化しました。
  * リリース前の検証手順を整理し、バージョン情報の反映をより確実にしました。
  * リリースタグの作成に必要なツールを自動的に準備するよう改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->