### PR TITLE
Skip release PR validation after tagging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Validate release pull request
-        if: ${{ steps.tagpr.outputs.pull_request != '' }}
+        if: ${{ steps.tagpr.outputs.pull_request != '' && steps.tagpr.outputs.tag == '' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PULL_REQUEST: ${{ steps.tagpr.outputs.pull_request }}


### PR DESCRIPTION
## Summary

- skip release pull request validation when tagpr creates a release tag
- keep validation enabled when tagpr creates or updates an open release pull request

## Root cause

After merging the 2.10.0 release pull request, tagpr returned both the created tag and the merged pull request metadata. The workflow treated any non-empty pull request output as a newly created release pull request and attempted to resolve its already-deleted head branch, causing a 404 and skipping deployment.

## Impact

Release-tag pushes no longer attempt to validate a merged release pull request. Normal release pull request validation remains unchanged.

## Validation

- `actionlint .github/workflows/release.yml`
- `cargo fmt --check`
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo test --locked` (146 tests passed)
- `git diff --check`