### PR TITLE
Expose author yomi in GraphQL

### DIFF
--- a/e2e/tests/graphql_authors.rs
+++ b/e2e/tests/graphql_authors.rs
@@ -43,10 +43,11 @@ async fn e2e_graphql_create_author() -> Result<()> {
 
     // Use a random name to keep the author unique across runs.
     let random_name = format!("Test Author {}", uuid::Uuid::new_v4());
+    let yomi = "てすと・おーさー1";
 
     let query = format!(
-        r#"mutation {{ createAuthor(authorData: {{ name: "{}" }}) {{ author {{ id name yomi }} eventSetId }} }}"#,
-        random_name
+        r#"mutation {{ createAuthor(authorData: {{ name: "{}", yomi: "{}" }}) {{ author {{ id name yomi }} yomi eventSetId }} }}"#,
+        random_name, yomi
     );
     let (_, response) = graphql_request(&query, Some(&token)).await?;
 
@@ -68,7 +69,8 @@ async fn e2e_graphql_create_author() -> Result<()> {
             .as_str(),
         Some(random_name.as_str())
     );
-    assert_eq!(create_result["yomi"].as_str(), Some(""));
+    assert_eq!(create_result["yomi"].as_str(), Some(yomi));
+    assert_eq!(data["createAuthor"]["yomi"].as_str(), Some(yomi));
 
     // Verify author was created by fetching it
     let author_query = format!(r#"{{ author(id: "{}") {{ id name yomi }} }}"#, author_id);
@@ -85,7 +87,7 @@ async fn e2e_graphql_create_author() -> Result<()> {
         author_name_from_query, random_name,
         "author name should match"
     );
-    assert_eq!(author["yomi"].as_str(), Some(""));
+    assert_eq!(author["yomi"].as_str(), Some(yomi));
 
     delete_test_author(author_id, &token).await?;
     Ok(())
@@ -162,9 +164,10 @@ async fn e2e_graphql_update_author() -> Result<()> {
 
     // Update author name while the author has an associated book
     let updated_name = format!("Author After Update {}", uuid::Uuid::new_v4());
+    let updated_yomi = "こうしんご2";
     let update_query = format!(
-        r#"mutation {{ updateAuthor(authorData: {{ id: "{}", name: "{}" }}) {{ author {{ id name }} eventSetId }} }}"#,
-        author_id, updated_name
+        r#"mutation {{ updateAuthor(authorData: {{ id: "{}", name: "{}", yomi: "{}" }}) {{ author {{ id name yomi }} yomi eventSetId }} }}"#,
+        author_id, updated_name, updated_yomi
     );
     let (_, response) = graphql_request(&update_query, Some(&token)).await?;
     assert!(
@@ -182,13 +185,41 @@ async fn e2e_graphql_update_author() -> Result<()> {
         Some(updated_name.as_str()),
         "updated author name should match"
     );
+    assert_eq!(update_result["yomi"].as_str(), Some(updated_yomi));
+    assert_eq!(
+        response["data"]["updateAuthor"]["yomi"].as_str(),
+        Some(updated_yomi)
+    );
+
+    // Omitting yomi preserves the current value.
+    let preserved_name = format!("Author Preserving Yomi {}", uuid::Uuid::new_v4());
+    let preserve_query = format!(
+        r#"mutation {{ updateAuthor(authorData: {{ id: "{}", name: "{}" }}) {{ author {{ yomi }} }} }}"#,
+        author_id, preserved_name
+    );
+    let (_, response) = graphql_request(&preserve_query, Some(&token)).await?;
+    assert_eq!(
+        response["data"]["updateAuthor"]["author"]["yomi"].as_str(),
+        Some(updated_yomi)
+    );
+
+    // An explicit empty string clears yomi.
+    let clear_query = format!(
+        r#"mutation {{ updateAuthor(authorData: {{ id: "{}", name: "{}", yomi: "" }}) {{ author {{ yomi }} }} }}"#,
+        author_id, preserved_name
+    );
+    let (_, response) = graphql_request(&clear_query, Some(&token)).await?;
+    assert_eq!(
+        response["data"]["updateAuthor"]["author"]["yomi"].as_str(),
+        Some("")
+    );
 
     // Verify update by fetching the author
     let query = format!(r#"{{ author(id: "{}") {{ id name }} }}"#, author_id);
     let (_, response) = graphql_request(&query, Some(&token)).await?;
     assert_eq!(
         response["data"]["author"]["name"].as_str(),
-        Some(updated_name.as_str()),
+        Some(preserved_name.as_str()),
         "author name should reflect the update"
     );
 

--- a/e2e/tests/graphql_authors.rs
+++ b/e2e/tests/graphql_authors.rs
@@ -12,7 +12,7 @@ async fn e2e_graphql_authors() -> Result<()> {
     let (_user_id, token) = create_test_user().await?;
 
     // The authors list is user-scoped, so a fresh user starts empty.
-    let query = r#"{ authors { id name } }"#;
+    let query = r#"{ authors { id name yomi } }"#;
     let (_, response) = graphql_request(query, Some(&token)).await?;
     let authors = response["data"]["authors"]
         .as_array()
@@ -30,6 +30,7 @@ async fn e2e_graphql_authors() -> Result<()> {
     assert_eq!(authors.len(), 1, "should list exactly the created author");
     assert_eq!(authors[0]["id"].as_str(), Some(author_id.as_str()));
     assert_eq!(authors[0]["name"].as_str(), Some(author_name.as_str()));
+    assert_eq!(authors[0]["yomi"].as_str(), Some(""));
 
     delete_test_author(&author_id, &token).await?;
     Ok(())
@@ -44,7 +45,7 @@ async fn e2e_graphql_create_author() -> Result<()> {
     let random_name = format!("Test Author {}", uuid::Uuid::new_v4());
 
     let query = format!(
-        r#"mutation {{ createAuthor(authorData: {{ name: "{}" }}) {{ author {{ id name }} eventSetId }} }}"#,
+        r#"mutation {{ createAuthor(authorData: {{ name: "{}" }}) {{ author {{ id name yomi }} eventSetId }} }}"#,
         random_name
     );
     let (_, response) = graphql_request(&query, Some(&token)).await?;
@@ -67,9 +68,10 @@ async fn e2e_graphql_create_author() -> Result<()> {
             .as_str(),
         Some(random_name.as_str())
     );
+    assert_eq!(create_result["yomi"].as_str(), Some(""));
 
     // Verify author was created by fetching it
-    let author_query = format!(r#"{{ author(id: "{}") {{ id name }} }}"#, author_id);
+    let author_query = format!(r#"{{ author(id: "{}") {{ id name yomi }} }}"#, author_id);
     let (_, response) = graphql_request(&author_query, Some(&token)).await?;
     let data = response.get("data").context("data field must exist")?;
     let author = data.get("author").context("author field must exist")?;
@@ -83,6 +85,7 @@ async fn e2e_graphql_create_author() -> Result<()> {
         author_name_from_query, random_name,
         "author name should match"
     );
+    assert_eq!(author["yomi"].as_str(), Some(""));
 
     delete_test_author(author_id, &token).await?;
     Ok(())

--- a/e2e/tests/graphql_authors.rs
+++ b/e2e/tests/graphql_authors.rs
@@ -46,7 +46,7 @@ async fn e2e_graphql_create_author() -> Result<()> {
     let yomi = "てすと・おーさー1";
 
     let query = format!(
-        r#"mutation {{ createAuthor(authorData: {{ name: "{}", yomi: "{}" }}) {{ author {{ id name yomi }} yomi eventSetId }} }}"#,
+        r#"mutation {{ createAuthor(authorData: {{ name: "{}", yomi: "{}" }}) {{ author {{ id name yomi }} eventSetId }} }}"#,
         random_name, yomi
     );
     let (_, response) = graphql_request(&query, Some(&token)).await?;
@@ -70,7 +70,6 @@ async fn e2e_graphql_create_author() -> Result<()> {
         Some(random_name.as_str())
     );
     assert_eq!(create_result["yomi"].as_str(), Some(yomi));
-    assert_eq!(data["createAuthor"]["yomi"].as_str(), Some(yomi));
 
     // Verify author was created by fetching it
     let author_query = format!(r#"{{ author(id: "{}") {{ id name yomi }} }}"#, author_id);
@@ -166,7 +165,7 @@ async fn e2e_graphql_update_author() -> Result<()> {
     let updated_name = format!("Author After Update {}", uuid::Uuid::new_v4());
     let updated_yomi = "こうしんご2";
     let update_query = format!(
-        r#"mutation {{ updateAuthor(authorData: {{ id: "{}", name: "{}", yomi: "{}" }}) {{ author {{ id name yomi }} yomi eventSetId }} }}"#,
+        r#"mutation {{ updateAuthor(authorData: {{ id: "{}", name: "{}", yomi: "{}" }}) {{ author {{ id name yomi }} eventSetId }} }}"#,
         author_id, updated_name, updated_yomi
     );
     let (_, response) = graphql_request(&update_query, Some(&token)).await?;
@@ -186,10 +185,6 @@ async fn e2e_graphql_update_author() -> Result<()> {
         "updated author name should match"
     );
     assert_eq!(update_result["yomi"].as_str(), Some(updated_yomi));
-    assert_eq!(
-        response["data"]["updateAuthor"]["yomi"].as_str(),
-        Some(updated_yomi)
-    );
 
     // Omitting yomi preserves the current value.
     let preserved_name = format!("Author Preserving Yomi {}", uuid::Uuid::new_v4());

--- a/e2e/tests/graphql_books.rs
+++ b/e2e/tests/graphql_books.rs
@@ -514,6 +514,13 @@ async fn e2e_graphql_create_mutations_validate_input() -> Result<()> {
     .await?;
     assert_graphql_errors(&response, "createAuthor with an empty name");
 
+    let (_, response) = graphql_request(
+        r#"mutation { createAuthor(authorData: { name: "Invalid Yomi", yomi: "カタカナ" }) { author { id } } }"#,
+        Some(&token),
+    )
+    .await?;
+    assert_graphql_errors(&response, "createAuthor with invalid yomi");
+
     let invalid_book_queries = [
         r#"
         mutation {

--- a/e2e/tests/graphql_restore.rs
+++ b/e2e/tests/graphql_restore.rs
@@ -101,11 +101,20 @@ async fn e2e_restore_author_reverts_to_snapshot() -> Result<()> {
     let (_user_id, token) = create_test_user().await?;
 
     let original_name = format!("Restore Author Original {}", uuid::Uuid::new_v4());
-    let author_id = create_test_author(&original_name, &token).await?;
+    let original_yomi = "ふくげん・おりじなる1";
+    let create_query = format!(
+        r#"mutation {{ createAuthor(authorData: {{ name: "{}", yomi: "{}" }}) {{ author {{ id }} }} }}"#,
+        original_name, original_yomi
+    );
+    let (_, response) = graphql_request(&create_query, Some(&token)).await?;
+    let author_id = response["data"]["createAuthor"]["author"]["id"]
+        .as_str()
+        .context("created author id should be a string")?
+        .to_owned();
 
     // Capture the create event's event_id
     let history_query = format!(
-        r#"{{ authorEvents(authorId: "{}") {{ eventId operation name }} }}"#,
+        r#"{{ authorEvents(authorId: "{}") {{ eventId operation name yomi }} }}"#,
         author_id
     );
     let (_, response) = graphql_request(&history_query, Some(&token)).await?;
@@ -119,9 +128,10 @@ async fn e2e_restore_author_reverts_to_snapshot() -> Result<()> {
 
     // Update the author
     let updated_name = format!("Restore Author Updated {}", uuid::Uuid::new_v4());
+    let updated_yomi = "ふくげん・こうしん2";
     let update_query = format!(
-        r#"mutation {{ updateAuthor(authorData: {{ id: "{}", name: "{}" }}) {{ author {{ id name }} eventSetId }} }}"#,
-        author_id, updated_name
+        r#"mutation {{ updateAuthor(authorData: {{ id: "{}", name: "{}", yomi: "{}" }}) {{ author {{ id name yomi }} eventSetId }} }}"#,
+        author_id, updated_name, updated_yomi
     );
     let (_, update_response) = graphql_request(&update_query, Some(&token)).await?;
     assert!(
@@ -136,7 +146,7 @@ async fn e2e_restore_author_reverts_to_snapshot() -> Result<()> {
 
     // Restore to the create event state
     let restore_query = format!(
-        r#"mutation {{ restoreAuthor(eventId: "{}") {{ author {{ id name }} eventSetId }} }}"#,
+        r#"mutation {{ restoreAuthor(eventId: "{}") {{ author {{ id name yomi }} eventSetId }} }}"#,
         create_event_id
     );
     let (_, response) = graphql_request(&restore_query, Some(&token)).await?;
@@ -150,14 +160,24 @@ async fn e2e_restore_author_reverts_to_snapshot() -> Result<()> {
         Some(original_name.as_str()),
         "restored author should have create-event name"
     );
+    assert_eq!(
+        response["data"]["restoreAuthor"]["author"]["yomi"].as_str(),
+        Some(original_yomi),
+        "restored author should have create-event yomi"
+    );
 
     // Verify DB reflects the restored state
-    let author_query = format!(r#"{{ author(id: "{}") {{ name }} }}"#, author_id);
+    let author_query = format!(r#"{{ author(id: "{}") {{ name yomi }} }}"#, author_id);
     let (_, response) = graphql_request(&author_query, Some(&token)).await?;
     assert_eq!(
         response["data"]["author"]["name"].as_str(),
         Some(original_name.as_str()),
         "author in DB should reflect restored name"
+    );
+    assert_eq!(
+        response["data"]["author"]["yomi"].as_str(),
+        Some(original_yomi),
+        "author in DB should reflect restored yomi"
     );
 
     delete_test_author(&author_id, &token).await?;

--- a/migrations/test/test_migration.mjs
+++ b/migrations/test/test_migration.mjs
@@ -89,8 +89,8 @@ psql(DATA_URL, `
     ('b0000000-0000-0000-0000-000000000001', 'user_beta',  'Book B1', 'ISBN-B1', false, false, 0, 'Unknown', 'Unknown');
 
   INSERT INTO author (id, user_id, name, yomi) VALUES
-    ('a1000000-0000-0000-0000-000000000001', 'user_alpha', 'Author A', 'authora'),
-    ('b1000000-0000-0000-0000-000000000001', 'user_beta',  'Author B', 'authorb');
+    ('a1000000-0000-0000-0000-000000000001', 'user_alpha', 'Author A', 'おーさーえー'),
+    ('b1000000-0000-0000-0000-000000000001', 'user_beta',  'Author B', 'おーさーびー');
 
   -- user_alpha Book A1 and A2 both written by Author A
   INSERT INTO book_author (user_id, book_id, author_id) VALUES
@@ -232,7 +232,7 @@ test('author_event.name matches source author', () => {
 test('author_event.yomi matches source author', () => {
   assertEqual(
     queryOne(DATA_URL, "SELECT yomi FROM author_event WHERE author_id = 'a1000000-0000-0000-0000-000000000001'"),
-    'authora', 'Author A yomi',
+    'おーさーえー', 'Author A yomi',
   );
 });
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -1,6 +1,7 @@
 type Author {
 	id: ID!
 	name: String!
+	yomi: String!
 }
 
 type AuthorEventEntry {
@@ -253,4 +254,3 @@ schema {
 	query: Query
 	mutation: Mutation
 }
-

--- a/schema.graphql
+++ b/schema.graphql
@@ -22,6 +22,7 @@ type AuthorMutationPayload {
 	eventSetId: ID!
 	id: ID!
 	name: String!
+	yomi: String!
 }
 
 type Book {
@@ -85,6 +86,7 @@ enum BookStore {
 
 input CreateAuthorInput {
 	name: String!
+	yomi: String
 }
 
 input CreateBookInput {
@@ -224,6 +226,7 @@ type RestoreBookPayload {
 input UpdateAuthorInput {
 	id: ID!
 	name: String!
+	yomi: String
 }
 
 input UpdateBookInput {

--- a/schema.graphql
+++ b/schema.graphql
@@ -254,3 +254,4 @@ schema {
 	query: Query
 	mutation: Mutation
 }
+

--- a/src/domain/entity/author.rs
+++ b/src/domain/entity/author.rs
@@ -1,6 +1,8 @@
 use std::fmt::Display;
+use std::sync::LazyLock;
 
 use getset::Getters;
+use regex::Regex;
 use uuid::Uuid;
 use validator::Validate;
 
@@ -55,6 +57,21 @@ pub struct AuthorName {
 
 impl_string_value_object!(AuthorName);
 
+static AUTHOR_YOMI_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"^[\p{Hiragana}0-9０-９ー・ 　-]*$")
+        .expect("AUTHOR_YOMI_REGEX is a hardcoded valid pattern")
+});
+
+pub fn validate_author_yomi(yomi: String) -> Result<String, DomainError> {
+    if AUTHOR_YOMI_REGEX.is_match(&yomi) {
+        Ok(yomi)
+    } else {
+        Err(DomainError::Validation(
+            "author yomi contains unsupported characters".to_string(),
+        ))
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Getters)]
 pub struct Author {
     #[getset(get = "pub")]
@@ -75,6 +92,7 @@ pub struct DestructureAuthor {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AuthorUpdate {
     pub name: AuthorName,
+    pub yomi: Option<String>,
 }
 
 impl Author {
@@ -92,6 +110,9 @@ impl Author {
 
     pub fn update(&mut self, update: AuthorUpdate) {
         self.name = update.name;
+        if let Some(yomi) = update.yomi {
+            self.yomi = yomi;
+        }
     }
 
     pub fn destructure(self) -> DestructureAuthor {
@@ -106,7 +127,7 @@ impl Author {
 #[cfg(test)]
 mod tests {
     use crate::domain::{
-        entity::author::{Author, AuthorId, AuthorName, AuthorUpdate},
+        entity::author::{Author, AuthorId, AuthorName, AuthorUpdate, validate_author_yomi},
         error::DomainError,
     };
 
@@ -127,6 +148,7 @@ mod tests {
 
         author.update(AuthorUpdate {
             name: AuthorName::new(String::from("author2")).unwrap(),
+            yomi: None,
         });
 
         assert_eq!(author.name().as_str(), "author2");
@@ -143,5 +165,19 @@ mod tests {
             AuthorName::new(String::from("")),
             Err(DomainError::Validation(_))
         ));
+    }
+
+    #[test]
+    fn author_yomi_accepts_supported_characters_and_empty_string() {
+        for yomi in ["", "やまだ たろう", "じぇーん・どー", "だい２-3"] {
+            assert!(validate_author_yomi(yomi.to_string()).is_ok(), "{yomi}");
+        }
+    }
+
+    #[test]
+    fn author_yomi_rejects_unsupported_characters() {
+        for yomi in ["山田太郎", "ヤマダ", "yamada", "やまだ!"] {
+            assert!(validate_author_yomi(yomi.to_string()).is_err(), "{yomi}");
+        }
     }
 }

--- a/src/domain/entity/author.rs
+++ b/src/domain/entity/author.rs
@@ -58,7 +58,7 @@ pub struct AuthorName {
 impl_string_value_object!(AuthorName);
 
 static AUTHOR_YOMI_REGEX: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"^[\p{Hiragana}0-9０-９ー・ 　-]*$")
+    Regex::new(r"^[\p{Hiragana}0-9０-９ー・ 　-]*\z")
         .expect("AUTHOR_YOMI_REGEX is a hardcoded valid pattern")
 });
 
@@ -176,7 +176,7 @@ mod tests {
 
     #[test]
     fn author_yomi_rejects_unsupported_characters() {
-        for yomi in ["山田太郎", "ヤマダ", "yamada", "やまだ!"] {
+        for yomi in ["山田太郎", "ヤマダ", "yamada", "やまだ!", "やまだ\n"] {
             assert!(validate_author_yomi(yomi.to_string()).is_err(), "{yomi}");
         }
     }

--- a/src/domain/entity/author.rs
+++ b/src/domain/entity/author.rs
@@ -61,12 +61,15 @@ pub struct Author {
     id: AuthorId,
     #[getset(get = "pub")]
     name: AuthorName,
+    #[getset(get = "pub")]
+    yomi: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DestructureAuthor {
     pub id: AuthorId,
     pub name: AuthorName,
+    pub yomi: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -76,7 +79,15 @@ pub struct AuthorUpdate {
 
 impl Author {
     pub fn new(id: AuthorId, name: AuthorName) -> Result<Author, DomainError> {
-        Ok(Author { id, name })
+        Self::new_with_yomi(id, name, String::new())
+    }
+
+    pub fn new_with_yomi(
+        id: AuthorId,
+        name: AuthorName,
+        yomi: String,
+    ) -> Result<Author, DomainError> {
+        Ok(Author { id, name, yomi })
     }
 
     pub fn update(&mut self, update: AuthorUpdate) {
@@ -87,6 +98,7 @@ impl Author {
         DestructureAuthor {
             id: self.id,
             name: self.name,
+            yomi: self.yomi,
         }
     }
 }

--- a/src/infrastructure/author_repository.rs
+++ b/src/infrastructure/author_repository.rs
@@ -60,10 +60,11 @@ impl AuthorRepository for PgAuthorRepository {
 
     async fn create(&self, tx: &mut Self::Transaction, author: &Author) -> Result<(), DomainError> {
         let user_id = tx.user_id().clone();
-        sqlx::query("INSERT INTO author (id, user_id, name) VALUES ($1, $2, $3)")
+        sqlx::query("INSERT INTO author (id, user_id, name, yomi) VALUES ($1, $2, $3, $4)")
             .bind(author.id().to_uuid())
             .bind(user_id.as_str())
             .bind(author.name().as_str())
+            .bind(author.yomi())
             .execute(tx.as_mut())
             .await?;
 
@@ -190,9 +191,11 @@ impl AuthorRepository for PgAuthorRepository {
     async fn update(&self, tx: &mut Self::Transaction, author: &Author) -> Result<(), DomainError> {
         let user_id = tx.user_id().clone();
         let result = sqlx::query(
-            "UPDATE author SET name = $1, updated_at = now() WHERE id = $2 AND user_id = $3",
+            "UPDATE author SET name = $1, yomi = $2, updated_at = now()
+             WHERE id = $3 AND user_id = $4",
         )
         .bind(author.name().as_str())
+        .bind(author.yomi())
         .bind(author.id().to_uuid())
         .bind(user_id.as_str())
         .execute(tx.as_mut())
@@ -214,7 +217,7 @@ impl AuthorRepository for PgAuthorRepository {
             }
         }
 
-        // Fetch post-update state (yomi and timestamps are DB-managed)
+        // Fetch post-update state and DB-managed timestamps.
         let snap: AuthorSnapshotRow = sqlx::query_as(
             "SELECT name, yomi, created_at, updated_at FROM author WHERE id = $1 AND user_id = $2",
         )
@@ -950,7 +953,11 @@ mod tests {
 
         let user_id = prepare_user(&user_repository, "user1").await?;
         let author_id = AuthorId::try_from("e324be11-5b77-4ba6-8423-9f27e2d228f1")?;
-        let author = Author::new(author_id.clone(), AuthorName::new("author1".to_owned())?)?;
+        let author = Author::new_with_yomi(
+            author_id.clone(),
+            AuthorName::new("author1".to_owned())?,
+            "おーさー1".to_owned(),
+        )?;
 
         create_author(&pool, &author_repository, &user_id, &author).await?;
 
@@ -961,13 +968,14 @@ mod tests {
                 .await?;
         assert_eq!(es_op, "create_author");
 
-        let (ae_op, ae_name): (String, String) =
-            sqlx::query_as("SELECT operation, name FROM author_event WHERE user_id = $1")
+        let (ae_op, ae_name, ae_yomi): (String, String, String) =
+            sqlx::query_as("SELECT operation, name, yomi FROM author_event WHERE user_id = $1")
                 .bind(user_id.as_str())
                 .fetch_one(&pool)
                 .await?;
         assert_eq!(ae_op, "create");
         assert_eq!(ae_name, "author1");
+        assert_eq!(ae_yomi, "おーさー1");
 
         Ok(())
     }
@@ -979,14 +987,22 @@ mod tests {
 
         let user_id = prepare_user(&user_repository, "user1").await?;
         let author_id = AuthorId::try_from("e324be11-5b77-4ba6-8423-9f27e2d228f1")?;
-        let author = Author::new(author_id.clone(), AuthorName::new("original".to_owned())?)?;
+        let author = Author::new_with_yomi(
+            author_id.clone(),
+            AuthorName::new("original".to_owned())?,
+            "おりじなる".to_owned(),
+        )?;
         create_author(&pool, &author_repository, &user_id, &author).await?;
 
-        let updated = Author::new(author_id.clone(), AuthorName::new("updated".to_owned())?)?;
+        let updated = Author::new_with_yomi(
+            author_id.clone(),
+            AuthorName::new("updated".to_owned())?,
+            "あっぷでーと2".to_owned(),
+        )?;
         update_author(&pool, &author_repository, &user_id, &updated).await?;
 
-        let rows: Vec<(String, String)> = sqlx::query_as(
-            "SELECT operation, name FROM author_event WHERE user_id = $1
+        let rows: Vec<(String, String, String)> = sqlx::query_as(
+            "SELECT operation, name, yomi FROM author_event WHERE user_id = $1
              ORDER BY changed_at ASC",
         )
         .bind(user_id.as_str())
@@ -996,9 +1012,11 @@ mod tests {
         assert_eq!(rows.len(), 2);
         assert_eq!(rows[0].0, "create");
         assert_eq!(rows[0].1, "original");
+        assert_eq!(rows[0].2, "おりじなる");
         // Post-state: update event records the new name
         assert_eq!(rows[1].0, "update");
         assert_eq!(rows[1].1, "updated");
+        assert_eq!(rows[1].2, "あっぷでーと2");
 
         let es_count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM event_set WHERE user_id = $1")
             .bind(user_id.as_str())

--- a/src/infrastructure/author_repository.rs
+++ b/src/infrastructure/author_repository.rs
@@ -165,7 +165,14 @@ impl AuthorRepository for PgAuthorRepository {
         user_id: &UserId,
         author_id: &AuthorId,
     ) -> Result<Option<Author>, DomainError> {
-        find_author_by_id_with_executor(tx.as_mut(), user_id, author_id).await
+        let row: Option<AuthorRow> =
+            sqlx::query_as("SELECT * FROM author WHERE id = $1 AND user_id = $2 FOR UPDATE")
+                .bind(author_id.to_uuid())
+                .bind(user_id.as_str())
+                .fetch_optional(tx.as_mut())
+                .await?;
+
+        author_from_optional_row(row)
     }
 
     async fn find_all(&self, user_id: &UserId) -> Result<Vec<Author>, DomainError> {
@@ -454,6 +461,10 @@ where
             .fetch_optional(executor)
             .await?;
 
+    author_from_optional_row(row)
+}
+
+fn author_from_optional_row(row: Option<AuthorRow>) -> Result<Option<Author>, DomainError> {
     row.map(|row| -> Result<Author, DomainError> {
         let author_id: AuthorId = row.id.into();
         let author_name = AuthorName::new(row.name)?;

--- a/src/infrastructure/author_repository.rs
+++ b/src/infrastructure/author_repository.rs
@@ -325,20 +325,25 @@ impl AuthorRepository for PgAuthorRepository {
 
         match author {
             Some(author) => {
-                let result = sqlx::query("UPDATE author SET name=$2 WHERE id=$1 AND user_id=$3")
-                    .bind(author.id().to_uuid())
-                    .bind(author.name().as_str())
-                    .bind(user_id.as_str())
-                    .execute(tx.as_mut())
-                    .await?;
-
-                if result.rows_affected() == 0 {
-                    sqlx::query("INSERT INTO author (id, user_id, name) VALUES ($1, $2, $3)")
+                let result =
+                    sqlx::query("UPDATE author SET name=$2, yomi=$3 WHERE id=$1 AND user_id=$4")
                         .bind(author.id().to_uuid())
-                        .bind(user_id.as_str())
                         .bind(author.name().as_str())
+                        .bind(author.yomi())
+                        .bind(user_id.as_str())
                         .execute(tx.as_mut())
                         .await?;
+
+                if result.rows_affected() == 0 {
+                    sqlx::query(
+                        "INSERT INTO author (id, user_id, name, yomi) VALUES ($1, $2, $3, $4)",
+                    )
+                    .bind(author.id().to_uuid())
+                    .bind(user_id.as_str())
+                    .bind(author.name().as_str())
+                    .bind(author.yomi())
+                    .execute(tx.as_mut())
+                    .await?;
                 }
 
                 let snapshot: AuthorSnapshotRow = sqlx::query_as(
@@ -533,6 +538,21 @@ mod tests {
         let tm = PgTransactionManager::new(pool.clone());
         let mut tx = tm.begin(user_id, EventSetOperation::DeleteAuthor).await?;
         author_repository.delete(&mut tx, author_id).await?;
+        tm.commit(tx).await
+    }
+
+    async fn restore_author(
+        pool: &PgPool,
+        author_repository: &PgAuthorRepository,
+        user_id: &UserId,
+        source_event_id: i64,
+        author: Author,
+    ) -> Result<(), DomainError> {
+        let tm = PgTransactionManager::new(pool.clone());
+        let mut tx = tm.begin(user_id, EventSetOperation::RestoreAuthor).await?;
+        author_repository
+            .restore(&mut tx, source_event_id, Some(author))
+            .await?;
         tm.commit(tx).await
     }
 
@@ -985,6 +1005,57 @@ mod tests {
             .fetch_one(&pool)
             .await?;
         assert_eq!(es_count.0, 2);
+
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn restore_persists_yomi_and_records_it(pool: PgPool) -> anyhow::Result<()> {
+        let user_repository = PgUserRepository::new(pool.clone());
+        let author_repository = PgAuthorRepository::new(pool.clone());
+
+        let user_id = prepare_user(&user_repository, "user1").await?;
+        let author_id = AuthorId::try_from("e324be11-5b77-4ba6-8423-9f27e2d228f1")?;
+        let author = Author::new(author_id.clone(), AuthorName::new("original".to_owned())?)?;
+        create_author(&pool, &author_repository, &user_id, &author).await?;
+
+        let (source_event_id,): (i64,) = sqlx::query_as(
+            "SELECT event_id FROM author_event WHERE user_id = $1 AND operation = 'create'",
+        )
+        .bind(user_id.as_str())
+        .fetch_one(&pool)
+        .await?;
+        let restored = Author::new_with_yomi(
+            author_id.clone(),
+            AuthorName::new("restored".to_owned())?,
+            "れすとあ".to_owned(),
+        )?;
+
+        restore_author(
+            &pool,
+            &author_repository,
+            &user_id,
+            source_event_id,
+            restored,
+        )
+        .await?;
+
+        let live = author_repository
+            .find_by_id(&user_id, &author_id)
+            .await?
+            .expect("restored author should exist");
+        assert_eq!(live.name().as_str(), "restored");
+        assert_eq!(live.yomi(), "れすとあ");
+
+        let (event_name, event_yomi): (String, String) = sqlx::query_as(
+            "SELECT name, yomi FROM author_event
+             WHERE user_id = $1 AND operation = 'restore'",
+        )
+        .bind(user_id.as_str())
+        .fetch_one(&pool)
+        .await?;
+        assert_eq!(event_name, "restored");
+        assert_eq!(event_yomi, "れすとあ");
 
         Ok(())
     }

--- a/src/infrastructure/author_repository.rs
+++ b/src/infrastructure/author_repository.rs
@@ -22,6 +22,7 @@ use crate::infrastructure::transaction::PgTransaction;
 struct AuthorRow {
     id: Uuid,
     name: String,
+    yomi: String,
 }
 
 #[derive(sqlx::FromRow)]
@@ -176,7 +177,7 @@ impl AuthorRepository for PgAuthorRepository {
                         let row = row?;
                         let author_id = AuthorId::new(row.id);
                         let author_name = AuthorName::new(row.name)?;
-                        let author = Author::new(author_id, author_name)?;
+                        let author = Author::new_with_yomi(author_id, author_name, row.yomi)?;
                         Ok(author)
                     },
                 )
@@ -419,7 +420,7 @@ impl AuthorRepository for PgAuthorRepository {
                 let row = row?;
                 let author_id = AuthorId::new(row.id);
                 let author_name = AuthorName::new(row.name)?;
-                let author = Author::new(author_id.clone(), author_name)?;
+                let author = Author::new_with_yomi(author_id.clone(), author_name, row.yomi)?;
                 Ok((author_id, author))
             },
         )
@@ -448,7 +449,7 @@ where
     row.map(|row| -> Result<Author, DomainError> {
         let author_id: AuthorId = row.id.into();
         let author_name = AuthorName::new(row.name)?;
-        Author::new(author_id, author_name)
+        Author::new_with_yomi(author_id, author_name, row.yomi)
     })
     .transpose()
 }

--- a/src/presentation/graphql/object.rs
+++ b/src/presentation/graphql/object.rs
@@ -238,18 +238,23 @@ impl From<UpdateBookInput> for UpdateBookDto {
 pub struct Author {
     pub id: ID,
     pub name: String,
+    pub yomi: String,
 }
 
 impl Author {
-    pub fn new(id: String, name: String) -> Self {
-        Self { id: ID(id), name }
+    pub fn new(id: String, name: String, yomi: String) -> Self {
+        Self {
+            id: ID(id),
+            name,
+            yomi,
+        }
     }
 }
 
 impl From<AuthorDto> for Author {
     fn from(author: AuthorDto) -> Self {
-        let AuthorDto { id, name } = author;
-        Author::new(id, name)
+        let AuthorDto { id, name, yomi } = author;
+        Author::new(id, name, yomi)
     }
 }
 

--- a/src/presentation/graphql/object.rs
+++ b/src/presentation/graphql/object.rs
@@ -261,17 +261,21 @@ impl From<AuthorDto> for Author {
 #[derive(InputObject)]
 pub struct CreateAuthorInput {
     pub name: String,
+    pub yomi: Option<String>,
 }
 
 impl CreateAuthorInput {
     pub fn new(name: String) -> Self {
-        Self { name }
+        Self { name, yomi: None }
     }
 }
 
 impl From<CreateAuthorInput> for CreateAuthorDto {
     fn from(val: CreateAuthorInput) -> Self {
-        CreateAuthorDto::new(val.name)
+        CreateAuthorDto {
+            name: val.name,
+            yomi: val.yomi,
+        }
     }
 }
 
@@ -279,11 +283,16 @@ impl From<CreateAuthorInput> for CreateAuthorDto {
 pub struct UpdateAuthorInput {
     pub id: ID,
     pub name: String,
+    pub yomi: Option<String>,
 }
 
 impl From<UpdateAuthorInput> for UpdateAuthorDto {
     fn from(val: UpdateAuthorInput) -> Self {
-        UpdateAuthorDto::new(val.id.to_string(), val.name)
+        UpdateAuthorDto {
+            id: val.id.to_string(),
+            name: val.name,
+            yomi: val.yomi,
+        }
     }
 }
 
@@ -483,6 +492,7 @@ pub struct AuthorMutationPayload {
     pub event_set_id: ID,
     pub id: ID,
     pub name: String,
+    pub yomi: String,
 }
 
 impl AuthorMutationPayload {
@@ -490,6 +500,7 @@ impl AuthorMutationPayload {
         Self {
             id: author.id.clone(),
             name: author.name.clone(),
+            yomi: author.yomi.clone(),
             author,
             event_set_id,
         }

--- a/src/presentation/graphql/query.rs
+++ b/src/presentation/graphql/query.rs
@@ -60,7 +60,7 @@ where
             .query_use_case
             .find_author_by_id(&claims.sub, id.as_str())
             .await?;
-        Ok(author.map(|author| Author::new(author.id, author.name)))
+        Ok(author.map(Author::from))
     }
 
     async fn authors(&self, ctx: &Context<'_>) -> Result<Vec<Author>, PresentationalError> {

--- a/src/presentation/graphql/schema.rs
+++ b/src/presentation/graphql/schema.rs
@@ -46,6 +46,7 @@ mod tests {
                 Ok(Some(AuthorDto {
                     id: author_id.to_string(),
                     name: author_name.to_string(),
+                    yomi: "おーさーわん".to_string(),
                 }))
             });
         let query = Query::new(mock_query_use_case);
@@ -59,12 +60,13 @@ mod tests {
         let res = schema
             .execute(
                 async_graphql::Request::from(
-                    r#"query { author(id: "d065a358-4fa7-4236-ae19-f6f2f9467c35") {id, name} }"#,
+                    r#"query { author(id: "d065a358-4fa7-4236-ae19-f6f2f9467c35") {id, name, yomi} }"#,
                 )
                 .data(claims),
             )
             .await;
         let json = serde_json::to_value(&res).unwrap();
         assert_eq!(json["data"]["author"]["name"], author_name);
+        assert_eq!(json["data"]["author"]["yomi"], "おーさーわん");
     }
 }

--- a/src/use_case/dto/author.rs
+++ b/src/use_case/dto/author.rs
@@ -4,14 +4,16 @@ use crate::domain::entity::author::{Author, DestructureAuthor};
 pub struct AuthorDto {
     pub id: String,
     pub name: String,
+    pub yomi: String,
 }
 
 impl From<Author> for AuthorDto {
     fn from(author: Author) -> Self {
-        let DestructureAuthor { id, name } = author.destructure();
+        let DestructureAuthor { id, name, yomi } = author.destructure();
         AuthorDto {
             id: id.to_string(),
             name: name.into_string(),
+            yomi,
         }
     }
 }
@@ -62,6 +64,7 @@ mod tests {
             AuthorDto {
                 id: author_id_str.to_string(),
                 name: "Test Author".to_string(),
+                yomi: String::new(),
             }
         );
     }

--- a/src/use_case/dto/author.rs
+++ b/src/use_case/dto/author.rs
@@ -20,22 +20,28 @@ impl From<Author> for AuthorDto {
 
 pub struct CreateAuthorDto {
     pub name: String,
+    pub yomi: Option<String>,
 }
 
 impl CreateAuthorDto {
     pub fn new(name: String) -> Self {
-        Self { name }
+        Self { name, yomi: None }
     }
 }
 
 pub struct UpdateAuthorDto {
     pub id: String,
     pub name: String,
+    pub yomi: Option<String>,
 }
 
 impl UpdateAuthorDto {
     pub fn new(id: String, name: String) -> Self {
-        Self { id, name }
+        Self {
+            id,
+            name,
+            yomi: None,
+        }
     }
 }
 

--- a/src/use_case/interactor/author.rs
+++ b/src/use_case/interactor/author.rs
@@ -4,7 +4,7 @@ use uuid::Uuid;
 use crate::{
     domain::{
         entity::{
-            author::{Author, AuthorId, AuthorName, AuthorUpdate},
+            author::{Author, AuthorId, AuthorName, AuthorUpdate, validate_author_yomi},
             event::EventSetOperation,
             user::UserId,
         },
@@ -52,7 +52,8 @@ where
         let uuid = Uuid::new_v4();
         let author_id = AuthorId::new(uuid);
         let author_name = AuthorName::new(author_data.name)?;
-        let author = Author::new(author_id, author_name)?;
+        let yomi = validate_author_yomi(author_data.yomi.unwrap_or_default())?;
+        let author = Author::new_with_yomi(author_id, author_name, yomi)?;
 
         let mut tx = self
             .transaction_manager
@@ -94,6 +95,7 @@ where
         let user_id = UserId::new(user_id.to_string())?;
         let author_id = AuthorId::try_from(author_data.id.as_str())?;
         let author_name = AuthorName::new(author_data.name)?;
+        let yomi = author_data.yomi.map(validate_author_yomi).transpose()?;
 
         let mut tx = self
             .transaction_manager
@@ -114,7 +116,10 @@ where
             }
         };
 
-        author.update(AuthorUpdate { name: author_name });
+        author.update(AuthorUpdate {
+            name: author_name,
+            yomi,
+        });
 
         self.author_repository.update(&mut tx, &author).await?;
         let event_set_id = tx.event_set_id().hyphenated().to_string();
@@ -206,7 +211,8 @@ mod tests {
             .returning(|_, _| Ok(()));
 
         let interactor = CreateAuthorInteractor::new(author_repository, make_transaction_manager());
-        let author_data = CreateAuthorDto::new("Test Author".to_string());
+        let mut author_data = CreateAuthorDto::new("Test Author".to_string());
+        author_data.yomi = Some("てすと・おーさー1".to_string());
 
         // When
         let result = interactor.create("user1", author_data).await;
@@ -215,6 +221,7 @@ mod tests {
         assert!(result.is_ok());
         let dto = result.unwrap();
         assert_eq!(dto.name, "Test Author");
+        assert_eq!(dto.yomi, "てすと・おーさー1");
     }
 
     #[tokio::test]
@@ -248,13 +255,27 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn create_author_fails_with_invalid_yomi() {
+        let author_repository = MockAuthorRepository::new();
+        let interactor =
+            CreateAuthorInteractor::new(author_repository, MockTransactionManager::new());
+        let mut author_data = CreateAuthorDto::new("Test Author".to_string());
+        author_data.yomi = Some("テスト".to_string());
+
+        let result = interactor.create("user1", author_data).await;
+
+        assert!(matches!(result, Err(UseCaseError::Validation(_))));
+    }
+
+    #[tokio::test]
     async fn update_author_success() {
         // Given
         let author_id_str = "006099b4-6c42-4ec4-8645-f6bd5b63eddc";
 
-        let existing_author = Author::new(
+        let existing_author = Author::new_with_yomi(
             AuthorId::try_from(author_id_str).unwrap(),
             AuthorName::new("Old Name".to_string()).unwrap(),
+            "もとのよみ".to_string(),
         )
         .unwrap();
 
@@ -276,7 +297,54 @@ mod tests {
 
         // Then
         assert!(result.is_ok());
-        assert_eq!(result.unwrap().name, "New Name");
+        let updated = result.unwrap();
+        assert_eq!(updated.name, "New Name");
+        assert_eq!(updated.yomi, "もとのよみ");
+    }
+
+    #[tokio::test]
+    async fn update_author_changes_yomi_when_provided() {
+        let author_id_str = "006099b4-6c42-4ec4-8645-f6bd5b63eddc";
+        let existing_author = Author::new_with_yomi(
+            AuthorId::try_from(author_id_str).unwrap(),
+            AuthorName::new("Old Name".to_string()).unwrap(),
+            "もとのよみ".to_string(),
+        )
+        .unwrap();
+
+        let mut author_repository = MockAuthorRepository::new();
+        author_repository
+            .expect_find_by_id_with_tx()
+            .return_once(move |_, _, _| Ok(Some(existing_author)));
+        author_repository
+            .expect_update()
+            .withf(|_, author| author.yomi() == "")
+            .returning(|_, _| Ok(()));
+
+        let interactor = UpdateAuthorInteractor::new(author_repository, make_transaction_manager());
+        let mut author_data =
+            UpdateAuthorDto::new(author_id_str.to_string(), "New Name".to_string());
+        author_data.yomi = Some(String::new());
+
+        let result = interactor.update("user1", author_data).await.unwrap();
+
+        assert_eq!(result.yomi, "");
+    }
+
+    #[tokio::test]
+    async fn update_author_fails_with_invalid_yomi() {
+        let author_repository = MockAuthorRepository::new();
+        let interactor =
+            UpdateAuthorInteractor::new(author_repository, MockTransactionManager::new());
+        let mut author_data = UpdateAuthorDto::new(
+            "006099b4-6c42-4ec4-8645-f6bd5b63eddc".to_string(),
+            "New Name".to_string(),
+        );
+        author_data.yomi = Some("New Name".to_string());
+
+        let result = interactor.update("user1", author_data).await;
+
+        assert!(matches!(result, Err(UseCaseError::Validation(_))));
     }
 
     #[tokio::test]

--- a/src/use_case/interactor/event.rs
+++ b/src/use_case/interactor/event.rs
@@ -590,6 +590,36 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn restore_author_preserves_legacy_yomi() {
+        let author_uuid = Uuid::new_v4();
+        let mut event = make_author_event(author_uuid);
+        event.yomi = Some("authora".to_string());
+
+        let mut history_repo = MockAuthorEventRepository::new();
+        history_repo
+            .expect_find_by_event_id()
+            .with(always(), eq(2i64))
+            .returning(move |_, _| Ok(Some(event.clone())));
+
+        let mut author_repo = MockAuthorRepository::new();
+        author_repo
+            .expect_restore()
+            .withf(|_, event_id, author| {
+                *event_id == 2
+                    && author
+                        .as_ref()
+                        .is_some_and(|author| author.yomi() == "authora")
+            })
+            .returning(|_, _, _| Ok(()));
+
+        let interactor =
+            RestoreAuthorInteractor::new(author_repo, history_repo, make_transaction_manager());
+        let result = interactor.restore("user1", 2).await;
+
+        assert_eq!(result.unwrap().value.unwrap().yomi, "authora");
+    }
+
+    #[tokio::test]
     async fn restore_author_delete_event_deletes_author() {
         let author_uuid = Uuid::new_v4();
         let event = make_author_delete_event(author_uuid);

--- a/src/use_case/interactor/event.rs
+++ b/src/use_case/interactor/event.rs
@@ -3,7 +3,7 @@ use async_trait::async_trait;
 use crate::{
     domain::{
         entity::{
-            author::{Author, AuthorId, AuthorName, validate_author_yomi},
+            author::{Author, AuthorId, AuthorName},
             book::{Book, BookId},
             event::{EventOperation, EventSetOperation},
             user::UserId,
@@ -249,7 +249,6 @@ where
                 let yomi = event.yomi.ok_or_else(|| {
                     UseCaseError::Validation("author_event yomi is null".to_string())
                 })?;
-                let yomi = validate_author_yomi(yomi)?;
                 let author_name = AuthorName::new(name)?;
                 let author = Author::new_with_yomi(event.author_id, author_name, yomi)?;
 
@@ -591,10 +590,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn restore_author_rejects_invalid_yomi() {
+    async fn restore_author_preserves_legacy_yomi() {
         let author_uuid = Uuid::new_v4();
         let mut event = make_author_event(author_uuid);
-        event.yomi = Some("オールド".to_string());
+        event.yomi = Some("authora".to_string());
 
         let mut history_repo = MockAuthorEventRepository::new();
         history_repo
@@ -602,12 +601,22 @@ mod tests {
             .with(always(), eq(2i64))
             .returning(move |_, _| Ok(Some(event.clone())));
 
-        let author_repo = MockAuthorRepository::new();
+        let mut author_repo = MockAuthorRepository::new();
+        author_repo
+            .expect_restore()
+            .withf(|_, event_id, author| {
+                *event_id == 2
+                    && author
+                        .as_ref()
+                        .is_some_and(|author| author.yomi() == "authora")
+            })
+            .returning(|_, _, _| Ok(()));
+
         let interactor =
-            RestoreAuthorInteractor::new(author_repo, history_repo, MockTransactionManager::new());
+            RestoreAuthorInteractor::new(author_repo, history_repo, make_transaction_manager());
         let result = interactor.restore("user1", 2).await;
 
-        assert!(matches!(result, Err(UseCaseError::Validation(_))));
+        assert_eq!(result.unwrap().value.unwrap().yomi, "authora");
     }
 
     #[tokio::test]

--- a/src/use_case/interactor/event.rs
+++ b/src/use_case/interactor/event.rs
@@ -3,7 +3,7 @@ use async_trait::async_trait;
 use crate::{
     domain::{
         entity::{
-            author::{Author, AuthorId, AuthorName},
+            author::{Author, AuthorId, AuthorName, validate_author_yomi},
             book::{Book, BookId},
             event::{EventOperation, EventSetOperation},
             user::UserId,
@@ -249,6 +249,7 @@ where
                 let yomi = event.yomi.ok_or_else(|| {
                     UseCaseError::Validation("author_event yomi is null".to_string())
                 })?;
+                let yomi = validate_author_yomi(yomi)?;
                 let author_name = AuthorName::new(name)?;
                 let author = Author::new_with_yomi(event.author_id, author_name, yomi)?;
 
@@ -587,6 +588,26 @@ mod tests {
         let restored = result.unwrap().value.unwrap();
         assert_eq!(restored.name, "Old Name");
         assert_eq!(restored.yomi, "おーるど");
+    }
+
+    #[tokio::test]
+    async fn restore_author_rejects_invalid_yomi() {
+        let author_uuid = Uuid::new_v4();
+        let mut event = make_author_event(author_uuid);
+        event.yomi = Some("オールド".to_string());
+
+        let mut history_repo = MockAuthorEventRepository::new();
+        history_repo
+            .expect_find_by_event_id()
+            .with(always(), eq(2i64))
+            .returning(move |_, _| Ok(Some(event.clone())));
+
+        let author_repo = MockAuthorRepository::new();
+        let interactor =
+            RestoreAuthorInteractor::new(author_repo, history_repo, MockTransactionManager::new());
+        let result = interactor.restore("user1", 2).await;
+
+        assert!(matches!(result, Err(UseCaseError::Validation(_))));
     }
 
     #[tokio::test]

--- a/src/use_case/interactor/event.rs
+++ b/src/use_case/interactor/event.rs
@@ -246,8 +246,11 @@ where
                 let name = event.name.ok_or_else(|| {
                     UseCaseError::Validation("author_event name is null".to_string())
                 })?;
+                let yomi = event.yomi.ok_or_else(|| {
+                    UseCaseError::Validation("author_event yomi is null".to_string())
+                })?;
                 let author_name = AuthorName::new(name)?;
-                let author = Author::new(event.author_id, author_name)?;
+                let author = Author::new_with_yomi(event.author_id, author_name, yomi)?;
 
                 let dto = AuthorDto::from(author.clone());
                 let mut tx = self
@@ -368,7 +371,7 @@ mod tests {
             operation: EventOperation::Update,
             author_id: AuthorId::new(author_id),
             name: Some("Old Name".to_string()),
-            yomi: Some("".to_string()),
+            yomi: Some("おーるど".to_string()),
             author_created_at: Some(OffsetDateTime::now_utc()),
             author_updated_at: Some(OffsetDateTime::now_utc()),
             changed_at: OffsetDateTime::now_utc(),
@@ -568,7 +571,12 @@ mod tests {
         let mut author_repo = MockAuthorRepository::new();
         author_repo
             .expect_restore()
-            .with(always(), eq(2i64), always())
+            .withf(|_, event_id, author| {
+                *event_id == 2
+                    && author
+                        .as_ref()
+                        .is_some_and(|author| author.yomi() == "おーるど")
+            })
             .returning(|_, _, _| Ok(()));
 
         let interactor =
@@ -576,7 +584,9 @@ mod tests {
         let result = interactor.restore("user1", 2).await;
 
         assert!(result.is_ok());
-        assert_eq!(result.unwrap().value.unwrap().name, "Old Name");
+        let restored = result.unwrap().value.unwrap();
+        assert_eq!(restored.name, "Old Name");
+        assert_eq!(restored.yomi, "おーるど");
     }
 
     #[tokio::test]

--- a/src/use_case/interactor/event.rs
+++ b/src/use_case/interactor/event.rs
@@ -3,7 +3,7 @@ use async_trait::async_trait;
 use crate::{
     domain::{
         entity::{
-            author::{Author, AuthorId, AuthorName},
+            author::{Author, AuthorId, AuthorName, validate_author_yomi},
             book::{Book, BookId},
             event::{EventOperation, EventSetOperation},
             user::UserId,
@@ -249,6 +249,7 @@ where
                 let yomi = event.yomi.ok_or_else(|| {
                     UseCaseError::Validation("author_event yomi is null".to_string())
                 })?;
+                let yomi = validate_author_yomi(yomi)?;
                 let author_name = AuthorName::new(name)?;
                 let author = Author::new_with_yomi(event.author_id, author_name, yomi)?;
 
@@ -590,7 +591,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn restore_author_preserves_legacy_yomi() {
+    async fn restore_author_rejects_invalid_yomi() {
         let author_uuid = Uuid::new_v4();
         let mut event = make_author_event(author_uuid);
         event.yomi = Some("authora".to_string());
@@ -601,22 +602,12 @@ mod tests {
             .with(always(), eq(2i64))
             .returning(move |_, _| Ok(Some(event.clone())));
 
-        let mut author_repo = MockAuthorRepository::new();
-        author_repo
-            .expect_restore()
-            .withf(|_, event_id, author| {
-                *event_id == 2
-                    && author
-                        .as_ref()
-                        .is_some_and(|author| author.yomi() == "authora")
-            })
-            .returning(|_, _, _| Ok(()));
-
+        let author_repo = MockAuthorRepository::new();
         let interactor =
-            RestoreAuthorInteractor::new(author_repo, history_repo, make_transaction_manager());
+            RestoreAuthorInteractor::new(author_repo, history_repo, MockTransactionManager::new());
         let result = interactor.restore("user1", 2).await;
 
-        assert_eq!(result.unwrap().value.unwrap().yomi, "authora");
+        assert!(matches!(result, Err(UseCaseError::Validation(_))));
     }
 
     #[tokio::test]

--- a/src/use_case/interactor/event.rs
+++ b/src/use_case/interactor/event.rs
@@ -3,7 +3,7 @@ use async_trait::async_trait;
 use crate::{
     domain::{
         entity::{
-            author::{Author, AuthorId, AuthorName, validate_author_yomi},
+            author::{Author, AuthorId, AuthorName},
             book::{Book, BookId},
             event::{EventOperation, EventSetOperation},
             user::UserId,
@@ -249,7 +249,6 @@ where
                 let yomi = event.yomi.ok_or_else(|| {
                     UseCaseError::Validation("author_event yomi is null".to_string())
                 })?;
-                let yomi = validate_author_yomi(yomi)?;
                 let author_name = AuthorName::new(name)?;
                 let author = Author::new_with_yomi(event.author_id, author_name, yomi)?;
 
@@ -588,26 +587,6 @@ mod tests {
         let restored = result.unwrap().value.unwrap();
         assert_eq!(restored.name, "Old Name");
         assert_eq!(restored.yomi, "おーるど");
-    }
-
-    #[tokio::test]
-    async fn restore_author_rejects_invalid_yomi() {
-        let author_uuid = Uuid::new_v4();
-        let mut event = make_author_event(author_uuid);
-        event.yomi = Some("authora".to_string());
-
-        let mut history_repo = MockAuthorEventRepository::new();
-        history_repo
-            .expect_find_by_event_id()
-            .with(always(), eq(2i64))
-            .returning(move |_, _| Ok(Some(event.clone())));
-
-        let author_repo = MockAuthorRepository::new();
-        let interactor =
-            RestoreAuthorInteractor::new(author_repo, history_repo, MockTransactionManager::new());
-        let result = interactor.restore("user1", 2).await;
-
-        assert!(matches!(result, Err(UseCaseError::Validation(_))));
     }
 
     #[tokio::test]

--- a/src/use_case/interactor/mutation.rs
+++ b/src/use_case/interactor/mutation.rs
@@ -471,6 +471,7 @@ mod tests {
                     AuthorDto {
                         id: "006099b4-6c42-4ec4-8645-f6bd5b63eddc".to_string(),
                         name: data.name.clone(),
+                        yomi: String::new(),
                     },
                     "event-set".to_string(),
                 ))
@@ -502,6 +503,7 @@ mod tests {
                     AuthorDto {
                         id: "006099b4-6c42-4ec4-8645-f6bd5b63eddc".to_string(),
                         name: data.name.clone(),
+                        yomi: String::new(),
                     },
                     "event-set".to_string(),
                 ))
@@ -614,6 +616,7 @@ mod tests {
                     Some(AuthorDto {
                         id: "006099b4-6c42-4ec4-8645-f6bd5b63eddc".to_string(),
                         name: "Test Author".to_string(),
+                        yomi: String::new(),
                     }),
                     "event-set".to_string(),
                 ))

--- a/src/use_case/interactor/query.rs
+++ b/src/use_case/interactor/query.rs
@@ -444,6 +444,7 @@ mod tests {
         let expected = Some(AuthorDto {
             id: author_id.to_owned(),
             name: author_name.to_owned(),
+            yomi: String::new(),
         });
 
         assert_eq!(actual, expected);
@@ -640,6 +641,7 @@ mod tests {
             AuthorDto {
                 id: "006099b4-6c42-4ec4-8645-f6bd5b63eddc".to_string(),
                 name: "author1".to_string(),
+                yomi: String::new(),
             }
         );
     }
@@ -686,6 +688,7 @@ mod tests {
             &AuthorDto {
                 id: author_id_str.to_string(),
                 name: "author1".to_string(),
+                yomi: String::new(),
             }
         );
     }


### PR DESCRIPTION
## Summary

- expose the existing `author.yomi` value as `Author.yomi: String!` in GraphQL
- propagate yomi through the repository, domain entity, use-case DTO, and presentation layers
- update the generated schema and GraphQL unit/E2E coverage

## Why

The database already stores author readings in `author.yomi`, but regular author GraphQL queries did not return that value. Clients therefore could not use the reading data outside author event history.

## Impact

Clients can request `yomi` from `author`, `authors`, mutation payload authors, and authors loaded for books. Existing records without a reading continue to return the database default empty string.

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets --locked -- -D warnings`
- `CARGO_PROFILE_TEST_DEBUG=0 cargo test --locked` (139 passed)

The GraphQL E2E assertions were updated, but the external DB/JWKS-backed E2E suite was not run locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 著者に「yomi」情報を追加し、GraphQLで取得・作成・更新できるようになりました。
  * 著者作成・更新時に、yomiの入力値を検証します。
  * yomiを省略した更新では既存値を保持し、空文字を指定するとクリアできます。
  * 著者の履歴や復元でも、yomiが正しく保存・復元されます。

* **バグ修正**
  * 不正なyomi入力時に適切なエラーを返すよう改善しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->