### PR TITLE
Fix release PR head resolution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,8 +45,16 @@ jobs:
         run: |
           set -euo pipefail
 
-          head_sha=$(jq -er '.head.sha' <<<"${PULL_REQUEST}")
+          head_ref=$(jq -er '.head.ref' <<<"${PULL_REQUEST}")
           pull_request_url=$(jq -er '.html_url' <<<"${PULL_REQUEST}")
+          head_sha=$(gh api \
+            "repos/${GITHUB_REPOSITORY}/git/ref/heads/${head_ref}" \
+            --jq '.object.sha')
+
+          if [[ -z "${head_sha}" ]]; then
+            echo "::error::Could not resolve current release pull request HEAD SHA"
+            exit 1
+          fi
 
           report_status() {
             local context=$1


### PR DESCRIPTION
### Motivation
- Prevent posting CI/E2E statuses or dispatching workflows against a stale or isolated commit by resolving the release PR branch's current HEAD via the Git ref API instead of trusting the embedded `pull_request.head.sha` from `tagpr`.

### Description
- Update `.github/workflows/release.yml` to extract `head.ref` from the `tagpr` output, call `gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/${head_ref}"` to obtain `.object.sha`, fail the validation if the lookup returns an empty SHA, and use the resolved `head_sha` for all status posts and workflow dispatch inputs.

### Testing
- Ran the required Rust pre-commit checks `cargo fmt --check`, `cargo clippy --all-targets --locked -- -D warnings`, and `cargo test --locked`, all of which passed.
- Attempted to run `actionlint .github/workflows/release.yml` but `actionlint` was not available in the environment and `go install github.com/rhysd/actionlint/cmd/actionlint@latest` failed due to Go proxy restrictions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5d0c0bb2448321aac9ecad4bbe175d)