### PR TITLE
Sync Rust versions in Renovate

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -4,6 +4,22 @@
     "config:best-practices",
   ],
   "minimumReleaseAge": "3 days",
+  "customManagers": [
+    {
+      // Use the Docker image as the source of truth so the toolchain is only
+      // updated after the matching trixie image is available.
+      "customType": "regex",
+      "managerFilePatterns": ["/^rust-toolchain\\.toml$/"],
+      "matchStrings": [
+        "channel\\s*=\\s*\"(?<currentValue>\\d+\\.\\d+\\.\\d+)\"",
+      ],
+      "depNameTemplate": "rust",
+      "packageNameTemplate": "rust",
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "docker",
+      "extractVersionTemplate": "^(?<version>\\d+\\.\\d+\\.\\d+)-trixie$",
+    },
+  ],
   "packageRules": [
     {
       // Group minor/patch updates by manager (e.g. npm, github-actions).
@@ -28,11 +44,23 @@
       "enabled": false
     },
     {
-      // Keep rust-toolchain.toml and Dockerfile rust base image in sync
+      // The custom manager above replaces the built-in toolchain update.
       "matchDepNames": ["rust"],
-      "matchManagers": ["rust-toolchain", "dockerfile"],
+      "matchManagers": ["rust-toolchain"],
+      "enabled": false,
+    },
+    {
+      // Keep rust-toolchain.toml and Dockerfile rust base image in sync.
+      "matchDepNames": ["rust"],
+      "matchManagers": ["custom.regex", "dockerfile"],
       "minimumReleaseAge": null,
-      "groupName": "rust version"
+      "groupName": "rust version",
+    },
+    {
+      // rust-toolchain.toml cannot store a Docker image digest.
+      "matchDepNames": ["rust"],
+      "matchManagers": ["custom.regex"],
+      "pinDigests": false,
     },
   ],
   "reviewers": ["hiterm"],


### PR DESCRIPTION
## Summary

- use the Docker `rust` image tags as the source of truth for
  `rust-toolchain.toml`
- disable the built-in Rust toolchain update
- group the custom toolchain update with the Dockerfile update
- prevent Docker digests from being written to `rust-toolchain.toml`

## Why

Renovate previously grouped the Rust toolchain and Docker image updates, but
resolved their versions from separate data sources. This allowed a pull request
to contain different Rust versions when a Rust patch release was available
before its matching `trixie` Docker image.

The new custom manager only offers versions that have a corresponding
`rust:<version>-trixie` image, so both files are updated together to the same
Rust version.

## Validation

- `renovate-config-validator`
- Renovate local dry run
- `cargo fmt --check`
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo test --locked`
