### PR TITLE
Unify mutation payloads

### DIFF
--- a/.agent/plans/20260716-unify-mutation-payloads.md
+++ b/.agent/plans/20260716-unify-mutation-payloads.md
@@ -12,17 +12,17 @@ GraphQL mutations currently expose each changed entity twice: once through the c
   - [x] plan updated
 - [x] (2026-07-16) Milestone 2: Remove aliases, add schema-focused tests, and regenerate `schema.graphql`.
   - [x] plan updated
-- [ ] Milestone 3: Run schema freshness, formatting, clippy, and unit tests, then commit and publish the API PR (completed: schema freshness, formatting, clippy, and 140 unit tests pass; remaining: commit and publish).
-  - [ ] plan updated
-- [ ] Milestone 4: Confirm cross-repository compatibility with the migrated frontend (completed: candidate SDL accepts all migrated mutation documents; remaining: full frontend typecheck is blocked by the candidate schema's unrelated `Author.yomi` requirement).
-  - [ ] plan updated
+- [x] (2026-07-16) Milestone 3: Run schema freshness, formatting, clippy, and unit tests, then commit and publish API draft PR #284.
+  - [x] plan updated
+- [x] (2026-07-17) Milestone 4: Confirm cross-repository compatibility by generating frontend types from the alias-free candidate SDL and passing the full frontend typecheck.
+  - [x] plan updated
 
 ## Surprises & Discoveries
 
-- Observation: The candidate schema makes `Author.yomi` required relative to the released frontend schema, independently of this mutation payload change.
-  Evidence: Candidate-SDL GraphQL Codegen succeeds for every migrated mutation, while frontend typecheck reports only existing fixtures and mappings that omit `yomi`.
 - Observation: Browser E2E cannot launch on the current host because `libnspr4.so` is absent and installing OS dependencies requires an unavailable sudo password.
   Evidence: Playwright stops in `browserType.launch` before executing application steps; API schema tests and frontend unit/type checks are unaffected.
+- Observation: PR #284 was initially based on the unmerged PR #282 branch and therefore included unrelated `Author.yomi` changes.
+  Evidence: Rebasing commits after `1587f01` onto `origin/main` removes PR #282 files; candidate-schema frontend generation and full typecheck then pass.
 
 ## Decision Log
 
@@ -35,7 +35,7 @@ GraphQL mutations currently expose each changed entity twice: once through the c
 
 ## Outcomes & Retrospective
 
-The payload structs and resolvers now expose one canonical entity representation, the checked-in SDL is regenerated, and a schema-focused test fixes the exact allowed field sets. Schema freshness, formatting, clippy, and all 140 unit tests pass. Publication remains in progress.
+The payload structs and resolvers now expose one canonical entity representation, the checked-in SDL is regenerated, and a schema-focused test fixes the exact allowed field sets. Schema freshness, formatting, clippy, all 140 unit tests, and candidate-schema frontend type checking pass. Draft PR #284 publishes only the mutation payload change and documents the required frontend-first release order.
 
 ## Context and Orientation
 
@@ -65,4 +65,4 @@ The client portion is tracked in `bookshelf/.agent/plans/20260716-unify-mutation
 
 No new dependencies or endpoints are permitted. `BookMutationPayload` must expose only `book` and `eventSetId`; `AuthorMutationPayload` only `author` and `eventSetId`; delete payloads expose the entity-specific ID and `eventSetId`.
 
-Plan revision note (2026-07-16): Recorded successful schema freshness, formatting, clippy, and full unit-test validation after completing the API implementation.
+Plan revision note (2026-07-17): Removed stale findings caused by the accidental PR #282 base, recorded the clean rebase onto `origin/main`, and completed candidate-schema frontend validation.

--- a/.agent/plans/20260716-unify-mutation-payloads.md
+++ b/.agent/plans/20260716-unify-mutation-payloads.md
@@ -1,0 +1,68 @@
+# Remove mutation payload compatibility aliases
+
+This ExecPlan is a living document maintained according to `.agent/PLANS.md`. The `Progress`, `Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` sections must remain current.
+
+## Purpose / Big Picture
+
+GraphQL mutations currently expose each changed entity twice: once through the canonical nested entity and again through copied fields at the payload root. After this work, clients have one stable representation, while every mutation retains its event-set identifier. The generated schema and schema tests demonstrate that canonical fields remain and compatibility aliases are absent.
+
+## Progress
+
+- [x] (2026-07-16) Milestone 1: Review the OpenSpec change and establish the coordinated frontend-first rollout.
+  - [x] plan updated
+- [x] (2026-07-16) Milestone 2: Remove aliases, add schema-focused tests, and regenerate `schema.graphql`.
+  - [x] plan updated
+- [ ] Milestone 3: Run schema freshness, formatting, clippy, and unit tests, then commit and publish the API PR (completed: schema freshness, formatting, clippy, and 140 unit tests pass; remaining: commit and publish).
+  - [ ] plan updated
+- [ ] Milestone 4: Confirm cross-repository compatibility with the migrated frontend (completed: candidate SDL accepts all migrated mutation documents; remaining: full frontend typecheck is blocked by the candidate schema's unrelated `Author.yomi` requirement).
+  - [ ] plan updated
+
+## Surprises & Discoveries
+
+- Observation: The candidate schema makes `Author.yomi` required relative to the released frontend schema, independently of this mutation payload change.
+  Evidence: Candidate-SDL GraphQL Codegen succeeds for every migrated mutation, while frontend typecheck reports only existing fixtures and mappings that omit `yomi`.
+- Observation: Browser E2E cannot launch on the current host because `libnspr4.so` is absent and installing OS dependencies requires an unavailable sudo password.
+  Evidence: Playwright stops in `browserType.launch` before executing application steps; API schema tests and frontend unit/type checks are unaffected.
+
+## Decision Log
+
+- Decision: Keep `book` and `author` as the only create/update entity representations and descriptive identifiers for delete payloads.
+  Rationale: This avoids copying entity fields into payload structs and makes deleted identifier ownership explicit.
+  Date/Author: 2026-07-16 / Codex
+- Decision: Publish the frontend migration before the API alias removal.
+  Rationale: Canonical selections work against both API versions, while old alias selections fail against the new schema.
+  Date/Author: 2026-07-16 / Codex
+
+## Outcomes & Retrospective
+
+The payload structs and resolvers now expose one canonical entity representation, the checked-in SDL is regenerated, and a schema-focused test fixes the exact allowed field sets. Schema freshness, formatting, clippy, and all 140 unit tests pass. Publication remains in progress.
+
+## Context and Orientation
+
+This Rust service builds its GraphQL schema from async-graphql types and writes the checked-in result to `schema.graphql`. Mutation payload structs and resolvers are located by searching for `BookMutationPayload`, `AuthorMutationPayload`, `DeleteBookPayload`, and `DeleteAuthorPayload`. `eventSetId` identifies the transaction event set and must remain present.
+
+## Plan of Work
+
+Remove copied book and author fields from create/update payload structs and constructors. Remove generic `id` from delete payload structs and constructors while retaining `bookId` or `authorId`. Add a schema-focused test that proves the exact allowed field sets, regenerate the schema, and update the OpenSpec task status as milestones complete.
+
+## Concrete Steps
+
+From `bookshelf-api`, locate payload definitions and schema generation commands, implement the edits, and run the CI schema freshness comparison. Before every commit run `cargo fmt --check`, `cargo clippy --all-targets --locked -- -D warnings`, and `cargo test --locked` in that order.
+
+## Validation and Acceptance
+
+The generated SDL must expose `book` plus `eventSetId`, `author` plus `eventSetId`, and descriptive delete IDs plus `eventSetId`; it must not expose copied entity fields or generic delete `id`. All mandatory Rust checks must pass. Existing CRUD E2E tests should be run when their database and authentication environment is available.
+
+## Idempotence and Recovery
+
+Schema generation, formatting, linting, and tests are repeatable. No database migration is involved. If integration validation fails, restore API compatibility aliases before deployment; do not reverse the rollout order.
+
+## Artifacts and Notes
+
+The client portion is tracked in `bookshelf/.agent/plans/20260716-unify-mutation-payloads.md`. The OpenSpec source is `openspec/changes/unify-mutation-payloads/`.
+
+## Interfaces and Dependencies
+
+No new dependencies or endpoints are permitted. `BookMutationPayload` must expose only `book` and `eventSetId`; `AuthorMutationPayload` only `author` and `eventSetId`; delete payloads expose the entity-specific ID and `eventSetId`.
+
+Plan revision note (2026-07-16): Recorded successful schema freshness, formatting, clippy, and full unit-test validation after completing the API implementation.

--- a/openspec/changes/unify-mutation-payloads/.openspec.yaml
+++ b/openspec/changes/unify-mutation-payloads/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-16

--- a/openspec/changes/unify-mutation-payloads/design.md
+++ b/openspec/changes/unify-mutation-payloads/design.md
@@ -1,0 +1,60 @@
+## Context
+
+`bookshelf-api` recently changed book and author mutations to return payload objects containing the affected entity and an `eventSetId`. Compatibility fields were then added at the payload root so the existing `bookshelf` frontend could continue selecting fields such as `createBook.id`. This produced two representations of the same value and requires payload structs to copy every entity field.
+
+The known frontend lives in the separately versioned `bookshelf` repository. Its handwritten GraphQL documents generate TypeScript SDK types, and its unit and E2E environments reproduce the GraphQL API through MSW handlers and executable mock resolvers. The current API already exposes both the compatibility aliases and the canonical nested fields, which permits a staged migration.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Establish `book` and `author` as the only entity representations in create and update payloads.
+- Establish `bookId` and `authorId` as the only deleted-entity identifiers in delete payloads.
+- Preserve `eventSetId` on every mutation payload.
+- Update the known frontend, generated types, and mocks without interrupting CRUD behavior.
+- Define a deployment order that never pairs the alias-free API with the old frontend.
+
+**Non-Goals:**
+
+- Changing mutation arguments or names.
+- Changing `Book`, `Author`, event history, database tables, or transaction recording.
+- Renaming the existing frontend file `src/graphql/deletBook.graphql`.
+- Adding new endpoints or dependencies.
+- Providing a permanent compatibility or versioning layer for unknown external clients.
+
+## Decisions
+
+The API will retain nested entity objects rather than direct payload fields. A single `Book` or `Author` GraphQL type avoids duplicating schema fields and Rust construction logic. The alternative of removing `book` and `author` would preserve the oldest frontend query shape but would make event metadata the only reason to have a payload object and would require future entity fields to be repeated.
+
+Delete payloads will retain descriptive identifiers rather than the generic `id` alias. A delete result cannot safely require a live entity object, and `bookId` or `authorId` communicates which identifier is returned. The alternative of retaining only `id` is shorter but ambiguous across payload types.
+
+The frontend migration will occur before API alias removal. The current API accepts canonical nested selections, so the new frontend works against both schema versions. The inverse deployment order is unsafe because GraphQL validates selected fields before executing a resolver.
+
+Frontend create and update operations will select entity fields through `book` or `author`. Delete operations will select `bookId` or `authorId`. Although update and delete callers currently ignore their result values, each GraphQL object selection must request at least one valid field, and selecting the canonical result keeps the documents meaningful.
+
+The frontend's unit-test MSW handlers and E2E mock resolvers will reproduce the actual payload object structure instead of returning entity objects directly. Generated GraphQL types will remain generated artifacts rather than being manually edited.
+
+API tests will verify both positive and negative schema behavior: canonical fields remain available and compatibility aliases are absent from the generated SDL. Existing API E2E tests already exercise nested create payloads, so no new endpoint-level E2E test is required.
+
+## Risks / Trade-offs
+
+- [Unknown clients still select aliases] → Treat the schema change as breaking, search known repositories, communicate it in release notes, and deploy the known frontend first.
+- [Frontend schema generation downloads the released API schema] → Migrate the frontend while the released API still contains both shapes; for local alias-free validation, copy the candidate schema and invoke GraphQL Code Generator directly.
+- [Mocks diverge from production payload structure] → Update both MSW handlers and executable GraphQL resolvers and run their associated tests.
+- [Deployment order is reversed] → Document that the frontend is forward-compatible with the new API while the old frontend is not; rollback the API first if validation errors appear.
+- [Generated files are edited inconsistently] → Regenerate `schema.graphql` from Rust and TypeScript GraphQL artifacts from their configured generators, then require clean regeneration checks.
+
+## Migration Plan
+
+1. Update `bookshelf` GraphQL documents, production consumers, generated TypeScript types, MSW handlers, and E2E mock resolvers to use nested entities and descriptive delete identifiers.
+2. Run frontend generation, unit tests, type checking, and mutation-related E2E tests.
+3. Deploy or otherwise make the frontend migration available while `bookshelf-api` still supports both payload shapes.
+4. Remove compatibility fields from the Rust payload structs and resolvers, regenerate `schema.graphql`, and add schema-focused unit coverage.
+5. Run all mandatory Rust formatting, linting, and test checks.
+6. Deploy the alias-free API after the migrated frontend.
+
+Rollback is asymmetric. If the frontend migration causes a problem, the previous frontend remains compatible with the still-compatible API. If the alias-free API is deployed too early, restore the previous API version or temporarily restore the aliases before investigating other changes.
+
+## Open Questions
+
+There are no blocking design questions. Release coordination must confirm whether any client other than `bookshelf` consumes these mutations; such a client must migrate before alias removal or receive an explicit compatibility period.

--- a/openspec/changes/unify-mutation-payloads/proposal.md
+++ b/openspec/changes/unify-mutation-payloads/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+GraphQL mutation payloads currently expose duplicate representations of the same entity, such as both `createBook.id` and `createBook.book.id`. These compatibility aliases were added during the recent payload-object migration and should be removed before clients become more dependent on them.
+
+## What Changes
+
+- **BREAKING** Remove the direct entity fields from `BookMutationPayload`, leaving `book` and `eventSetId`.
+- **BREAKING** Remove the direct `id` and `name` fields from `AuthorMutationPayload`, leaving `author` and `eventSetId`.
+- **BREAKING** Remove the generic `id` aliases from `DeleteBookPayload` and `DeleteAuthorPayload`, retaining `bookId`, `authorId`, and `eventSetId`.
+- Update the `bookshelf` frontend to select created and updated entities through `book` or `author`, and deleted identifiers through `bookId` or `authorId`.
+- Coordinate the rollout so the frontend switches to the canonical fields before the API aliases are removed.
+
+## Capabilities
+
+### New Capabilities
+
+- `canonical-mutation-payloads`: Defines the canonical GraphQL response shapes for book and author create, update, and delete mutations, including coordinated client compatibility requirements.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+The change affects the GraphQL schema and mutation payload construction in this `bookshelf-api` repository, its generated `schema.graphql`, and schema-focused tests. It also affects GraphQL documents, generated TypeScript types, production consumers, MSW handlers, executable mock resolvers, and related tests in the separately versioned `bookshelf` frontend repository.
+
+This is a breaking API schema change for any client still selecting the compatibility aliases. The known `bookshelf` client can migrate safely against the current API because the canonical nested fields already exist. No database schema, event-recording behavior, or external dependency changes are required.

--- a/openspec/changes/unify-mutation-payloads/specs/canonical-mutation-payloads/spec.md
+++ b/openspec/changes/unify-mutation-payloads/specs/canonical-mutation-payloads/spec.md
@@ -1,0 +1,61 @@
+## ADDED Requirements
+
+### Requirement: Book mutation payloads expose one entity representation
+The system SHALL expose the affected book from create and update mutations through the `book` field of `BookMutationPayload`, SHALL expose the associated event set through `eventSetId`, and SHALL NOT expose direct aliases of fields belonging to that book on the payload.
+
+#### Scenario: Create book returns canonical payload
+- **WHEN** an authenticated client successfully executes `createBook`
+- **THEN** the client can select the created identifier through `createBook.book.id`
+- **AND** the client can select the mutation event set through `createBook.eventSetId`
+
+#### Scenario: Update book returns canonical payload
+- **WHEN** an authenticated client successfully executes `updateBook`
+- **THEN** the client can select updated entity fields through `updateBook.book`
+- **AND** the payload does not define direct fields such as `id`, `title`, or `updatedAt`
+
+### Requirement: Author mutation payloads expose one entity representation
+The system SHALL expose the affected author from create and update mutations through the `author` field of `AuthorMutationPayload`, SHALL expose the associated event set through `eventSetId`, and SHALL NOT expose direct aliases of fields belonging to that author on the payload.
+
+#### Scenario: Create author returns canonical payload
+- **WHEN** an authenticated client successfully executes `createAuthor`
+- **THEN** the client can select the created identifier through `createAuthor.author.id`
+- **AND** the client can select the mutation event set through `createAuthor.eventSetId`
+
+#### Scenario: Update author returns canonical payload
+- **WHEN** an authenticated client successfully executes `updateAuthor`
+- **THEN** the client can select updated entity fields through `updateAuthor.author`
+- **AND** the payload does not define direct `id` or `name` fields
+
+### Requirement: Delete payloads use descriptive entity identifiers
+The system SHALL expose a deleted book identifier as `bookId`, SHALL expose a deleted author identifier as `authorId`, SHALL preserve `eventSetId` on both payloads, and SHALL NOT define a generic `id` alias on either delete payload.
+
+#### Scenario: Delete book returns its identifier
+- **WHEN** an authenticated client successfully executes `deleteBook`
+- **THEN** the client can select the deleted identifier through `deleteBook.bookId`
+- **AND** the client can select the mutation event set through `deleteBook.eventSetId`
+
+#### Scenario: Delete author returns its identifier
+- **WHEN** an authenticated client successfully executes `deleteAuthor`
+- **THEN** the client can select the deleted identifier through `deleteAuthor.authorId`
+- **AND** the client can select the mutation event set through `deleteAuthor.eventSetId`
+
+### Requirement: Known client migrates before alias removal
+The `bookshelf` client SHALL use only canonical mutation payload fields before `bookshelf-api` removes the compatibility aliases.
+
+#### Scenario: Frontend creates a book and pending authors
+- **WHEN** a user creates a book and the form creates one or more new authors
+- **THEN** the frontend reads author identifiers through `createAuthor.author.id`
+- **AND** it reads the created book identifier through `createBook.book.id`
+
+#### Scenario: Frontend updates and deletes entities
+- **WHEN** the frontend executes book or author update and delete mutations
+- **THEN** its GraphQL documents select updated entities through `book` or `author`
+- **AND** its delete documents select `bookId` or `authorId`
+
+### Requirement: Test doubles match the canonical schema
+Frontend test doubles SHALL return the same mutation payload nesting and identifier names as the production GraphQL schema.
+
+#### Scenario: Mocked mutation responses
+- **WHEN** unit, demo-mode, or mock-API tests execute a book or author mutation
+- **THEN** create and update responses wrap entities under `book` or `author`
+- **AND** delete responses expose `bookId` or `authorId`

--- a/openspec/changes/unify-mutation-payloads/tasks.md
+++ b/openspec/changes/unify-mutation-payloads/tasks.md
@@ -1,0 +1,44 @@
+## 1. Prepare coordinated changes
+
+- [ ] 1.1 Verify both repository branches and working trees, creating a non-main frontend feature branch without disturbing unrelated work
+- [ ] 1.2 Record the cross-repository implementation and deployment order in each repository's required planning artifact
+
+## 2. Migrate the bookshelf client
+
+- [ ] 2.1 Update create and update GraphQL documents to select entity fields under `book` or `author`
+- [ ] 2.2 Update delete GraphQL documents to select `bookId` or `authorId`
+- [ ] 2.3 Update production consumers to read `createBook.book.id` and `createAuthor.author.id`
+- [ ] 2.4 Update MSW mutation handlers to return canonical payload object shapes
+- [ ] 2.5 Update executable mock API resolvers to return canonical payload object shapes
+- [ ] 2.6 Regenerate frontend GraphQL types and update affected unit and E2E expectations
+
+## 3. Validate and commit the bookshelf client
+
+- [ ] 3.1 Run `pnpm run generate` and confirm generated operations contain no compatibility alias selections
+- [ ] 3.2 Run `pnpm run lint:fix`, `pnpm run test`, and `pnpm run typecheck`
+- [ ] 3.3 Run mutation-relevant mock API and demo-mode E2E tests
+- [ ] 3.4 Commit the frontend migration before removing API aliases
+
+## 4. Simplify bookshelf-api payloads
+
+- [ ] 4.1 Remove direct book fields from `BookMutationPayload` and construct it with only `book` and `eventSetId`
+- [ ] 4.2 Remove direct author fields from `AuthorMutationPayload` and construct it with only `author` and `eventSetId`
+- [ ] 4.3 Remove generic `id` aliases from delete payload structs and resolvers
+- [ ] 4.4 Add schema-focused unit coverage proving canonical fields remain and compatibility aliases are absent
+- [ ] 4.5 Regenerate `schema.graphql` from the Rust schema
+
+## 5. Validate and commit bookshelf-api
+
+- [ ] 5.1 Run the schema freshness comparison used by CI
+- [ ] 5.2 Run `cargo fmt --check`
+- [ ] 5.3 Run `cargo clippy --all-targets --locked -- -D warnings`
+- [ ] 5.4 Run `cargo test --locked`
+- [ ] 5.5 Run relevant GraphQL CRUD E2E tests when the database and authentication test environment is available
+- [ ] 5.6 Commit the API alias removal after all mandatory checks pass
+
+## 6. Verify integration and rollout
+
+- [ ] 6.1 Generate frontend types from the alias-free candidate API schema and rerun frontend type checking
+- [ ] 6.2 Run the cross-repository integration suite when its environment is available
+- [ ] 6.3 Deploy or release the migrated frontend before the alias-free API
+- [ ] 6.4 Confirm create, update, and delete flows after both versions are deployed and document any external-client follow-up

--- a/openspec/changes/unify-mutation-payloads/tasks.md
+++ b/openspec/changes/unify-mutation-payloads/tasks.md
@@ -38,7 +38,7 @@
 
 ## 6. Verify integration and rollout
 
-- [ ] 6.1 Generate frontend types from the alias-free candidate API schema and rerun frontend type checking
+- [x] 6.1 Generate frontend types from the alias-free candidate API schema and rerun frontend type checking
 - [ ] 6.2 Run the cross-repository integration suite when its environment is available
 - [ ] 6.3 Deploy or release the migrated frontend before the alias-free API
 - [ ] 6.4 Confirm create, update, and delete flows after both versions are deployed and document any external-client follow-up

--- a/openspec/changes/unify-mutation-payloads/tasks.md
+++ b/openspec/changes/unify-mutation-payloads/tasks.md
@@ -1,40 +1,40 @@
 ## 1. Prepare coordinated changes
 
-- [ ] 1.1 Verify both repository branches and working trees, creating a non-main frontend feature branch without disturbing unrelated work
-- [ ] 1.2 Record the cross-repository implementation and deployment order in each repository's required planning artifact
+- [x] 1.1 Verify both repository branches and working trees, creating a non-main frontend feature branch without disturbing unrelated work
+- [x] 1.2 Record the cross-repository implementation and deployment order in each repository's required planning artifact
 
 ## 2. Migrate the bookshelf client
 
-- [ ] 2.1 Update create and update GraphQL documents to select entity fields under `book` or `author`
-- [ ] 2.2 Update delete GraphQL documents to select `bookId` or `authorId`
-- [ ] 2.3 Update production consumers to read `createBook.book.id` and `createAuthor.author.id`
-- [ ] 2.4 Update MSW mutation handlers to return canonical payload object shapes
-- [ ] 2.5 Update executable mock API resolvers to return canonical payload object shapes
-- [ ] 2.6 Regenerate frontend GraphQL types and update affected unit and E2E expectations
+- [x] 2.1 Update create and update GraphQL documents to select entity fields under `book` or `author`
+- [x] 2.2 Update delete GraphQL documents to select `bookId` or `authorId`
+- [x] 2.3 Update production consumers to read `createBook.book.id` and `createAuthor.author.id`
+- [x] 2.4 Update MSW mutation handlers to return canonical payload object shapes
+- [x] 2.5 Update executable mock API resolvers to return canonical payload object shapes
+- [x] 2.6 Regenerate frontend GraphQL types and update affected unit and E2E expectations
 
 ## 3. Validate and commit the bookshelf client
 
-- [ ] 3.1 Run `pnpm run generate` and confirm generated operations contain no compatibility alias selections
-- [ ] 3.2 Run `pnpm run lint:fix`, `pnpm run test`, and `pnpm run typecheck`
+- [x] 3.1 Run `pnpm run generate` and confirm generated operations contain no compatibility alias selections
+- [x] 3.2 Run `pnpm run lint:fix`, `pnpm run test`, and `pnpm run typecheck`
 - [ ] 3.3 Run mutation-relevant mock API and demo-mode E2E tests
-- [ ] 3.4 Commit the frontend migration before removing API aliases
+- [x] 3.4 Commit the frontend migration before removing API aliases
 
 ## 4. Simplify bookshelf-api payloads
 
-- [ ] 4.1 Remove direct book fields from `BookMutationPayload` and construct it with only `book` and `eventSetId`
-- [ ] 4.2 Remove direct author fields from `AuthorMutationPayload` and construct it with only `author` and `eventSetId`
-- [ ] 4.3 Remove generic `id` aliases from delete payload structs and resolvers
-- [ ] 4.4 Add schema-focused unit coverage proving canonical fields remain and compatibility aliases are absent
-- [ ] 4.5 Regenerate `schema.graphql` from the Rust schema
+- [x] 4.1 Remove direct book fields from `BookMutationPayload` and construct it with only `book` and `eventSetId`
+- [x] 4.2 Remove direct author fields from `AuthorMutationPayload` and construct it with only `author` and `eventSetId`
+- [x] 4.3 Remove generic `id` aliases from delete payload structs and resolvers
+- [x] 4.4 Add schema-focused unit coverage proving canonical fields remain and compatibility aliases are absent
+- [x] 4.5 Regenerate `schema.graphql` from the Rust schema
 
 ## 5. Validate and commit bookshelf-api
 
-- [ ] 5.1 Run the schema freshness comparison used by CI
-- [ ] 5.2 Run `cargo fmt --check`
-- [ ] 5.3 Run `cargo clippy --all-targets --locked -- -D warnings`
-- [ ] 5.4 Run `cargo test --locked`
+- [x] 5.1 Run the schema freshness comparison used by CI
+- [x] 5.2 Run `cargo fmt --check`
+- [x] 5.3 Run `cargo clippy --all-targets --locked -- -D warnings`
+- [x] 5.4 Run `cargo test --locked`
 - [ ] 5.5 Run relevant GraphQL CRUD E2E tests when the database and authentication test environment is available
-- [ ] 5.6 Commit the API alias removal after all mandatory checks pass
+- [x] 5.6 Commit the API alias removal after all mandatory checks pass
 
 ## 6. Verify integration and rollout
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -19,8 +19,6 @@ type AuthorEventEntry {
 type AuthorMutationPayload {
 	author: Author!
 	eventSetId: ID!
-	id: ID!
-	name: String!
 }
 
 type Book {
@@ -65,16 +63,6 @@ enum BookFormat {
 type BookMutationPayload {
 	book: Book!
 	eventSetId: ID!
-	id: String!
-	title: String!
-	isbn: String!
-	read: Boolean!
-	owned: Boolean!
-	priority: Int!
-	format: BookFormat!
-	store: BookStore!
-	createdAt: Int!
-	updatedAt: Int!
 }
 
 enum BookStore {
@@ -100,13 +88,11 @@ input CreateBookInput {
 type DeleteAuthorPayload {
 	authorId: ID!
 	eventSetId: ID!
-	id: ID!
 }
 
 type DeleteBookPayload {
 	bookId: ID!
 	eventSetId: ID!
-	id: ID!
 }
 
 type EventSetDetail {

--- a/src/presentation/graphql/mutation.rs
+++ b/src/presentation/graphql/mutation.rs
@@ -79,10 +79,8 @@ where
             .delete_book(&claims.sub, book_id.as_str())
             .await?;
 
-        let book_id = ID(result.value);
         Ok(DeleteBookPayload {
-            book_id: book_id.clone(),
-            id: book_id,
+            book_id: ID(result.value),
             event_set_id: ID(result.event_set_id),
         })
     }
@@ -129,10 +127,8 @@ where
             .mutation_use_case
             .delete_author(&claims.sub, author_id.as_str())
             .await?;
-        let author_id = ID(result.value);
         Ok(DeleteAuthorPayload {
-            author_id: author_id.clone(),
-            id: author_id,
+            author_id: ID(result.value),
             event_set_id: ID(result.event_set_id),
         })
     }

--- a/src/presentation/graphql/object.rs
+++ b/src/presentation/graphql/object.rs
@@ -441,34 +441,11 @@ impl From<EventSetDetailDto> for EventSetDetail {
 pub struct BookMutationPayload {
     pub book: Book,
     pub event_set_id: ID,
-    pub id: String,
-    pub title: String,
-    pub isbn: String,
-    pub read: bool,
-    pub owned: bool,
-    pub priority: i32,
-    pub format: BookFormat,
-    pub store: BookStore,
-    pub created_at: i64,
-    pub updated_at: i64,
 }
 
 impl BookMutationPayload {
     pub fn new(book: Book, event_set_id: ID) -> Self {
-        Self {
-            id: book.id.clone(),
-            title: book.title.clone(),
-            isbn: book.isbn.clone(),
-            read: book.read,
-            owned: book.owned,
-            priority: book.priority,
-            format: book.format,
-            store: book.store,
-            created_at: book.created_at,
-            updated_at: book.updated_at,
-            book,
-            event_set_id,
-        }
+        Self { book, event_set_id }
     }
 }
 
@@ -476,15 +453,11 @@ impl BookMutationPayload {
 pub struct AuthorMutationPayload {
     pub author: Author,
     pub event_set_id: ID,
-    pub id: ID,
-    pub name: String,
 }
 
 impl AuthorMutationPayload {
     pub fn new(author: Author, event_set_id: ID) -> Self {
         Self {
-            id: author.id.clone(),
-            name: author.name.clone(),
             author,
             event_set_id,
         }
@@ -495,14 +468,12 @@ impl AuthorMutationPayload {
 pub struct DeleteBookPayload {
     pub book_id: ID,
     pub event_set_id: ID,
-    pub id: ID,
 }
 
 #[derive(SimpleObject)]
 pub struct DeleteAuthorPayload {
     pub author_id: ID,
     pub event_set_id: ID,
-    pub id: ID,
 }
 
 #[derive(SimpleObject)]

--- a/src/presentation/graphql/schema.rs
+++ b/src/presentation/graphql/schema.rs
@@ -67,4 +67,18 @@ mod tests {
         let json = serde_json::to_value(&res).unwrap();
         assert_eq!(json["data"]["author"]["name"], author_name);
     }
+
+    #[test]
+    fn mutation_payloads_expose_only_canonical_fields() {
+        let query = Query::new(MockQueryUseCase::new());
+        let mutation = Mutation::new(MockMutationUseCase::new());
+        let sdl = build_schema(query, mutation).sdl();
+
+        assert!(sdl.contains("type BookMutationPayload {\n\tbook: Book!\n\teventSetId: ID!\n}"));
+        assert!(
+            sdl.contains("type AuthorMutationPayload {\n\tauthor: Author!\n\teventSetId: ID!\n}")
+        );
+        assert!(sdl.contains("type DeleteBookPayload {\n\tbookId: ID!\n\teventSetId: ID!\n}"));
+        assert!(sdl.contains("type DeleteAuthorPayload {\n\tauthorId: ID!\n\teventSetId: ID!\n}"));
+    }
 }


### PR DESCRIPTION
## What changed

- Remove copied book fields from `BookMutationPayload`
- Remove copied author fields from `AuthorMutationPayload`
- Remove generic `id` aliases from delete payloads
- Regenerate `schema.graphql`
- Add schema-focused coverage for the exact canonical payload field sets
- Update the OpenSpec task progress and add the required ExecPlan

## Why

Mutation payloads exposed the same entity twice: through the canonical nested object and temporary compatibility fields. Keeping only the nested entity avoids duplicated schema and Rust construction logic, while descriptive delete identifiers remain unambiguous.

## Impact

This is a breaking GraphQL schema change for clients selecting compatibility aliases. The coordinated frontend PR migrates the known client first and must be released before this API change.

## Validation

- schema freshness comparison
- `cargo fmt --check`
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo test --locked` — 140 passed
- Frontend GraphQL Codegen and full TypeScript type checking succeed against the alias-free candidate SDL

## Environment notes

Database/authenticated API E2E was not available. Targeted frontend Playwright E2E could not launch because the host lacks `libnspr4.so` and OS dependency installation requires sudo.