### PR TITLE
Validate frontend against PR schema

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -159,15 +159,7 @@ jobs:
               cp ../schema.graphql src/graphql/schema.graphql
               status=$?
               if [ "${status}" -eq 0 ]; then
-                pnpm exec graphql-codegen --config codegen.yml
-                status=$?
-              fi
-              if [ "${status}" -eq 0 ]; then
-                pnpm exec msw init
-                status=$?
-              fi
-              if [ "${status}" -eq 0 ]; then
-                pnpm exec tsr generate
+                pnpm run generate:without-fetch
                 status=$?
               fi
               step_end=$(date +%s)

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -156,10 +156,29 @@ jobs:
             fi
             if [ "${status}" -eq 0 ]; then
               step_start=$(date +%s)
-              pnpm run generate
+              cp ../schema.graphql src/graphql/schema.graphql
+              status=$?
+              if [ "${status}" -eq 0 ]; then
+                pnpm exec graphql-codegen --config codegen.yml
+                status=$?
+              fi
+              if [ "${status}" -eq 0 ]; then
+                pnpm exec msw init
+                status=$?
+              fi
+              if [ "${status}" -eq 0 ]; then
+                pnpm exec tsr generate
+                status=$?
+              fi
+              step_end=$(date +%s)
+              printf 'Frontend GraphQL generation: %ss (status %s)\n' "$((step_end - step_start))" "${status}" >>"${frontend_timing}"
+            fi
+            if [ "${status}" -eq 0 ]; then
+              step_start=$(date +%s)
+              pnpm run typecheck
               status=$?
               step_end=$(date +%s)
-              printf 'Frontend generate: %ss (status %s)\n' "$((step_end - step_start))" "${status}" >>"${frontend_timing}"
+              printf 'Frontend typecheck: %ss (status %s)\n' "$((step_end - step_start))" "${status}" >>"${frontend_timing}"
             fi
             if [ "${status}" -eq 0 ]; then
               step_start=$(date +%s)


### PR DESCRIPTION
## Summary

- generate frontend GraphQL types from the API PR schema
- run frontend type checking before the integration test
- preserve MSW worker and route tree generation

## Why

The frontend integration job previously ran `pnpm run generate`, which fetched
the schema for the released API version from `bookshelf-api.version`. As a
result, API pull request schema changes were not used for frontend type
generation. Additive GraphQL changes could therefore pass runtime integration
tests while breaking the frontend after the dependency version was updated.

This change copies the schema from the API checkout into the frontend checkout,
generates the frontend artifacts, and runs TypeScript type checking before
Playwright. This detects consumer type incompatibilities in the API pull
request that introduces them.

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo test --locked` (146 passed)
- reproduced the frontend's 15 missing `Author.yomi` type errors using the API
  2.10.0 schema in a temporary frontend checkout

The frontend repository is unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **テスト・品質改善**
  * 統合テストの準備処理を見直し、フロントエンドのコード生成と型チェックを段階的に実行するよう改善しました。
  * 各処理の実行時間と結果を記録し、問題の特定を容易にしました。
  * ブラウザテスト開始前に型チェックを追加し、早期に不整合を検出できるようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->