### PR TITLE
Document Codex gh sandbox behavior

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,16 @@ Always use `--no-pager` flag with git commands:
 git --no-pager diff
 ```
 
+## GitHub CLI Authentication
+
+When running as Codex, do not immediately conclude that GitHub CLI is
+unauthenticated when a `gh` command fails with an authentication or
+network-related error. Sandbox restrictions can cause misleading failures.
+
+Retry the required command with escalated sandbox permissions first. Only ask
+the user to re-authenticate when the authentication failure also occurs outside
+the sandbox.
+
 ## Branch Workflow
 
 Before making any changes, verify you are not on `main`:


### PR DESCRIPTION
## Summary

- document how Codex should handle misleading GitHub CLI authentication errors
- require retrying relevant `gh` commands outside the sandbox before requesting re-authentication

## Why

Sandbox restrictions can make an authenticated GitHub CLI session appear
unauthenticated. Treating that result as definitive causes unnecessary
re-authentication requests.

## Impact

Codex agents working in this repository will distinguish sandbox failures from
actual GitHub CLI authentication failures.

## Validation

- Documentation-only change; Cargo checks were not required
- Confirmed `gh auth status` fails inside the sandbox and succeeds with escalated
  sandbox permissions
