### PR TITLE
Return entity event IDs from mutations

### DIFF
--- a/.agent/plans/20260815-return-entity-event-ids.md
+++ b/.agent/plans/20260815-return-entity-event-ids.md
@@ -26,6 +26,8 @@ entity snapshot.
   - [x] plan updated
 - [x] Milestone 4: Update architecture documentation and pass all mandatory validation.
   - [x] plan updated
+- [x] Milestone 5: Replace bare create/update event ID results with the domain `EventId` newtype.
+  - [x] plan updated
 
 Work began on 2026-08-15 UTC.
 
@@ -51,14 +53,14 @@ Work began on 2026-08-15 UTC.
 ## Decision Log
 
 - Decision: Change Book and Author repository `create` and `update` methods to
-  return `Result<i64, DomainError>` containing the inserted entity event ID.
+  return `Result<EventId, DomainError>` containing the inserted entity event ID.
   Rationale: The database-generated ID is known atomically at insertion time;
   a later history lookup adds work and can select the wrong row under
   concurrency.
   Date/Author: 2026-08-15, Codex.
 - Decision: Add `EntityMutationResultDto<T>` for Book and Author create/update,
   while retaining `MutationResultDto<T>` for delete, restore, and import.
-  Rationale: A required `i64` expresses the one-event guarantee without making
+  Rationale: A required `EventId` expresses the one-event guarantee without making
   unrelated operations carry an optional or misleading identifier.
   Date/Author: 2026-08-15, Codex.
 - Decision: Let `ImportBooksInteractor` explicitly ignore each event ID returned
@@ -66,15 +68,21 @@ Work began on 2026-08-15 UTC.
   Rationale: Import creates multiple Book and possibly Author events, so no one
   event ID truthfully represents the mutation payload.
   Date/Author: 2026-08-15, Codex.
+- Decision: Represent create/update repository results and entity mutation DTO
+  fields with `EventId` instead of bare `i64` values.
+  Rationale: The newtype makes the identifier's meaning explicit and prevents
+  unrelated numeric IDs from satisfying these internal contracts. PostgreSQL
+  and GraphQL remain the conversion boundaries.
+  Date/Author: 2026-08-15, Codex.
 
 ## Outcomes & Retrospective
 
-The feature is complete. Repository event inserts return their database IDs,
-create/update use cases preserve those IDs through commit, and GraphQL exposes
-them as required IDs without changing other mutation contracts. The generated
-schema is current, all 154 Rust unit tests pass, and 12 history/restore E2E tests
-pass against local PostgreSQL. Formatting and warning-denying clippy validation
-also pass.
+The feature is complete. Repository event inserts return their database IDs as
+the domain `EventId` newtype, create/update use cases preserve those IDs through
+commit, and GraphQL exposes them as required IDs without changing other
+mutation contracts. The generated schema is current, all 159 Rust unit tests
+pass, and 12 history/restore E2E tests pass against local PostgreSQL. Formatting
+and warning-denying clippy validation also pass.
 
 ## Context and Orientation
 
@@ -187,11 +195,11 @@ At completion, `src/use_case/dto/mutation.rs` defines:
     pub struct EntityMutationResultDto<T> {
         pub value: T,
         pub event_set_id: String,
-        pub event_id: i64,
+        pub event_id: EventId,
     }
 
 `BookMutationResultDto` and `AuthorMutationResultDto` alias this type. The Book
-and Author repository traits return `Result<i64, DomainError>` from `create`
+and Author repository traits return `Result<EventId, DomainError>` from `create`
 and `update`. No new crate dependency is required. The GraphQL layer uses
 `async_graphql::ID` and converts the signed 64-bit database ID to a decimal
 string.
@@ -206,3 +214,7 @@ tests passed; recorded the E2E environment requirement and evidence.
 Plan revision note (2026-08-15): Marked final validation complete after
 `cargo fmt --check`, warning-denying clippy, and all Rust tests passed; updated
 the retrospective with final evidence.
+
+Plan revision note (2026-08-15): Replaced bare create/update event ID results
+with `EventId`, keeping raw `i64` handling at the PostgreSQL boundary and
+decimal string conversion at the GraphQL boundary.

--- a/.agent/plans/20260815-return-entity-event-ids.md
+++ b/.agent/plans/20260815-return-entity-event-ids.md
@@ -32,6 +32,8 @@ entity snapshot.
   - [x] plan updated
 - [x] Milestone 7: Name the specialized result after its single-entity-event invariant.
   - [x] plan updated
+- [x] Milestone 8: Verify combined mutation delegation preserves entity event IDs.
+  - [x] plan updated
 
 Work began on 2026-08-15 UTC.
 
@@ -242,3 +244,7 @@ introducing a large shared assertion helper.
 Plan revision note (2026-08-15): Renamed the specialized mutation result to
 `SingleEventMutationResultDto<T>` so its name expresses the one-returnable-event
 invariant for the mutated entity.
+
+Plan revision note (2026-08-16): Added explicit assertions that the combined
+mutation interactor preserves the event IDs returned by all four Book and
+Author create/update sub-use-cases.

--- a/.agent/plans/20260815-return-entity-event-ids.md
+++ b/.agent/plans/20260815-return-entity-event-ids.md
@@ -30,6 +30,8 @@ entity snapshot.
   - [x] plan updated
 - [x] Milestone 6: Clarify E2E scenario names, phases, and restore-compatibility scope.
   - [x] plan updated
+- [x] Milestone 7: Name the specialized result after its single-entity-event invariant.
+  - [x] plan updated
 
 Work began on 2026-08-15 UTC.
 
@@ -60,7 +62,7 @@ Work began on 2026-08-15 UTC.
   a later history lookup adds work and can select the wrong row under
   concurrency.
   Date/Author: 2026-08-15, Codex.
-- Decision: Add `EntityMutationResultDto<T>` for Book and Author create/update,
+- Decision: Add `SingleEventMutationResultDto<T>` for Book and Author create/update,
   while retaining `MutationResultDto<T>` for delete, restore, and import.
   Rationale: A required `EventId` expresses the one-event guarantee without making
   unrelated operations carry an optional or misleading identifier.
@@ -81,6 +83,12 @@ Work began on 2026-08-15 UTC.
   Rationale: Local GraphQL queries and assertions remain readable, while the
   restore phase verifies only that the returned event ID is accepted. Detailed
   restore state transitions belong to `graphql_restore.rs`.
+  Date/Author: 2026-08-15, Codex.
+- Decision: Name the specialized create/update result
+  `SingleEventMutationResultDto<T>`.
+  Rationale: The name states why `event_id` is required: exactly one returnable
+  event is generated for the mutated entity. It does not imply that the entire
+  event set contains only one event.
   Date/Author: 2026-08-15, Codex.
 
 ## Outcomes & Retrospective
@@ -121,7 +129,7 @@ First, make repository `create` and `update` return the exact inserted event ID.
 For Book, return the ID already read for the event-author join insert. For
 Author, add `RETURNING event_id`, fetch the scalar ID, and return it. Update
 mocks and database tests so both create and update prove the returned ID points
-to the expected event. Add a generic `EntityMutationResultDto<T>` with `value`,
+to the expected event. Add a generic `SingleEventMutationResultDto<T>` with `value`,
 `event_set_id`, and `event_id`; use it only for Book and Author create/update.
 Capture the event ID before commit and construct the successful result only
 after commit. Existing failure tests must show that repository or commit errors
@@ -200,7 +208,7 @@ in `docs/database.md`.
 
 At completion, `src/use_case/dto/mutation.rs` defines:
 
-    pub struct EntityMutationResultDto<T> {
+    pub struct SingleEventMutationResultDto<T> {
         pub value: T,
         pub event_set_id: String,
         pub event_id: EventId,
@@ -230,3 +238,7 @@ decimal string conversion at the GraphQL boundary.
 Plan revision note (2026-08-15): Renamed and divided the four create/update E2E
 scenarios into mutation, history, and restore-compatibility phases without
 introducing a large shared assertion helper.
+
+Plan revision note (2026-08-15): Renamed the specialized mutation result to
+`SingleEventMutationResultDto<T>` so its name expresses the one-returnable-event
+invariant for the mutated entity.

--- a/.agent/plans/20260815-return-entity-event-ids.md
+++ b/.agent/plans/20260815-return-entity-event-ids.md
@@ -28,6 +28,8 @@ entity snapshot.
   - [x] plan updated
 - [x] Milestone 5: Replace bare create/update event ID results with the domain `EventId` newtype.
   - [x] plan updated
+- [x] Milestone 6: Clarify E2E scenario names, phases, and restore-compatibility scope.
+  - [x] plan updated
 
 Work began on 2026-08-15 UTC.
 
@@ -73,6 +75,12 @@ Work began on 2026-08-15 UTC.
   Rationale: The newtype makes the identifier's meaning explicit and prevents
   unrelated numeric IDs from satisfying these internal contracts. PostgreSQL
   and GraphQL remain the conversion boundaries.
+  Date/Author: 2026-08-15, Codex.
+- Decision: Keep four explicit create/update Book/Author E2E scenarios and
+  structure each as mutation, history, and restore compatibility.
+  Rationale: Local GraphQL queries and assertions remain readable, while the
+  restore phase verifies only that the returned event ID is accepted. Detailed
+  restore state transitions belong to `graphql_restore.rs`.
   Date/Author: 2026-08-15, Codex.
 
 ## Outcomes & Retrospective
@@ -218,3 +226,7 @@ the retrospective with final evidence.
 Plan revision note (2026-08-15): Replaced bare create/update event ID results
 with `EventId`, keeping raw `i64` handling at the PostgreSQL boundary and
 decimal string conversion at the GraphQL boundary.
+
+Plan revision note (2026-08-15): Renamed and divided the four create/update E2E
+scenarios into mutation, history, and restore-compatibility phases without
+introducing a large shared assertion helper.

--- a/.agent/plans/20260815-return-entity-event-ids.md
+++ b/.agent/plans/20260815-return-entity-event-ids.md
@@ -1,0 +1,208 @@
+# Return Book and Author mutation event IDs
+
+This ExecPlan is a living document. The sections `Progress`, `Surprises &
+Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must be kept up to
+date as work proceeds. Maintain this document in accordance with
+`.agent/PLANS.md`.
+
+## Purpose / Big Picture
+
+After this change, a GraphQL client that creates or updates a Book or Author can
+read both `eventSetId`, which identifies the whole logical operation, and
+`eventId`, which identifies the exact entity snapshot recorded by that
+operation. The client can find the returned `eventId` in `bookEvents` or
+`authorEvents` and pass it directly to `restoreBook` or `restoreAuthor`.
+Delete, restore, import, and user registration payloads keep their existing
+shape because those operations do not promise exactly one newly recorded
+entity snapshot.
+
+## Progress
+
+- [x] Milestone 1: Propagate database-generated event IDs through repositories and create/update use cases, with unit tests.
+  - [x] plan updated
+- [x] Milestone 2: Expose required GraphQL `eventId` fields and regenerate the checked-in schema, with presentation tests.
+  - [x] plan updated
+- [x] Milestone 3: Prove history and restore interoperability with Book and Author E2E tests.
+  - [x] plan updated
+- [x] Milestone 4: Update architecture documentation and pass all mandatory validation.
+  - [x] plan updated
+
+Work began on 2026-08-15 UTC.
+
+## Surprises & Discoveries
+
+- Observation: `PgBookRepository` already uses `INSERT ... RETURNING event_id`
+  for create and update so it can populate `book_event_author`, but then returns
+  `()` to its caller. `PgAuthorRepository` inserts equivalent events with
+  `execute` and does not currently read the generated ID.
+  Evidence: `src/infrastructure/book_repository.rs` binds the returned ID to
+  `event_id`; `src/infrastructure/author_repository.rs` executes the event
+  inserts without `RETURNING`.
+- Observation: `BookRepository::create` is shared by single-Book creation and
+  `ImportBooksInteractor`.
+  Evidence: `src/use_case/interactor/book.rs` invokes the same method inside
+  both transaction flows.
+- Observation: The E2E suite requires a running API and rejects execution when
+  `TEST_SERVER_URL` is absent; the documented Docker PostgreSQL, JWKS, and API
+  setup runs successfully in this workspace.
+  Evidence: the initial run failed only with the missing environment variable;
+  after starting the documented services, 6 history and 6 restore tests passed.
+
+## Decision Log
+
+- Decision: Change Book and Author repository `create` and `update` methods to
+  return `Result<i64, DomainError>` containing the inserted entity event ID.
+  Rationale: The database-generated ID is known atomically at insertion time;
+  a later history lookup adds work and can select the wrong row under
+  concurrency.
+  Date/Author: 2026-08-15, Codex.
+- Decision: Add `EntityMutationResultDto<T>` for Book and Author create/update,
+  while retaining `MutationResultDto<T>` for delete, restore, and import.
+  Rationale: A required `i64` expresses the one-event guarantee without making
+  unrelated operations carry an optional or misleading identifier.
+  Date/Author: 2026-08-15, Codex.
+- Decision: Let `ImportBooksInteractor` explicitly ignore each event ID returned
+  by `BookRepository::create`.
+  Rationale: Import creates multiple Book and possibly Author events, so no one
+  event ID truthfully represents the mutation payload.
+  Date/Author: 2026-08-15, Codex.
+
+## Outcomes & Retrospective
+
+The feature is complete. Repository event inserts return their database IDs,
+create/update use cases preserve those IDs through commit, and GraphQL exposes
+them as required IDs without changing other mutation contracts. The generated
+schema is current, all 154 Rust unit tests pass, and 12 history/restore E2E tests
+pass against local PostgreSQL. Formatting and warning-denying clippy validation
+also pass.
+
+## Context and Orientation
+
+The event log has an `event_set` row for one user-visible operation and one or
+more `book_event` or `author_event` rows for entity snapshots. The
+`TransactionManager` in `src/domain/repository/transaction.rs` opens and commits
+the transaction. Book and Author repository traits in
+`src/domain/repository/book_repository.rs` and
+`src/domain/repository/author_repository.rs` receive that transaction and both
+change live state and insert events. PostgreSQL implementations live in
+`src/infrastructure/book_repository.rs` and
+`src/infrastructure/author_repository.rs`.
+
+The interactors in `src/use_case/interactor/book.rs` and
+`src/use_case/interactor/author.rs` orchestrate each transaction. Their public
+results are declared in `src/use_case/dto/mutation.rs` and flow through the
+combined mutation use case to `src/presentation/graphql/mutation.rs`. GraphQL
+payload objects are declared in `src/presentation/graphql/object.rs`; the
+generated schema snapshot is `schema.graphql`.
+
+Repository and interactor tests are Rust unit or database-backed tests in their
+source modules. GraphQL E2E tests live under `e2e/tests`; history and restore
+coverage is concentrated in `graphql_history.rs` and `graphql_restore.rs`.
+
+## Plan of Work
+
+First, make repository `create` and `update` return the exact inserted event ID.
+For Book, return the ID already read for the event-author join insert. For
+Author, add `RETURNING event_id`, fetch the scalar ID, and return it. Update
+mocks and database tests so both create and update prove the returned ID points
+to the expected event. Add a generic `EntityMutationResultDto<T>` with `value`,
+`event_set_id`, and `event_id`; use it only for Book and Author create/update.
+Capture the event ID before commit and construct the successful result only
+after commit. Existing failure tests must show that repository or commit errors
+return `Err`, not a partially populated result.
+
+Second, add `event_id: ID` to `BookMutationPayload` and
+`AuthorMutationPayload`, extend their constructors, and pass
+`ID(result.event_id.to_string())` from all four resolvers. Update schema-focused
+and resolver tests, generate `schema.graphql` using the repository's existing
+schema generation path, and assert both fields render as `eventId: ID!` while
+delete, restore, import, and registration payloads do not acquire the field.
+
+Third, update E2E operations for create and update to request `eventId`. For
+each entity kind, verify the returned ID exists in history, shares the returned
+event-set ID, and is accepted by the matching restore mutation. Reuse existing
+authentication and database fixtures so the tests validate the production
+repository-to-GraphQL path.
+
+Finally, update `docs/architecture/event-recording.md` to define the two IDs and
+the multi-event exclusion. Add a `CHANGELOG.md` entry only if inspection shows
+that unreleased API changes are recorded there. Run formatting, lint, all Rust
+tests, and the relevant E2E suites. Update this plan and the OpenSpec task list
+at every completed milestone.
+
+## Concrete Steps
+
+Run all commands from the repository root
+`/home/hiterm/.codex/worktrees/2868aaed-3a25-4349-8dc8-23d46957f293/bookshelf-api`.
+
+Inspect changes throughout with:
+
+    git --no-pager diff
+
+Run focused unit tests after each layer is changed using test-name filters found
+in the edited modules. Generate or refresh `schema.graphql` with the existing
+repository command discovered from CI or source tests. At the final milestone,
+run exactly:
+
+    cargo fmt --check
+    cargo clippy --all-targets --locked -- -D warnings
+    cargo test --locked
+
+Run relevant E2E tests with the package and feature/environment command already
+used by this repository. If PostgreSQL or authentication fixtures are not
+available, record the exact failing prerequisite and keep the E2E execution
+task open rather than treating infrastructure absence as a passing test.
+
+## Validation and Acceptance
+
+Acceptance requires the generated schema to contain required `eventId: ID!`
+fields on `BookMutationPayload` and `AuthorMutationPayload`. Unit tests must
+show all four create/update interactors return the repository-provided numeric
+event ID only after a successful commit, and errors remain errors. E2E tests
+must create and update each entity, locate the returned event ID in its history
+with the same event-set ID, and successfully invoke restore with it. Delete,
+restore, import, and registration schema contracts must remain unchanged. All
+three mandatory Cargo commands must exit successfully.
+
+## Idempotence and Recovery
+
+Source edits and test commands are safe to repeat. Database-backed tests must
+use their existing isolated fixture setup and cleanup. No migration or data
+rewrite is required. If schema regeneration changes unrelated output, inspect
+the generator and retain only output produced from the current Rust schema; do
+not manually invent generated definitions. Never discard unrelated working-tree
+changes.
+
+## Artifacts and Notes
+
+The normative OpenSpec artifacts are under
+`openspec/changes/return-entity-event-ids/`. The architecture invariant is in
+`docs/architecture/event-recording.md`, and the physical event table schema is
+in `docs/database.md`.
+
+## Interfaces and Dependencies
+
+At completion, `src/use_case/dto/mutation.rs` defines:
+
+    pub struct EntityMutationResultDto<T> {
+        pub value: T,
+        pub event_set_id: String,
+        pub event_id: i64,
+    }
+
+`BookMutationResultDto` and `AuthorMutationResultDto` alias this type. The Book
+and Author repository traits return `Result<i64, DomainError>` from `create`
+and `update`. No new crate dependency is required. The GraphQL layer uses
+`async_graphql::ID` and converts the signed 64-bit database ID to a decimal
+string.
+
+Plan revision note (2026-08-15): Initial plan created from the approved feature
+description, repository architecture, and OpenSpec design before code changes.
+
+Plan revision note (2026-08-15): Marked the first three milestones complete
+after focused unit tests, schema regeneration, E2E compilation, and 12 live E2E
+tests passed; recorded the E2E environment requirement and evidence.
+
+Plan revision note (2026-08-15): Marked final validation complete after
+`cargo fmt --check`, warning-denying clippy, and all Rust tests passed; updated
+the retrospective with final evidence.

--- a/docs/architecture/event-recording.md
+++ b/docs/architecture/event-recording.md
@@ -38,6 +38,11 @@ Single-entity Book and Author `create` and `update` mutations also return an
   by history queries and accepted as the source by the corresponding restore
   mutation.
 
+Internally, create/update repository results carry the domain `EventId` newtype.
+Only the PostgreSQL adapter handles its underlying `BIGINT`/`i64` value, and the
+GraphQL boundary converts it to the decimal string representation required by
+GraphQL `ID`.
+
 Mutations that do not guarantee exactly one newly recorded entity snapshot do
 not return a single `eventId`. This includes delete, restore, bulk import, and
 user registration. Their payload contracts remain specific to the operation;

--- a/docs/architecture/event-recording.md
+++ b/docs/architecture/event-recording.md
@@ -28,6 +28,22 @@ to `begin`, and the generated `event_set.id` exposed by the transaction so
 mutation results can return an `eventSetId` after a successful commit. Event
 row creation and persistence details remain in the infrastructure layer.
 
+Single-entity Book and Author `create` and `update` mutations also return an
+`eventId`. The two identifiers have different scopes:
+
+- `eventSetId` identifies the complete logical operation and can group one or
+  more entity events.
+- `eventId` identifies the newly recorded Book or Author snapshot for that
+  create or update mutation. It is the same per-entity event identifier exposed
+  by history queries and accepted as the source by the corresponding restore
+  mutation.
+
+Mutations that do not guarantee exactly one newly recorded entity snapshot do
+not return a single `eventId`. This includes delete, restore, bulk import, and
+user registration. Their payload contracts remain specific to the operation;
+in particular, an import can record multiple Book and Author events under one
+`eventSetId`.
+
 ## Infrastructure responsibilities
 
 - `PgTransactionManager::begin` generates the `event_set` UUID, binds the

--- a/e2e/src/lib.rs
+++ b/e2e/src/lib.rs
@@ -181,19 +181,45 @@ pub async fn create_test_user() -> Result<(String, String)> {
 }
 
 pub async fn create_test_author(name: &str, token: &str) -> Result<String> {
-    let query = format!(
-        r#"mutation {{ createAuthor(authorData: {{ name: "{}" }}) {{ author {{ id }} }} }}"#,
-        name
-    );
-    let (_, response) = graphql_request(&query, Some(token)).await?;
-    let id = response["data"]["createAuthor"]["author"]["id"]
-        .as_str()
-        .context("createAuthor id should be a string")?
-        .to_owned();
+    let (id, _, _) = create_test_author_with_event(name, token).await?;
     Ok(id)
 }
 
+pub async fn create_test_author_with_event(
+    name: &str,
+    token: &str,
+) -> Result<(String, String, String)> {
+    let query = format!(
+        r#"mutation {{ createAuthor(authorData: {{ name: "{}" }}) {{ author {{ id }} eventId eventSetId }} }}"#,
+        name
+    );
+    let (_, response) = graphql_request(&query, Some(token)).await?;
+    let payload = &response["data"]["createAuthor"];
+    let id = payload["author"]["id"]
+        .as_str()
+        .context("createAuthor id should be a string")?
+        .to_owned();
+    let event_id = payload["eventId"]
+        .as_str()
+        .context("createAuthor eventId should be a string")?
+        .to_owned();
+    let event_set_id = payload["eventSetId"]
+        .as_str()
+        .context("createAuthor eventSetId should be a string")?
+        .to_owned();
+    Ok((id, event_id, event_set_id))
+}
+
 pub async fn create_test_book(title: &str, author_id: &str, token: &str) -> Result<String> {
+    let (id, _, _) = create_test_book_with_event(title, author_id, token).await?;
+    Ok(id)
+}
+
+pub async fn create_test_book_with_event(
+    title: &str,
+    author_id: &str,
+    token: &str,
+) -> Result<(String, String, String)> {
     let query = format!(
         r#"
         mutation {{
@@ -206,17 +232,26 @@ pub async fn create_test_book(title: &str, author_id: &str, token: &str) -> Resu
                 priority: 50
                 format: E_BOOK
                 store: KINDLE
-            }}) {{ book {{ id }} }}
+            }}) {{ book {{ id }} eventId eventSetId }}
         }}
         "#,
         title, author_id
     );
     let (_, response) = graphql_request(&query, Some(token)).await?;
-    let id = response["data"]["createBook"]["book"]["id"]
+    let payload = &response["data"]["createBook"];
+    let id = payload["book"]["id"]
         .as_str()
         .context("createBook id should be a string")?
         .to_owned();
-    Ok(id)
+    let event_id = payload["eventId"]
+        .as_str()
+        .context("createBook eventId should be a string")?
+        .to_owned();
+    let event_set_id = payload["eventSetId"]
+        .as_str()
+        .context("createBook eventSetId should be a string")?
+        .to_owned();
+    Ok((id, event_id, event_set_id))
 }
 
 pub fn assert_graphql_errors(response: &serde_json::Value, context: &str) {

--- a/e2e/tests/graphql_history.rs
+++ b/e2e/tests/graphql_history.rs
@@ -8,14 +8,17 @@ use serial_test::serial;
 
 #[tokio::test]
 #[serial]
-async fn e2e_book_events_records_create_operation() -> Result<()> {
+async fn e2e_create_book_returns_event_matching_history_and_usable_for_restore() -> Result<()> {
     let (_user_id, token) = create_test_user().await?;
 
     let author_id =
         create_test_author(&format!("History Author {}", uuid::Uuid::new_v4()), &token).await?;
+
+    // Phase 1: mutation — capture the entity and event references.
     let (book_id, event_id, event_set_id) =
         create_test_book_with_event("History Book Create", &author_id, &token).await?;
 
+    // Phase 2: history — match the returned references and recorded snapshot.
     let query = format!(
         r#"{{ bookEvents(bookId: "{}") {{
             eventId eventSetId operation bookId
@@ -94,6 +97,7 @@ async fn e2e_book_events_records_create_operation() -> Result<()> {
         "create event extra should be null"
     );
 
+    // Phase 3: restore compatibility — verify the returned event ID is accepted.
     let restore_query = format!(
         r#"mutation {{ restoreBook(eventId: "{}") {{ book {{ id }} eventSetId }} }}"#,
         event_id
@@ -109,14 +113,14 @@ async fn e2e_book_events_records_create_operation() -> Result<()> {
 
 #[tokio::test]
 #[serial]
-async fn e2e_book_events_records_update_operation() -> Result<()> {
+async fn e2e_update_book_returns_event_matching_history_and_usable_for_restore() -> Result<()> {
     let (_user_id, token) = create_test_user().await?;
 
     let author_id =
         create_test_author(&format!("History Author {}", uuid::Uuid::new_v4()), &token).await?;
     let book_id = create_test_book("Original Title", &author_id, &token).await?;
 
-    // Update the book
+    // Phase 1: mutation — capture the updated entity's event references.
     let update_query = format!(
         r#"
         mutation {{
@@ -140,6 +144,11 @@ async fn e2e_book_events_records_update_operation() -> Result<()> {
         response.get("errors").is_none(),
         "updateBook should not return errors"
     );
+    let returned_book_id = response["data"]["updateBook"]["book"]["id"]
+        .as_str()
+        .context("updateBook book ID should be a string")?
+        .to_owned();
+    assert_eq!(returned_book_id, book_id);
     let event_id = response["data"]["updateBook"]["eventId"]
         .as_str()
         .context("updateBook eventId should be a string")?
@@ -149,15 +158,17 @@ async fn e2e_book_events_records_update_operation() -> Result<()> {
         .context("updateBook eventSetId should be a string")?
         .to_owned();
 
+    // Phase 2: history — match the returned references and recorded snapshot.
     let query = format!(
         r#"{{ bookEvents(bookId: "{}") {{
             eventId eventSetId operation bookId
             title authorIds isbn read owned priority format store
             bookCreatedAt bookUpdatedAt changedAt extra
         }} }}"#,
-        book_id
+        returned_book_id
     );
     let (_, response) = graphql_request(&query, Some(&token)).await?;
+    assert_no_graphql_errors(&response, "bookEvents after updateBook");
     let entries = response["data"]["bookEvents"]
         .as_array()
         .context("bookEvents should be an array")?;
@@ -176,7 +187,10 @@ async fn e2e_book_events_records_update_operation() -> Result<()> {
         update_entry["eventSetId"].as_str(),
         Some(event_set_id.as_str())
     );
-    assert_eq!(update_entry["bookId"].as_str(), Some(book_id.as_str()));
+    assert_eq!(
+        update_entry["bookId"].as_str(),
+        Some(returned_book_id.as_str())
+    );
     assert_eq!(update_entry["title"].as_str(), Some("Updated Title"));
     assert_eq!(
         update_entry["authorIds"]
@@ -202,6 +216,7 @@ async fn e2e_book_events_records_update_operation() -> Result<()> {
     assert_eq!(create_entry["operation"].as_str(), Some("create"));
     assert_eq!(create_entry["title"].as_str(), Some("Original Title"));
 
+    // Phase 3: restore compatibility — verify the returned event ID is accepted.
     let restore_query = format!(
         r#"mutation {{ restoreBook(eventId: "{}") {{ book {{ id title }} eventSetId }} }}"#,
         event_id
@@ -265,13 +280,16 @@ async fn e2e_book_events_records_delete_operation() -> Result<()> {
 
 #[tokio::test]
 #[serial]
-async fn e2e_author_events_records_create_operation() -> Result<()> {
+async fn e2e_create_author_returns_event_matching_history_and_usable_for_restore() -> Result<()> {
     let (_user_id, token) = create_test_user().await?;
 
     let author_name = format!("Author History Create {}", uuid::Uuid::new_v4());
+
+    // Phase 1: mutation — capture the entity and event references.
     let (author_id, event_id, event_set_id) =
         create_test_author_with_event(&author_name, &token).await?;
 
+    // Phase 2: history — match the returned references and recorded snapshot.
     let query = format!(
         r#"{{ authorEvents(authorId: "{}") {{
             eventId eventSetId operation authorId
@@ -323,6 +341,7 @@ async fn e2e_author_events_records_create_operation() -> Result<()> {
         "create event extra should be null"
     );
 
+    // Phase 3: restore compatibility — verify the returned event ID is accepted.
     let restore_query = format!(
         r#"mutation {{ restoreAuthor(eventId: "{}") {{ author {{ id }} eventSetId }} }}"#,
         event_id
@@ -336,13 +355,15 @@ async fn e2e_author_events_records_create_operation() -> Result<()> {
 
 #[tokio::test]
 #[serial]
-async fn e2e_author_events_records_update_operation() -> Result<()> {
+async fn e2e_update_author_returns_event_matching_history_and_usable_for_restore() -> Result<()> {
     let (_user_id, token) = create_test_user().await?;
 
     let original_name = format!("Author Before Update History {}", uuid::Uuid::new_v4());
     let author_id = create_test_author(&original_name, &token).await?;
 
     let updated_name = format!("Author After Update History {}", uuid::Uuid::new_v4());
+
+    // Phase 1: mutation — capture the updated entity's event references.
     let update_query = format!(
         r#"mutation {{ updateAuthor(authorData: {{ id: "{}", name: "{}" }}) {{ author {{ id name }} eventId eventSetId }} }}"#,
         author_id, updated_name
@@ -352,6 +373,11 @@ async fn e2e_author_events_records_update_operation() -> Result<()> {
         response.get("errors").is_none(),
         "updateAuthor should not return errors"
     );
+    let returned_author_id = response["data"]["updateAuthor"]["author"]["id"]
+        .as_str()
+        .context("updateAuthor author ID should be a string")?
+        .to_owned();
+    assert_eq!(returned_author_id, author_id);
     let event_id = response["data"]["updateAuthor"]["eventId"]
         .as_str()
         .context("updateAuthor eventId should be a string")?
@@ -361,14 +387,16 @@ async fn e2e_author_events_records_update_operation() -> Result<()> {
         .context("updateAuthor eventSetId should be a string")?
         .to_owned();
 
+    // Phase 2: history — match the returned references and recorded snapshot.
     let query = format!(
         r#"{{ authorEvents(authorId: "{}") {{
             eventId eventSetId operation authorId
             name yomi authorCreatedAt authorUpdatedAt changedAt extra
         }} }}"#,
-        author_id
+        returned_author_id
     );
     let (_, response) = graphql_request(&query, Some(&token)).await?;
+    assert_no_graphql_errors(&response, "authorEvents after updateAuthor");
     let entries = response["data"]["authorEvents"]
         .as_array()
         .context("authorEvents should be an array")?;
@@ -386,7 +414,10 @@ async fn e2e_author_events_records_update_operation() -> Result<()> {
         update_entry["eventSetId"].as_str(),
         Some(event_set_id.as_str())
     );
-    assert_eq!(update_entry["authorId"].as_str(), Some(author_id.as_str()));
+    assert_eq!(
+        update_entry["authorId"].as_str(),
+        Some(returned_author_id.as_str())
+    );
     assert_eq!(update_entry["name"].as_str(), Some(updated_name.as_str()));
     assert_eq!(
         update_entry["yomi"].as_str(),
@@ -405,6 +436,7 @@ async fn e2e_author_events_records_update_operation() -> Result<()> {
     assert_eq!(create_entry["operation"].as_str(), Some("create"));
     assert_eq!(create_entry["name"].as_str(), Some(original_name.as_str()));
 
+    // Phase 3: restore compatibility — verify the returned event ID is accepted.
     let restore_query = format!(
         r#"mutation {{ restoreAuthor(eventId: "{}") {{ author {{ id name }} eventSetId }} }}"#,
         event_id

--- a/e2e/tests/graphql_history.rs
+++ b/e2e/tests/graphql_history.rs
@@ -13,7 +13,8 @@ async fn e2e_book_events_records_create_operation() -> Result<()> {
 
     let author_id =
         create_test_author(&format!("History Author {}", uuid::Uuid::new_v4()), &token).await?;
-    let book_id = create_test_book("History Book Create", &author_id, &token).await?;
+    let (book_id, event_id, event_set_id) =
+        create_test_book_with_event("History Book Create", &author_id, &token).await?;
 
     let query = format!(
         r#"{{ bookEvents(bookId: "{}") {{
@@ -36,11 +37,8 @@ async fn e2e_book_events_records_create_operation() -> Result<()> {
     assert_eq!(entries.len(), 1, "should have exactly 1 event entry");
 
     let entry = &entries[0];
-    assert!(!entry["eventId"].is_null(), "eventId should not be null");
-    assert!(
-        !entry["eventSetId"].is_null(),
-        "eventSetId should not be null"
-    );
+    assert_eq!(entry["eventId"].as_str(), Some(event_id.as_str()));
+    assert_eq!(entry["eventSetId"].as_str(), Some(event_set_id.as_str()));
     assert_eq!(entry["operation"].as_str(), Some("create"));
     assert_eq!(
         entry["bookId"].as_str(),
@@ -96,6 +94,13 @@ async fn e2e_book_events_records_create_operation() -> Result<()> {
         "create event extra should be null"
     );
 
+    let restore_query = format!(
+        r#"mutation {{ restoreBook(eventId: "{}") {{ book {{ id }} eventSetId }} }}"#,
+        event_id
+    );
+    let (_, restore_response) = graphql_request(&restore_query, Some(&token)).await?;
+    assert_no_graphql_errors(&restore_response, "restoreBook from createBook eventId");
+
     // Cleanup
     delete_test_book(&book_id, &token).await?;
     delete_test_author(&author_id, &token).await?;
@@ -125,7 +130,7 @@ async fn e2e_book_events_records_update_operation() -> Result<()> {
                 priority: 50
                 format: E_BOOK
                 store: KINDLE
-            }}) {{ book {{ id title }} eventSetId }}
+            }}) {{ book {{ id title }} eventId eventSetId }}
         }}
         "#,
         book_id, author_id
@@ -135,6 +140,14 @@ async fn e2e_book_events_records_update_operation() -> Result<()> {
         response.get("errors").is_none(),
         "updateBook should not return errors"
     );
+    let event_id = response["data"]["updateBook"]["eventId"]
+        .as_str()
+        .context("updateBook eventId should be a string")?
+        .to_owned();
+    let event_set_id = response["data"]["updateBook"]["eventSetId"]
+        .as_str()
+        .context("updateBook eventSetId should be a string")?
+        .to_owned();
 
     let query = format!(
         r#"{{ bookEvents(bookId: "{}") {{
@@ -158,13 +171,10 @@ async fn e2e_book_events_records_update_operation() -> Result<()> {
     // Each entry records the post-state after the operation was applied.
     let update_entry = &entries[0];
     assert_eq!(update_entry["operation"].as_str(), Some("update"));
-    assert!(
-        !update_entry["eventId"].is_null(),
-        "update eventId should not be null"
-    );
-    assert!(
-        !update_entry["eventSetId"].is_null(),
-        "update eventSetId should not be null"
+    assert_eq!(update_entry["eventId"].as_str(), Some(event_id.as_str()));
+    assert_eq!(
+        update_entry["eventSetId"].as_str(),
+        Some(event_set_id.as_str())
     );
     assert_eq!(update_entry["bookId"].as_str(), Some(book_id.as_str()));
     assert_eq!(update_entry["title"].as_str(), Some("Updated Title"));
@@ -191,6 +201,13 @@ async fn e2e_book_events_records_update_operation() -> Result<()> {
     let create_entry = &entries[1];
     assert_eq!(create_entry["operation"].as_str(), Some("create"));
     assert_eq!(create_entry["title"].as_str(), Some("Original Title"));
+
+    let restore_query = format!(
+        r#"mutation {{ restoreBook(eventId: "{}") {{ book {{ id title }} eventSetId }} }}"#,
+        event_id
+    );
+    let (_, restore_response) = graphql_request(&restore_query, Some(&token)).await?;
+    assert_no_graphql_errors(&restore_response, "restoreBook from updateBook eventId");
 
     // Cleanup
     delete_test_book(&book_id, &token).await?;
@@ -252,7 +269,8 @@ async fn e2e_author_events_records_create_operation() -> Result<()> {
     let (_user_id, token) = create_test_user().await?;
 
     let author_name = format!("Author History Create {}", uuid::Uuid::new_v4());
-    let author_id = create_test_author(&author_name, &token).await?;
+    let (author_id, event_id, event_set_id) =
+        create_test_author_with_event(&author_name, &token).await?;
 
     let query = format!(
         r#"{{ authorEvents(authorId: "{}") {{
@@ -274,11 +292,8 @@ async fn e2e_author_events_records_create_operation() -> Result<()> {
     assert_eq!(entries.len(), 1, "should have exactly 1 event entry");
 
     let entry = &entries[0];
-    assert!(!entry["eventId"].is_null(), "eventId should not be null");
-    assert!(
-        !entry["eventSetId"].is_null(),
-        "eventSetId should not be null"
-    );
+    assert_eq!(entry["eventId"].as_str(), Some(event_id.as_str()));
+    assert_eq!(entry["eventSetId"].as_str(), Some(event_set_id.as_str()));
     assert_eq!(entry["operation"].as_str(), Some("create"));
     assert_eq!(
         entry["authorId"].as_str(),
@@ -308,6 +323,13 @@ async fn e2e_author_events_records_create_operation() -> Result<()> {
         "create event extra should be null"
     );
 
+    let restore_query = format!(
+        r#"mutation {{ restoreAuthor(eventId: "{}") {{ author {{ id }} eventSetId }} }}"#,
+        event_id
+    );
+    let (_, restore_response) = graphql_request(&restore_query, Some(&token)).await?;
+    assert_no_graphql_errors(&restore_response, "restoreAuthor from createAuthor eventId");
+
     delete_test_author(&author_id, &token).await?;
     Ok(())
 }
@@ -322,7 +344,7 @@ async fn e2e_author_events_records_update_operation() -> Result<()> {
 
     let updated_name = format!("Author After Update History {}", uuid::Uuid::new_v4());
     let update_query = format!(
-        r#"mutation {{ updateAuthor(authorData: {{ id: "{}", name: "{}" }}) {{ author {{ id name }} eventSetId }} }}"#,
+        r#"mutation {{ updateAuthor(authorData: {{ id: "{}", name: "{}" }}) {{ author {{ id name }} eventId eventSetId }} }}"#,
         author_id, updated_name
     );
     let (_, response) = graphql_request(&update_query, Some(&token)).await?;
@@ -330,6 +352,14 @@ async fn e2e_author_events_records_update_operation() -> Result<()> {
         response.get("errors").is_none(),
         "updateAuthor should not return errors"
     );
+    let event_id = response["data"]["updateAuthor"]["eventId"]
+        .as_str()
+        .context("updateAuthor eventId should be a string")?
+        .to_owned();
+    let event_set_id = response["data"]["updateAuthor"]["eventSetId"]
+        .as_str()
+        .context("updateAuthor eventSetId should be a string")?
+        .to_owned();
 
     let query = format!(
         r#"{{ authorEvents(authorId: "{}") {{
@@ -351,8 +381,11 @@ async fn e2e_author_events_records_update_operation() -> Result<()> {
     // Each entry records the post-state after the operation was applied.
     let update_entry = &entries[0];
     assert_eq!(update_entry["operation"].as_str(), Some("update"));
-    assert!(!update_entry["eventId"].is_null());
-    assert!(!update_entry["eventSetId"].is_null());
+    assert_eq!(update_entry["eventId"].as_str(), Some(event_id.as_str()));
+    assert_eq!(
+        update_entry["eventSetId"].as_str(),
+        Some(event_set_id.as_str())
+    );
     assert_eq!(update_entry["authorId"].as_str(), Some(author_id.as_str()));
     assert_eq!(update_entry["name"].as_str(), Some(updated_name.as_str()));
     assert_eq!(
@@ -371,6 +404,13 @@ async fn e2e_author_events_records_update_operation() -> Result<()> {
     let create_entry = &entries[1];
     assert_eq!(create_entry["operation"].as_str(), Some("create"));
     assert_eq!(create_entry["name"].as_str(), Some(original_name.as_str()));
+
+    let restore_query = format!(
+        r#"mutation {{ restoreAuthor(eventId: "{}") {{ author {{ id name }} eventSetId }} }}"#,
+        event_id
+    );
+    let (_, restore_response) = graphql_request(&restore_query, Some(&token)).await?;
+    assert_no_graphql_errors(&restore_response, "restoreAuthor from updateAuthor eventId");
 
     delete_test_author(&author_id, &token).await?;
     Ok(())

--- a/openspec/changes/return-entity-event-ids/.openspec.yaml
+++ b/openspec/changes/return-entity-event-ids/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-15

--- a/openspec/changes/return-entity-event-ids/design.md
+++ b/openspec/changes/return-entity-event-ids/design.md
@@ -1,0 +1,81 @@
+## Context
+
+Book and Author mutations record entity snapshots in per-entity event tables
+inside the same `TransactionManager` transaction that changes the entity. The
+event insert already produces an `event_id`, but create/update results currently
+discard it and expose only the operation-wide event set ID. Restore mutations
+accept a historical event ID, so clients must query history to discover the
+event just created by a mutation.
+
+This change crosses repository, use-case, GraphQL presentation, generated
+schema, documentation, and test layers. The existing event recording invariant
+and transaction boundary must remain intact.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Return the newly recorded entity event ID from Book and Author create/update
+  mutations.
+- Keep `eventSetId` as the identifier for the complete logical operation.
+- Ensure the returned event ID identifies the committed Book or Author snapshot
+  and can be supplied to the corresponding restore mutation.
+- Preserve atomic failure behavior: neither a mutation result nor an event ID is
+  returned when persistence fails.
+
+**Non-Goals:**
+
+- Adding a single event ID to delete, restore, import, or registration results.
+- Changing restore input semantics, database schema, or event history queries.
+- Returning all event IDs for operations that record multiple entity events.
+
+## Decisions
+
+Repository create/update operations will return the `event_id` obtained from
+the existing event `INSERT ... RETURNING event_id`. This keeps the authoritative
+database-generated identifier attached to the write that created it. Inferring
+the ID later from event history was rejected because it adds a query and can be
+ambiguous under concurrent writes.
+
+Create/update use cases will return a dedicated generic
+`EntityMutationResultDto<T>` containing `value`, `event_set_id`, and `event_id`.
+The existing `MutationResultDto<T>` remains for operations that do not guarantee
+one newly recorded entity snapshot. Adding an optional event ID to the generic
+result was rejected because it would weaken the create/update contract and make
+absence handling leak into GraphQL.
+
+GraphQL payloads will expose the numeric repository ID as a required GraphQL
+`ID` by converting it to its decimal string representation. Both Book and
+Author payload types are shared by create and update, and all four resolvers
+will populate the field.
+
+Repository event insertion and entity mutation will continue inside the same
+`TransactionManager` callback. The event ID becomes externally visible only
+after that callback succeeds; an error returns no mutation result.
+
+End-to-end tests will compare the returned ID and event-set ID with history,
+then use the ID as restore input. This validates the cross-layer contract more
+directly than testing only the schema shape.
+
+## Risks / Trade-offs
+
+- [A resolver omits the new non-null field] → Construct payloads from the
+  dedicated result type and cover all four resolvers plus generated schema.
+- [The returned ID names the wrong entity event] → Assert entity type,
+  history membership, and event-set equality in unit and E2E tests.
+- [A transaction error leaks an uncommitted ID] → Return the result only
+  after `TransactionManager` completes successfully and retain rollback tests.
+- [Shared payload types imply `eventId` for out-of-scope operations] → Keep
+  delete and restore on their distinct payload types; do not add the field
+  there.
+
+## Migration Plan
+
+This is an additive GraphQL schema change. Deploy the repository/use-case and
+GraphQL changes together, regenerate the checked-in schema, and allow clients to
+adopt `eventId` when ready. Rollback removes the additive GraphQL field and
+internal result propagation; no data migration is necessary.
+
+## Open Questions
+
+None.

--- a/openspec/changes/return-entity-event-ids/design.md
+++ b/openspec/changes/return-entity-event-ids/design.md
@@ -63,6 +63,13 @@ End-to-end tests will compare the returned ID and event-set ID with history,
 then use the ID as restore input. This validates the cross-layer contract more
 directly than testing only the schema shape.
 
+Each create/update E2E scenario is organized into mutation, history, and
+restore-compatibility phases. These tests only assert that the returned event
+ID is accepted by the restore API; restore state transitions remain the
+responsibility of the dedicated restore E2E suite. The four Book/Author and
+create/update scenarios stay explicit instead of hiding their GraphQL payloads
+behind a large shared helper.
+
 ## Risks / Trade-offs
 
 - [A resolver omits the new non-null field] → Construct payloads from the

--- a/openspec/changes/return-entity-event-ids/design.md
+++ b/openspec/changes/return-entity-event-ids/design.md
@@ -38,13 +38,16 @@ the ID later from event history was rejected because it adds a query and can be
 ambiguous under concurrent writes.
 
 The database adapter will convert the PostgreSQL `BIGINT` value into the domain
-newtype `EventId`. Repository contracts and `EntityMutationResultDto<T>` will
+newtype `EventId`. Repository contracts and `SingleEventMutationResultDto<T>` will
 carry `EventId` instead of a bare `i64`, so unrelated numeric values cannot be
 substituted accidentally. GraphQL remains the external conversion boundary and
 renders `EventId` through its decimal `Display` representation.
 
 Create/update use cases will return a dedicated generic
-`EntityMutationResultDto<T>` containing `value`, `event_set_id`, and `event_id`.
+`SingleEventMutationResultDto<T>` containing `value`, `event_set_id`, and
+`event_id`. Its name expresses the invariant that the mutation produces exactly
+one returnable event for the mutated entity; it does not require the entire
+event set to contain only one event.
 The existing `MutationResultDto<T>` remains for operations that do not guarantee
 one newly recorded entity snapshot. Adding an optional event ID to the generic
 result was rejected because it would weaken the create/update contract and make

--- a/openspec/changes/return-entity-event-ids/design.md
+++ b/openspec/changes/return-entity-event-ids/design.md
@@ -37,6 +37,12 @@ database-generated identifier attached to the write that created it. Inferring
 the ID later from event history was rejected because it adds a query and can be
 ambiguous under concurrent writes.
 
+The database adapter will convert the PostgreSQL `BIGINT` value into the domain
+newtype `EventId`. Repository contracts and `EntityMutationResultDto<T>` will
+carry `EventId` instead of a bare `i64`, so unrelated numeric values cannot be
+substituted accidentally. GraphQL remains the external conversion boundary and
+renders `EventId` through its decimal `Display` representation.
+
 Create/update use cases will return a dedicated generic
 `EntityMutationResultDto<T>` containing `value`, `event_set_id`, and `event_id`.
 The existing `MutationResultDto<T>` remains for operations that do not guarantee

--- a/openspec/changes/return-entity-event-ids/proposal.md
+++ b/openspec/changes/return-entity-event-ids/proposal.md
@@ -1,0 +1,38 @@
+## Why
+
+Book and Author create/update mutations currently return the logical operation's
+`eventSetId`, but clients cannot directly identify the specific recorded entity
+snapshot. Returning that event's ID lets clients inspect history and use the
+newly recorded snapshot as a restore source without an additional lookup.
+
+## What Changes
+
+- Add a required `eventId` field to `BookMutationPayload` and
+  `AuthorMutationPayload` for create and update mutations.
+- Define `eventId` as the newly recorded Book or Author create/update event,
+  distinct from the operation-wide `eventSetId`.
+- Propagate the inserted event ID through repository and use-case mutation
+  results while preserving the existing transaction boundary.
+- Add unit and E2E coverage linking returned IDs to event history and restore
+  inputs.
+- Document that mutations which can produce zero or multiple entity events do
+  not return a single `eventId`.
+
+## Capabilities
+
+### New Capabilities
+
+- `entity-mutation-event-ids`: Defines how Book and Author create/update
+  mutations expose the newly recorded entity event alongside its event set.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+This additive GraphQL API change affects Book and Author repositories, mutation
+use-case DTOs and traits, GraphQL payload construction, generated
+`schema.graphql`, event-recording documentation, and unit/E2E tests. It does not
+change delete, restore, import, or user-registration payload semantics, database
+schema, or the `TransactionManager` boundary.

--- a/openspec/changes/return-entity-event-ids/specs/entity-mutation-event-ids/spec.md
+++ b/openspec/changes/return-entity-event-ids/specs/entity-mutation-event-ids/spec.md
@@ -1,0 +1,64 @@
+## ADDED Requirements
+
+### Requirement: Create mutations expose their recorded entity event
+The system SHALL return the newly recorded entity create event as a required
+`eventId` on `createBook` and `createAuthor` payloads, alongside the affected
+entity and the logical operation's `eventSetId`.
+
+#### Scenario: Create a Book
+- **WHEN** an authenticated client successfully creates a Book
+- **THEN** `createBook.eventId` identifies that Book's newly recorded create event
+- **AND** the event's event-set ID equals `createBook.eventSetId`
+
+#### Scenario: Create an Author
+- **WHEN** an authenticated client successfully creates an Author
+- **THEN** `createAuthor.eventId` identifies that Author's newly recorded create event
+- **AND** the event's event-set ID equals `createAuthor.eventSetId`
+
+### Requirement: Update mutations expose their recorded entity event
+The system SHALL return the newly recorded entity update event as a required
+`eventId` on `updateBook` and `updateAuthor` payloads, alongside the affected
+entity and the logical operation's `eventSetId`.
+
+#### Scenario: Update a Book
+- **WHEN** an authenticated client successfully updates a Book
+- **THEN** `updateBook.eventId` identifies that Book's newly recorded update event
+- **AND** the event's event-set ID equals `updateBook.eventSetId`
+
+#### Scenario: Update an Author
+- **WHEN** an authenticated client successfully updates an Author
+- **THEN** `updateAuthor.eventId` identifies that Author's newly recorded update event
+- **AND** the event's event-set ID equals `updateAuthor.eventSetId`
+
+### Requirement: Returned entity event IDs are valid restore sources
+The system SHALL accept an event ID returned by a successful Book or Author
+create/update mutation wherever the corresponding restore mutation accepts a
+historical entity event ID.
+
+#### Scenario: Restore from a returned Book event ID
+- **WHEN** a client passes a successful Book create/update payload's `eventId` to `restoreBook`
+- **THEN** the restore operation uses that recorded Book snapshot as its source
+
+#### Scenario: Restore from a returned Author event ID
+- **WHEN** a client passes a successful Author create/update payload's `eventId` to `restoreAuthor`
+- **THEN** the restore operation uses that recorded Author snapshot as its source
+
+### Requirement: Entity event IDs remain transactionally atomic
+The system MUST NOT return an entity event ID when the repository operation or
+transaction that records the corresponding Book or Author event fails.
+
+#### Scenario: Event recording fails
+- **WHEN** Book or Author create/update event recording fails
+- **THEN** the mutation fails without returning an `eventId`
+
+#### Scenario: Transaction completion fails
+- **WHEN** the Book or Author create/update transaction does not commit successfully
+- **THEN** the mutation fails without returning an `eventId`
+
+### Requirement: Multi-event mutation contracts remain unchanged
+The system SHALL NOT add a single `eventId` to delete, restore, import, or user
+registration payloads as part of this capability.
+
+#### Scenario: Inspect out-of-scope mutation payloads
+- **WHEN** a client inspects delete, restore, import, or user registration payloads
+- **THEN** those payloads retain their existing event identifier contract

--- a/openspec/changes/return-entity-event-ids/tasks.md
+++ b/openspec/changes/return-entity-event-ids/tasks.md
@@ -17,6 +17,7 @@
 - [x] 3.1 Add Book create/update E2E coverage linking returned event IDs and event-set IDs to history and restore
 - [x] 3.2 Add Author create/update E2E coverage linking returned event IDs and event-set IDs to history and restore
 - [x] 3.3 Run mutation- and restore-related E2E tests when their database and authentication environment is available
+- [x] 3.4 Name and structure create/update E2E tests around the mutation-to-history-to-restore contract
 
 ## 4. Documentation and validation
 

--- a/openspec/changes/return-entity-event-ids/tasks.md
+++ b/openspec/changes/return-entity-event-ids/tasks.md
@@ -4,6 +4,7 @@
 - [x] 1.2 Return inserted event IDs from Author create/update repository operations and cover them with unit tests
 - [x] 1.3 Add `EntityMutationResultDto<T>` and migrate only Book/Author create/update use-case contracts
 - [x] 1.4 Verify create/update transaction failure paths cannot return an event ID
+- [x] 1.5 Represent returned create/update event IDs with the domain `EventId` newtype
 
 ## 2. GraphQL contract
 

--- a/openspec/changes/return-entity-event-ids/tasks.md
+++ b/openspec/changes/return-entity-event-ids/tasks.md
@@ -6,6 +6,7 @@
 - [x] 1.4 Verify create/update transaction failure paths cannot return an event ID
 - [x] 1.5 Represent returned create/update event IDs with the domain `EventId` newtype
 - [x] 1.6 Name the specialized mutation result after its single-entity-event invariant
+- [x] 1.7 Verify the combined mutation interactor preserves returned event IDs
 
 ## 2. GraphQL contract
 

--- a/openspec/changes/return-entity-event-ids/tasks.md
+++ b/openspec/changes/return-entity-event-ids/tasks.md
@@ -2,9 +2,10 @@
 
 - [x] 1.1 Return inserted event IDs from Book create/update repository operations and cover them with unit tests
 - [x] 1.2 Return inserted event IDs from Author create/update repository operations and cover them with unit tests
-- [x] 1.3 Add `EntityMutationResultDto<T>` and migrate only Book/Author create/update use-case contracts
+- [x] 1.3 Add `SingleEventMutationResultDto<T>` and migrate only Book/Author create/update use-case contracts
 - [x] 1.4 Verify create/update transaction failure paths cannot return an event ID
 - [x] 1.5 Represent returned create/update event IDs with the domain `EventId` newtype
+- [x] 1.6 Name the specialized mutation result after its single-entity-event invariant
 
 ## 2. GraphQL contract
 

--- a/openspec/changes/return-entity-event-ids/tasks.md
+++ b/openspec/changes/return-entity-event-ids/tasks.md
@@ -1,0 +1,26 @@
+## 1. Repository and use-case results
+
+- [x] 1.1 Return inserted event IDs from Book create/update repository operations and cover them with unit tests
+- [x] 1.2 Return inserted event IDs from Author create/update repository operations and cover them with unit tests
+- [x] 1.3 Add `EntityMutationResultDto<T>` and migrate only Book/Author create/update use-case contracts
+- [x] 1.4 Verify create/update transaction failure paths cannot return an event ID
+
+## 2. GraphQL contract
+
+- [x] 2.1 Add required `eventId` fields to Book and Author mutation payloads and populate all four create/update resolvers
+- [x] 2.2 Add GraphQL unit coverage for payload values and out-of-scope payload stability
+- [x] 2.3 Regenerate `schema.graphql` and verify the new fields are non-null IDs
+
+## 3. Cross-layer verification
+
+- [x] 3.1 Add Book create/update E2E coverage linking returned event IDs and event-set IDs to history and restore
+- [x] 3.2 Add Author create/update E2E coverage linking returned event IDs and event-set IDs to history and restore
+- [x] 3.3 Run mutation- and restore-related E2E tests when their database and authentication environment is available
+
+## 4. Documentation and validation
+
+- [x] 4.1 Document operation-level and entity-event identifiers in `docs/architecture/event-recording.md`
+- [x] 4.2 Add a changelog entry for the additive GraphQL fields if this repository's changelog convention requires it
+- [x] 4.3 Run `cargo fmt --check`
+- [x] 4.4 Run `cargo clippy --all-targets --locked -- -D warnings`
+- [x] 4.5 Run `cargo test --locked`

--- a/schema.graphql
+++ b/schema.graphql
@@ -22,6 +22,7 @@ type AuthorEventEntry {
 type AuthorMutationPayload {
 	author: Author!
 	eventSetId: ID!
+	eventId: ID!
 }
 
 type Book {
@@ -66,6 +67,7 @@ enum BookFormat {
 type BookMutationPayload {
 	book: Book!
 	eventSetId: ID!
+	eventId: ID!
 }
 
 enum BookStore {

--- a/src/domain/entity/event.rs
+++ b/src/domain/entity/event.rs
@@ -10,6 +10,27 @@ use crate::{
     },
 };
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EventId(i64);
+
+impl EventId {
+    pub fn value(self) -> i64 {
+        self.0
+    }
+}
+
+impl From<i64> for EventId {
+    fn from(value: i64) -> Self {
+        Self(value)
+    }
+}
+
+impl std::fmt::Display for EventId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum EventOperation {
     Create,
@@ -99,7 +120,15 @@ impl TryFrom<&str> for EventOperation {
 
 #[cfg(test)]
 mod tests {
-    use super::{EventOperation, EventSetOperation};
+    use super::{EventId, EventOperation, EventSetOperation};
+
+    #[test]
+    fn event_id_round_trips_database_value() {
+        let event_id = EventId::from(42);
+
+        assert_eq!(event_id.value(), 42);
+        assert_eq!(event_id.to_string(), "42");
+    }
 
     #[test]
     fn event_operation_round_trip() {

--- a/src/domain/repository/author_repository.rs
+++ b/src/domain/repository/author_repository.rs
@@ -7,6 +7,7 @@ use time::OffsetDateTime;
 use crate::domain::{
     entity::{
         author::{Author, AuthorId, AuthorName},
+        event::EventId,
         user::UserId,
     },
     error::DomainError,
@@ -17,8 +18,11 @@ use crate::domain::{
 pub trait AuthorRepository: Send + Sync + 'static {
     type Transaction: Send;
 
-    async fn create(&self, tx: &mut Self::Transaction, author: &Author)
-    -> Result<i64, DomainError>;
+    async fn create(
+        &self,
+        tx: &mut Self::Transaction,
+        author: &Author,
+    ) -> Result<EventId, DomainError>;
     async fn find_by_id(
         &self,
         user_id: &UserId,
@@ -44,8 +48,11 @@ pub trait AuthorRepository: Send + Sync + 'static {
         name: &AuthorName,
         created_at: OffsetDateTime,
     ) -> Result<AuthorId, DomainError>;
-    async fn update(&self, tx: &mut Self::Transaction, author: &Author)
-    -> Result<i64, DomainError>;
+    async fn update(
+        &self,
+        tx: &mut Self::Transaction,
+        author: &Author,
+    ) -> Result<EventId, DomainError>;
     async fn delete(
         &self,
         tx: &mut Self::Transaction,

--- a/src/domain/repository/author_repository.rs
+++ b/src/domain/repository/author_repository.rs
@@ -17,7 +17,8 @@ use crate::domain::{
 pub trait AuthorRepository: Send + Sync + 'static {
     type Transaction: Send;
 
-    async fn create(&self, tx: &mut Self::Transaction, author: &Author) -> Result<(), DomainError>;
+    async fn create(&self, tx: &mut Self::Transaction, author: &Author)
+    -> Result<i64, DomainError>;
     async fn find_by_id(
         &self,
         user_id: &UserId,
@@ -43,7 +44,8 @@ pub trait AuthorRepository: Send + Sync + 'static {
         name: &AuthorName,
         created_at: OffsetDateTime,
     ) -> Result<AuthorId, DomainError>;
-    async fn update(&self, tx: &mut Self::Transaction, author: &Author) -> Result<(), DomainError>;
+    async fn update(&self, tx: &mut Self::Transaction, author: &Author)
+    -> Result<i64, DomainError>;
     async fn delete(
         &self,
         tx: &mut Self::Transaction,

--- a/src/domain/repository/book_repository.rs
+++ b/src/domain/repository/book_repository.rs
@@ -4,6 +4,7 @@ use mockall::automock;
 use crate::domain::{
     entity::{
         book::{Book, BookId},
+        event::EventId,
         user::UserId,
     },
     error::DomainError,
@@ -14,7 +15,8 @@ use crate::domain::{
 pub trait BookRepository: Send + Sync + 'static {
     type Transaction: Send;
 
-    async fn create(&self, tx: &mut Self::Transaction, book: &Book) -> Result<i64, DomainError>;
+    async fn create(&self, tx: &mut Self::Transaction, book: &Book)
+    -> Result<EventId, DomainError>;
     async fn find_by_id(
         &self,
         user_id: &UserId,
@@ -27,7 +29,8 @@ pub trait BookRepository: Send + Sync + 'static {
         book_id: &BookId,
     ) -> Result<Option<Book>, DomainError>;
     async fn find_all(&self, user_id: &UserId) -> Result<Vec<Book>, DomainError>;
-    async fn update(&self, tx: &mut Self::Transaction, book: &Book) -> Result<i64, DomainError>;
+    async fn update(&self, tx: &mut Self::Transaction, book: &Book)
+    -> Result<EventId, DomainError>;
     async fn delete(&self, tx: &mut Self::Transaction, book_id: &BookId)
     -> Result<(), DomainError>;
     // Upserts or deletes the entity and records a restore event in one transaction.

--- a/src/domain/repository/book_repository.rs
+++ b/src/domain/repository/book_repository.rs
@@ -14,7 +14,7 @@ use crate::domain::{
 pub trait BookRepository: Send + Sync + 'static {
     type Transaction: Send;
 
-    async fn create(&self, tx: &mut Self::Transaction, book: &Book) -> Result<(), DomainError>;
+    async fn create(&self, tx: &mut Self::Transaction, book: &Book) -> Result<i64, DomainError>;
     async fn find_by_id(
         &self,
         user_id: &UserId,
@@ -27,7 +27,7 @@ pub trait BookRepository: Send + Sync + 'static {
         book_id: &BookId,
     ) -> Result<Option<Book>, DomainError>;
     async fn find_all(&self, user_id: &UserId) -> Result<Vec<Book>, DomainError>;
-    async fn update(&self, tx: &mut Self::Transaction, book: &Book) -> Result<(), DomainError>;
+    async fn update(&self, tx: &mut Self::Transaction, book: &Book) -> Result<i64, DomainError>;
     async fn delete(&self, tx: &mut Self::Transaction, book_id: &BookId)
     -> Result<(), DomainError>;
     // Upserts or deletes the entity and records a restore event in one transaction.

--- a/src/infrastructure/author_repository.rs
+++ b/src/infrastructure/author_repository.rs
@@ -60,7 +60,11 @@ impl PgAuthorRepository {
 impl AuthorRepository for PgAuthorRepository {
     type Transaction = PgTransaction;
 
-    async fn create(&self, tx: &mut Self::Transaction, author: &Author) -> Result<(), DomainError> {
+    async fn create(
+        &self,
+        tx: &mut Self::Transaction,
+        author: &Author,
+    ) -> Result<i64, DomainError> {
         let user_id = tx.user_id().clone();
         sqlx::query(
             "INSERT INTO author (id, user_id, name, yomi, created_at, updated_at)
@@ -84,11 +88,12 @@ impl AuthorRepository for PgAuthorRepository {
         .fetch_one(tx.as_mut())
         .await?;
 
-        sqlx::query(
+        let (event_id,): (i64,) = sqlx::query_as(
             "INSERT INTO author_event
                (event_set_id, operation, author_id, user_id, name, yomi,
                 author_created_at, author_updated_at)
-             VALUES ($1, 'create', $2, $3, $4, $5, $6, $7)",
+             VALUES ($1, 'create', $2, $3, $4, $5, $6, $7)
+             RETURNING event_id",
         )
         .bind(tx.event_set_id())
         .bind(author.id().to_uuid())
@@ -97,10 +102,10 @@ impl AuthorRepository for PgAuthorRepository {
         .bind(&snap.yomi)
         .bind(snap.created_at)
         .bind(snap.updated_at)
-        .execute(tx.as_mut())
+        .fetch_one(tx.as_mut())
         .await?;
 
-        Ok(())
+        Ok(event_id)
     }
 
     async fn find_or_create_by_name(
@@ -211,7 +216,11 @@ impl AuthorRepository for PgAuthorRepository {
         authors
     }
 
-    async fn update(&self, tx: &mut Self::Transaction, author: &Author) -> Result<(), DomainError> {
+    async fn update(
+        &self,
+        tx: &mut Self::Transaction,
+        author: &Author,
+    ) -> Result<i64, DomainError> {
         let user_id = tx.user_id().clone();
         let result = sqlx::query(
             "UPDATE author SET name = $1, yomi = $2, updated_at = $3
@@ -250,11 +259,12 @@ impl AuthorRepository for PgAuthorRepository {
         .fetch_one(tx.as_mut())
         .await?;
 
-        sqlx::query(
+        let (event_id,): (i64,) = sqlx::query_as(
             "INSERT INTO author_event
                (event_set_id, operation, author_id, user_id, name, yomi,
                 author_created_at, author_updated_at)
-             VALUES ($1, 'update', $2, $3, $4, $5, $6, $7)",
+             VALUES ($1, 'update', $2, $3, $4, $5, $6, $7)
+             RETURNING event_id",
         )
         .bind(tx.event_set_id())
         .bind(author.id().to_uuid())
@@ -263,10 +273,10 @@ impl AuthorRepository for PgAuthorRepository {
         .bind(&snap.yomi)
         .bind(snap.created_at)
         .bind(snap.updated_at)
-        .execute(tx.as_mut())
+        .fetch_one(tx.as_mut())
         .await?;
 
-        Ok(())
+        Ok(event_id)
     }
 
     async fn delete(
@@ -561,11 +571,12 @@ mod tests {
         author_repository: &PgAuthorRepository,
         user_id: &UserId,
         author: &Author,
-    ) -> Result<(), DomainError> {
+    ) -> Result<i64, DomainError> {
         let tm = PgTransactionManager::new(pool.clone());
         let mut tx = tm.begin(user_id, EventSetOperation::CreateAuthor).await?;
-        author_repository.create(&mut tx, author).await?;
-        tm.commit(tx).await
+        let event_id = author_repository.create(&mut tx, author).await?;
+        tm.commit(tx).await?;
+        Ok(event_id)
     }
 
     async fn update_author(
@@ -573,11 +584,12 @@ mod tests {
         author_repository: &PgAuthorRepository,
         user_id: &UserId,
         author: &Author,
-    ) -> Result<(), DomainError> {
+    ) -> Result<i64, DomainError> {
         let tm = PgTransactionManager::new(pool.clone());
         let mut tx = tm.begin(user_id, EventSetOperation::UpdateAuthor).await?;
-        author_repository.update(&mut tx, author).await?;
-        tm.commit(tx).await
+        let event_id = author_repository.update(&mut tx, author).await?;
+        tm.commit(tx).await?;
+        Ok(event_id)
     }
 
     async fn delete_author(
@@ -622,7 +634,7 @@ mod tests {
         let author_name = AuthorName::new(String::from("author1"))?;
         let author = new_author(author_id.clone(), author_name)?;
 
-        create_author(&pool, &author_repository, &user_id, &author).await?;
+        let event_id = create_author(&pool, &author_repository, &user_id, &author).await?;
 
         let actual = author_repository.find_by_id(&user_id, &author_id).await?;
         assert_eq!(actual, Some(author.clone()));
@@ -1021,14 +1033,17 @@ mod tests {
                 .await?;
         assert_eq!(es_op, "create_author");
 
-        let (ae_op, ae_name, ae_yomi): (String, String, String) =
-            sqlx::query_as("SELECT operation, name, yomi FROM author_event WHERE user_id = $1")
-                .bind(user_id.as_str())
-                .fetch_one(&pool)
-                .await?;
+        let (stored_event_id, ae_op, ae_name, ae_yomi): (i64, String, String, String) =
+            sqlx::query_as(
+                "SELECT event_id, operation, name, yomi FROM author_event WHERE user_id = $1",
+            )
+            .bind(user_id.as_str())
+            .fetch_one(&pool)
+            .await?;
         assert_eq!(ae_op, "create");
         assert_eq!(ae_name, "author1");
         assert_eq!(ae_yomi, "おーさー1");
+        assert_eq!(event_id, stored_event_id);
 
         Ok(())
     }
@@ -1054,10 +1069,10 @@ mod tests {
             "あっぷでーと2".to_owned(),
             OffsetDateTime::UNIX_EPOCH,
         )?;
-        update_author(&pool, &author_repository, &user_id, &updated).await?;
+        let event_id = update_author(&pool, &author_repository, &user_id, &updated).await?;
 
-        let rows: Vec<(String, String, String)> = sqlx::query_as(
-            "SELECT operation, name, yomi FROM author_event WHERE user_id = $1
+        let rows: Vec<(i64, String, String, String)> = sqlx::query_as(
+            "SELECT event_id, operation, name, yomi FROM author_event WHERE user_id = $1
              ORDER BY changed_at ASC",
         )
         .bind(user_id.as_str())
@@ -1065,13 +1080,14 @@ mod tests {
         .await?;
 
         assert_eq!(rows.len(), 2);
-        assert_eq!(rows[0].0, "create");
-        assert_eq!(rows[0].1, "original");
-        assert_eq!(rows[0].2, "おりじなる");
+        assert_eq!(rows[0].1, "create");
+        assert_eq!(rows[0].2, "original");
+        assert_eq!(rows[0].3, "おりじなる");
         // Post-state: update event records the new name
-        assert_eq!(rows[1].0, "update");
-        assert_eq!(rows[1].1, "updated");
-        assert_eq!(rows[1].2, "あっぷでーと2");
+        assert_eq!(rows[1].0, event_id);
+        assert_eq!(rows[1].1, "update");
+        assert_eq!(rows[1].2, "updated");
+        assert_eq!(rows[1].3, "あっぷでーと2");
 
         let es_count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM event_set WHERE user_id = $1")
             .bind(user_id.as_str())

--- a/src/infrastructure/author_repository.rs
+++ b/src/infrastructure/author_repository.rs
@@ -10,7 +10,7 @@ use uuid::Uuid;
 use crate::domain::{
     entity::{
         author::{Author, AuthorId, AuthorName},
-        event::EventOperation,
+        event::{EventId, EventOperation},
         user::UserId,
     },
     error::DomainError,
@@ -64,7 +64,7 @@ impl AuthorRepository for PgAuthorRepository {
         &self,
         tx: &mut Self::Transaction,
         author: &Author,
-    ) -> Result<i64, DomainError> {
+    ) -> Result<EventId, DomainError> {
         let user_id = tx.user_id().clone();
         sqlx::query(
             "INSERT INTO author (id, user_id, name, yomi, created_at, updated_at)
@@ -105,7 +105,7 @@ impl AuthorRepository for PgAuthorRepository {
         .fetch_one(tx.as_mut())
         .await?;
 
-        Ok(event_id)
+        Ok(EventId::from(event_id))
     }
 
     async fn find_or_create_by_name(
@@ -220,7 +220,7 @@ impl AuthorRepository for PgAuthorRepository {
         &self,
         tx: &mut Self::Transaction,
         author: &Author,
-    ) -> Result<i64, DomainError> {
+    ) -> Result<EventId, DomainError> {
         let user_id = tx.user_id().clone();
         let result = sqlx::query(
             "UPDATE author SET name = $1, yomi = $2, updated_at = $3
@@ -276,7 +276,7 @@ impl AuthorRepository for PgAuthorRepository {
         .fetch_one(tx.as_mut())
         .await?;
 
-        Ok(event_id)
+        Ok(EventId::from(event_id))
     }
 
     async fn delete(
@@ -576,7 +576,7 @@ mod tests {
         let mut tx = tm.begin(user_id, EventSetOperation::CreateAuthor).await?;
         let event_id = author_repository.create(&mut tx, author).await?;
         tm.commit(tx).await?;
-        Ok(event_id)
+        Ok(event_id.value())
     }
 
     async fn update_author(
@@ -589,7 +589,7 @@ mod tests {
         let mut tx = tm.begin(user_id, EventSetOperation::UpdateAuthor).await?;
         let event_id = author_repository.update(&mut tx, author).await?;
         tm.commit(tx).await?;
-        Ok(event_id)
+        Ok(event_id.value())
     }
 
     async fn delete_author(

--- a/src/infrastructure/author_repository.rs
+++ b/src/infrastructure/author_repository.rs
@@ -634,7 +634,7 @@ mod tests {
         let author_name = AuthorName::new(String::from("author1"))?;
         let author = new_author(author_id.clone(), author_name)?;
 
-        let event_id = create_author(&pool, &author_repository, &user_id, &author).await?;
+        create_author(&pool, &author_repository, &user_id, &author).await?;
 
         let actual = author_repository.find_by_id(&user_id, &author_id).await?;
         assert_eq!(actual, Some(author.clone()));
@@ -1024,7 +1024,7 @@ mod tests {
             OffsetDateTime::UNIX_EPOCH,
         )?;
 
-        create_author(&pool, &author_repository, &user_id, &author).await?;
+        let event_id = create_author(&pool, &author_repository, &user_id, &author).await?;
 
         let (es_op,): (String,) =
             sqlx::query_as("SELECT operation FROM event_set WHERE user_id = $1")

--- a/src/infrastructure/book_repository.rs
+++ b/src/infrastructure/book_repository.rs
@@ -668,7 +668,7 @@ mod tests {
         assert_eq!(all_books.len(), 0);
 
         let book = book_entity1(&author_ids)?;
-        let event_id = create_book(&pool, &book_repository, &user_id, &book).await?;
+        create_book(&pool, &book_repository, &user_id, &book).await?;
 
         let actual = book_repository.find_by_id(&user_id, book.id()).await?;
         assert_eq!(actual, Some(book));
@@ -1151,7 +1151,7 @@ mod tests {
         let author_ids = prepare_authors1(&pool, &user_id, &author_repository).await?;
         let book = book_entity1(&author_ids)?;
 
-        create_book(&pool, &book_repository, &user_id, &book).await?;
+        let event_id = create_book(&pool, &book_repository, &user_id, &book).await?;
 
         let (cs_op,): (String,) = sqlx::query_as(
             "SELECT operation FROM event_set WHERE user_id = $1 AND operation = 'create_book'",

--- a/src/infrastructure/book_repository.rs
+++ b/src/infrastructure/book_repository.rs
@@ -123,7 +123,7 @@ impl PgBookRepository {
 impl BookRepository for PgBookRepository {
     type Transaction = PgTransaction;
 
-    async fn create(&self, tx: &mut Self::Transaction, book: &Book) -> Result<(), DomainError> {
+    async fn create(&self, tx: &mut Self::Transaction, book: &Book) -> Result<i64, DomainError> {
         let user_id = tx.user_id().clone();
         sqlx::query(
             "INSERT INTO book (
@@ -205,7 +205,7 @@ impl BookRepository for PgBookRepository {
             .await?;
         }
 
-        Ok(())
+        Ok(event_id)
     }
 
     async fn find_by_id(
@@ -267,7 +267,7 @@ impl BookRepository for PgBookRepository {
         books
     }
 
-    async fn update(&self, tx: &mut Self::Transaction, book: &Book) -> Result<(), DomainError> {
+    async fn update(&self, tx: &mut Self::Transaction, book: &Book) -> Result<i64, DomainError> {
         let user_id = tx.user_id().clone();
         let result = sqlx::query(
             "UPDATE book SET
@@ -376,7 +376,7 @@ impl BookRepository for PgBookRepository {
             .await?;
         }
 
-        Ok(())
+        Ok(event_id)
     }
 
     async fn delete(
@@ -595,11 +595,12 @@ mod tests {
         book_repository: &PgBookRepository,
         user_id: &UserId,
         book: &Book,
-    ) -> Result<(), DomainError> {
+    ) -> Result<i64, DomainError> {
         let tm = PgTransactionManager::new(pool.clone());
         let mut tx = tm.begin(user_id, EventSetOperation::CreateBook).await?;
-        book_repository.create(&mut tx, book).await?;
-        tm.commit(tx).await
+        let event_id = book_repository.create(&mut tx, book).await?;
+        tm.commit(tx).await?;
+        Ok(event_id)
     }
 
     async fn update_book(
@@ -607,11 +608,12 @@ mod tests {
         book_repository: &PgBookRepository,
         user_id: &UserId,
         book: &Book,
-    ) -> Result<(), DomainError> {
+    ) -> Result<i64, DomainError> {
         let tm = PgTransactionManager::new(pool.clone());
         let mut tx = tm.begin(user_id, EventSetOperation::UpdateBook).await?;
-        book_repository.update(&mut tx, book).await?;
-        tm.commit(tx).await
+        let event_id = book_repository.update(&mut tx, book).await?;
+        tm.commit(tx).await?;
+        Ok(event_id)
     }
 
     async fn delete_book(
@@ -666,7 +668,7 @@ mod tests {
         assert_eq!(all_books.len(), 0);
 
         let book = book_entity1(&author_ids)?;
-        create_book(&pool, &book_repository, &user_id, &book).await?;
+        let event_id = create_book(&pool, &book_repository, &user_id, &book).await?;
 
         let actual = book_repository.find_by_id(&user_id, book.id()).await?;
         assert_eq!(actual, Some(book));
@@ -1159,13 +1161,14 @@ mod tests {
         .await?;
         assert_eq!(cs_op, "create_book");
 
-        let (bh_op, bh_title): (String, String) =
-            sqlx::query_as("SELECT operation, title FROM book_event WHERE user_id = $1")
+        let (stored_event_id, bh_op, bh_title): (i64, String, String) =
+            sqlx::query_as("SELECT event_id, operation, title FROM book_event WHERE user_id = $1")
                 .bind(user_id.as_str())
                 .fetch_one(&pool)
                 .await?;
         assert_eq!(bh_op, "create");
         assert_eq!(bh_title, "title1");
+        assert_eq!(event_id, stored_event_id);
 
         let (author_count,): (i64,) = sqlx::query_as(
             "SELECT COUNT(*) FROM book_event_author bea
@@ -1205,10 +1208,10 @@ mod tests {
             PrimitiveDateTime::new(date!(2022 - 05 - 05), time!(0:00)).assume_utc(),
             PrimitiveDateTime::new(date!(2022 - 05 - 05), time!(0:00)).assume_utc(),
         )?;
-        update_book(&pool, &book_repository, &user_id, &updated).await?;
+        let event_id = update_book(&pool, &book_repository, &user_id, &updated).await?;
 
-        let rows: Vec<(String, String)> = sqlx::query_as(
-            "SELECT operation, title FROM book_event WHERE user_id = $1
+        let rows: Vec<(i64, String, String)> = sqlx::query_as(
+            "SELECT event_id, operation, title FROM book_event WHERE user_id = $1
              ORDER BY changed_at DESC",
         )
         .bind(user_id.as_str())
@@ -1217,9 +1220,10 @@ mod tests {
 
         assert_eq!(rows.len(), 2);
         // Most recent entry is the update event (post-update state)
-        assert_eq!(rows[0].0, "update");
-        assert_eq!(rows[0].1, "title2");
-        assert_eq!(rows[1].0, "create");
+        assert_eq!(rows[0].0, event_id);
+        assert_eq!(rows[0].1, "update");
+        assert_eq!(rows[0].2, "title2");
+        assert_eq!(rows[1].1, "create");
 
         let cs_count: (i64,) = sqlx::query_as(
             "SELECT COUNT(*) FROM event_set WHERE user_id = $1

--- a/src/infrastructure/book_repository.rs
+++ b/src/infrastructure/book_repository.rs
@@ -11,6 +11,7 @@ use crate::{
         entity::{
             author::AuthorId,
             book::{Book, BookId, BookTitle, Isbn, OwnedFlag, Priority, ReadFlag},
+            event::EventId,
             user::UserId,
         },
         error::DomainError,
@@ -123,7 +124,11 @@ impl PgBookRepository {
 impl BookRepository for PgBookRepository {
     type Transaction = PgTransaction;
 
-    async fn create(&self, tx: &mut Self::Transaction, book: &Book) -> Result<i64, DomainError> {
+    async fn create(
+        &self,
+        tx: &mut Self::Transaction,
+        book: &Book,
+    ) -> Result<EventId, DomainError> {
         let user_id = tx.user_id().clone();
         sqlx::query(
             "INSERT INTO book (
@@ -205,7 +210,7 @@ impl BookRepository for PgBookRepository {
             .await?;
         }
 
-        Ok(event_id)
+        Ok(EventId::from(event_id))
     }
 
     async fn find_by_id(
@@ -267,7 +272,11 @@ impl BookRepository for PgBookRepository {
         books
     }
 
-    async fn update(&self, tx: &mut Self::Transaction, book: &Book) -> Result<i64, DomainError> {
+    async fn update(
+        &self,
+        tx: &mut Self::Transaction,
+        book: &Book,
+    ) -> Result<EventId, DomainError> {
         let user_id = tx.user_id().clone();
         let result = sqlx::query(
             "UPDATE book SET
@@ -376,7 +385,7 @@ impl BookRepository for PgBookRepository {
             .await?;
         }
 
-        Ok(event_id)
+        Ok(EventId::from(event_id))
     }
 
     async fn delete(
@@ -600,7 +609,7 @@ mod tests {
         let mut tx = tm.begin(user_id, EventSetOperation::CreateBook).await?;
         let event_id = book_repository.create(&mut tx, book).await?;
         tm.commit(tx).await?;
-        Ok(event_id)
+        Ok(event_id.value())
     }
 
     async fn update_book(
@@ -613,7 +622,7 @@ mod tests {
         let mut tx = tm.begin(user_id, EventSetOperation::UpdateBook).await?;
         let event_id = book_repository.update(&mut tx, book).await?;
         tm.commit(tx).await?;
-        Ok(event_id)
+        Ok(event_id.value())
     }
 
     async fn delete_book(

--- a/src/presentation/graphql/mutation.rs
+++ b/src/presentation/graphql/mutation.rs
@@ -48,6 +48,7 @@ where
         Ok(BookMutationPayload::new(
             book.value.into(),
             ID(book.event_set_id),
+            ID(book.event_id.to_string()),
         ))
     }
 
@@ -65,6 +66,7 @@ where
         Ok(BookMutationPayload::new(
             book.value.into(),
             ID(book.event_set_id),
+            ID(book.event_id.to_string()),
         ))
     }
 
@@ -98,6 +100,7 @@ where
         Ok(AuthorMutationPayload::new(
             author.value.into(),
             ID(author.event_set_id),
+            ID(author.event_id.to_string()),
         ))
     }
 
@@ -114,6 +117,7 @@ where
         Ok(AuthorMutationPayload::new(
             author.value.into(),
             ID(author.event_set_id),
+            ID(author.event_id.to_string()),
         ))
     }
 

--- a/src/presentation/graphql/object.rs
+++ b/src/presentation/graphql/object.rs
@@ -472,11 +472,16 @@ impl From<EventSetDetailDto> for EventSetDetail {
 pub struct BookMutationPayload {
     pub book: Book,
     pub event_set_id: ID,
+    pub event_id: ID,
 }
 
 impl BookMutationPayload {
-    pub fn new(book: Book, event_set_id: ID) -> Self {
-        Self { book, event_set_id }
+    pub fn new(book: Book, event_set_id: ID, event_id: ID) -> Self {
+        Self {
+            book,
+            event_set_id,
+            event_id,
+        }
     }
 }
 
@@ -484,13 +489,15 @@ impl BookMutationPayload {
 pub struct AuthorMutationPayload {
     pub author: Author,
     pub event_set_id: ID,
+    pub event_id: ID,
 }
 
 impl AuthorMutationPayload {
-    pub fn new(author: Author, event_set_id: ID) -> Self {
+    pub fn new(author: Author, event_set_id: ID, event_id: ID) -> Self {
         Self {
             author,
             event_set_id,
+            event_id,
         }
     }
 }

--- a/src/presentation/graphql/schema.rs
+++ b/src/presentation/graphql/schema.rs
@@ -90,7 +90,7 @@ mod tests {
                         updated_at: time::OffsetDateTime::UNIX_EPOCH,
                     },
                     "e77df9d5-b7bf-47f2-8753-03f285d440e3".to_string(),
-                    1234,
+                    1234.into(),
                 ))
             });
         let schema = build_schema(

--- a/src/presentation/graphql/schema.rs
+++ b/src/presentation/graphql/schema.rs
@@ -24,7 +24,7 @@ mod tests {
             graphql::{mutation::Mutation, query::Query},
         },
         use_case::{
-            dto::author::AuthorDto,
+            dto::{author::AuthorDto, mutation::EntityMutationResultDto},
             traits::{mutation::MockMutationUseCase, query::MockQueryUseCase},
         },
     };
@@ -74,16 +74,64 @@ mod tests {
         assert_eq!(json["data"]["author"]["updatedAt"], "1970-01-01T00:00:00Z");
     }
 
+    #[tokio::test]
+    async fn create_author_payload_exposes_numeric_event_id_as_graphql_id() {
+        let mut mutation_use_case = MockMutationUseCase::new();
+        mutation_use_case
+            .expect_create_author()
+            .with(predicate::eq("user1"), predicate::always())
+            .returning(|_, input| {
+                Ok(EntityMutationResultDto::new(
+                    AuthorDto {
+                        id: "d065a358-4fa7-4236-ae19-f6f2f9467c35".to_string(),
+                        name: input.name,
+                        yomi: String::new(),
+                        created_at: time::OffsetDateTime::UNIX_EPOCH,
+                        updated_at: time::OffsetDateTime::UNIX_EPOCH,
+                    },
+                    "e77df9d5-b7bf-47f2-8753-03f285d440e3".to_string(),
+                    1234,
+                ))
+            });
+        let schema = build_schema(
+            Query::new(MockQueryUseCase::new()),
+            Mutation::new(mutation_use_case),
+        );
+        let claims = Claims {
+            sub: "user1".to_string(),
+            _permissions: None,
+        };
+
+        let response = schema
+            .execute(
+                async_graphql::Request::from(
+                    r#"mutation { createAuthor(authorData: { name: "Author" }) { eventId eventSetId author { name } } }"#,
+                )
+                .data(claims),
+            )
+            .await;
+        let json = serde_json::to_value(response).unwrap();
+
+        assert_eq!(json["data"]["createAuthor"]["eventId"], "1234");
+        assert_eq!(
+            json["data"]["createAuthor"]["eventSetId"],
+            "e77df9d5-b7bf-47f2-8753-03f285d440e3"
+        );
+        assert_eq!(json["data"]["createAuthor"]["author"]["name"], "Author");
+    }
+
     #[test]
     fn mutation_payloads_expose_only_canonical_fields() {
         let query = Query::new(MockQueryUseCase::new());
         let mutation = Mutation::new(MockMutationUseCase::new());
         let sdl = build_schema(query, mutation).sdl();
 
-        assert!(sdl.contains("type BookMutationPayload {\n\tbook: Book!\n\teventSetId: ID!\n}"));
-        assert!(
-            sdl.contains("type AuthorMutationPayload {\n\tauthor: Author!\n\teventSetId: ID!\n}")
-        );
+        assert!(sdl.contains(
+            "type BookMutationPayload {\n\tbook: Book!\n\teventSetId: ID!\n\teventId: ID!\n}"
+        ));
+        assert!(sdl.contains(
+            "type AuthorMutationPayload {\n\tauthor: Author!\n\teventSetId: ID!\n\teventId: ID!\n}"
+        ));
         assert!(sdl.contains("type DeleteBookPayload {\n\tbookId: ID!\n\teventSetId: ID!\n}"));
         assert!(sdl.contains("type DeleteAuthorPayload {\n\tauthorId: ID!\n\teventSetId: ID!\n}"));
     }

--- a/src/presentation/graphql/schema.rs
+++ b/src/presentation/graphql/schema.rs
@@ -24,7 +24,7 @@ mod tests {
             graphql::{mutation::Mutation, query::Query},
         },
         use_case::{
-            dto::{author::AuthorDto, mutation::EntityMutationResultDto},
+            dto::{author::AuthorDto, mutation::SingleEventMutationResultDto},
             traits::{mutation::MockMutationUseCase, query::MockQueryUseCase},
         },
     };
@@ -81,7 +81,7 @@ mod tests {
             .expect_create_author()
             .with(predicate::eq("user1"), predicate::always())
             .returning(|_, input| {
-                Ok(EntityMutationResultDto::new(
+                Ok(SingleEventMutationResultDto::new(
                     AuthorDto {
                         id: "d065a358-4fa7-4236-ae19-f6f2f9467c35".to_string(),
                         name: input.name,

--- a/src/use_case/dto/mutation.rs
+++ b/src/use_case/dto/mutation.rs
@@ -24,14 +24,15 @@ impl<T> std::ops::Deref for MutationResultDto<T> {
     }
 }
 
+/// Result of a mutation that produces exactly one event for the mutated entity.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct EntityMutationResultDto<T> {
+pub struct SingleEventMutationResultDto<T> {
     pub value: T,
     pub event_set_id: String,
     pub event_id: EventId,
 }
 
-impl<T> EntityMutationResultDto<T> {
+impl<T> SingleEventMutationResultDto<T> {
     pub fn new(value: T, event_set_id: String, event_id: EventId) -> Self {
         Self {
             value,
@@ -41,7 +42,7 @@ impl<T> EntityMutationResultDto<T> {
     }
 }
 
-impl<T> std::ops::Deref for EntityMutationResultDto<T> {
+impl<T> std::ops::Deref for SingleEventMutationResultDto<T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
@@ -49,8 +50,8 @@ impl<T> std::ops::Deref for EntityMutationResultDto<T> {
     }
 }
 
-pub type BookMutationResultDto = EntityMutationResultDto<BookDto>;
-pub type AuthorMutationResultDto = EntityMutationResultDto<AuthorDto>;
+pub type BookMutationResultDto = SingleEventMutationResultDto<BookDto>;
+pub type AuthorMutationResultDto = SingleEventMutationResultDto<AuthorDto>;
 pub type DeleteBookResultDto = MutationResultDto<String>;
 pub type DeleteAuthorResultDto = MutationResultDto<String>;
 pub type ImportBooksResultDto = MutationResultDto<Vec<BookDto>>;

--- a/src/use_case/dto/mutation.rs
+++ b/src/use_case/dto/mutation.rs
@@ -1,4 +1,5 @@
 use super::{author::AuthorDto, book::BookDto};
+use crate::domain::entity::event::EventId;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MutationResultDto<T> {
@@ -27,11 +28,11 @@ impl<T> std::ops::Deref for MutationResultDto<T> {
 pub struct EntityMutationResultDto<T> {
     pub value: T,
     pub event_set_id: String,
-    pub event_id: i64,
+    pub event_id: EventId,
 }
 
 impl<T> EntityMutationResultDto<T> {
-    pub fn new(value: T, event_set_id: String, event_id: i64) -> Self {
+    pub fn new(value: T, event_set_id: String, event_id: EventId) -> Self {
         Self {
             value,
             event_set_id,

--- a/src/use_case/dto/mutation.rs
+++ b/src/use_case/dto/mutation.rs
@@ -23,8 +23,33 @@ impl<T> std::ops::Deref for MutationResultDto<T> {
     }
 }
 
-pub type BookMutationResultDto = MutationResultDto<BookDto>;
-pub type AuthorMutationResultDto = MutationResultDto<AuthorDto>;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EntityMutationResultDto<T> {
+    pub value: T,
+    pub event_set_id: String,
+    pub event_id: i64,
+}
+
+impl<T> EntityMutationResultDto<T> {
+    pub fn new(value: T, event_set_id: String, event_id: i64) -> Self {
+        Self {
+            value,
+            event_set_id,
+            event_id,
+        }
+    }
+}
+
+impl<T> std::ops::Deref for EntityMutationResultDto<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.value
+    }
+}
+
+pub type BookMutationResultDto = EntityMutationResultDto<BookDto>;
+pub type AuthorMutationResultDto = EntityMutationResultDto<AuthorDto>;
 pub type DeleteBookResultDto = MutationResultDto<String>;
 pub type DeleteAuthorResultDto = MutationResultDto<String>;
 pub type ImportBooksResultDto = MutationResultDto<Vec<BookDto>>;

--- a/src/use_case/interactor/author.rs
+++ b/src/use_case/interactor/author.rs
@@ -17,7 +17,10 @@ use crate::{
     use_case::{
         dto::{
             author::{CreateAuthorDto, UpdateAuthorDto},
-            mutation::{AuthorMutationResultDto, DeleteAuthorResultDto, MutationResultDto},
+            mutation::{
+                AuthorMutationResultDto, DeleteAuthorResultDto, EntityMutationResultDto,
+                MutationResultDto,
+            },
         },
         error::UseCaseError,
         traits::author::{CreateAuthorUseCase, DeleteAuthorUseCase, UpdateAuthorUseCase},
@@ -61,11 +64,15 @@ where
             .transaction_manager
             .begin(&user_id, EventSetOperation::CreateAuthor)
             .await?;
-        self.author_repository.create(&mut tx, &author).await?;
+        let event_id = self.author_repository.create(&mut tx, &author).await?;
         let event_set_id = tx.event_set_id().hyphenated().to_string();
         self.transaction_manager.commit(tx).await?;
 
-        Ok(MutationResultDto::new(author.into(), event_set_id))
+        Ok(EntityMutationResultDto::new(
+            author.into(),
+            event_set_id,
+            event_id,
+        ))
     }
 }
 
@@ -126,11 +133,15 @@ where
             OffsetDateTime::now_utc(),
         );
 
-        self.author_repository.update(&mut tx, &author).await?;
+        let event_id = self.author_repository.update(&mut tx, &author).await?;
         let event_set_id = tx.event_set_id().hyphenated().to_string();
         self.transaction_manager.commit(tx).await?;
 
-        Ok(MutationResultDto::new(author.into(), event_set_id))
+        Ok(EntityMutationResultDto::new(
+            author.into(),
+            event_set_id,
+            event_id,
+        ))
     }
 }
 
@@ -215,7 +226,7 @@ mod tests {
         author_repository
             .expect_create()
             .with(always(), always())
-            .returning(|_, _| Ok(()));
+            .returning(|_, _| Ok(303));
 
         let interactor = CreateAuthorInteractor::new(author_repository, make_transaction_manager());
         let mut author_data = CreateAuthorDto::new("Test Author".to_string());
@@ -234,6 +245,27 @@ mod tests {
         assert_eq!(dto.created_at, dto.updated_at);
         assert!(dto.created_at >= before);
         assert!(dto.created_at <= after);
+        assert_eq!(dto.event_id, 303);
+    }
+
+    #[tokio::test]
+    async fn create_author_repository_failure_returns_no_result() {
+        let mut author_repository = MockAuthorRepository::new();
+        author_repository
+            .expect_create()
+            .returning(|_, _| Err(DomainError::Unexpected("event insert failed".to_string())));
+
+        let interactor = CreateAuthorInteractor::new(author_repository, {
+            let mut tm = MockTransactionManager::new();
+            tm.expect_begin().returning(|_, _| Ok(()));
+            tm.expect_commit().times(0);
+            tm
+        });
+        let author_data = CreateAuthorDto::new("Test Author".to_string());
+
+        let result = interactor.create("user1", author_data).await;
+
+        assert!(matches!(result, Err(UseCaseError::Unexpected(_))));
     }
 
     #[tokio::test]
@@ -303,7 +335,7 @@ mod tests {
         author_repository
             .expect_update()
             .with(always(), always())
-            .returning(|_, _| Ok(()));
+            .returning(|_, _| Ok(404));
 
         let interactor = UpdateAuthorInteractor::new(author_repository, make_transaction_manager());
         let author_data = UpdateAuthorDto::new(author_id_str.to_string(), "New Name".to_string());
@@ -322,6 +354,34 @@ mod tests {
         assert!(updated.updated_at >= previous_updated_at);
         assert!(updated.updated_at >= before);
         assert!(updated.updated_at <= after);
+        assert_eq!(updated.event_id, 404);
+    }
+
+    #[tokio::test]
+    async fn update_author_commit_failure_returns_no_result() {
+        let author_id_str = "006099b4-6c42-4ec4-8645-f6bd5b63eddc";
+        let author = Author::new(
+            AuthorId::try_from(author_id_str).unwrap(),
+            AuthorName::new("Old Name".to_string()).unwrap(),
+            OffsetDateTime::UNIX_EPOCH,
+        )
+        .unwrap();
+        let mut author_repository = MockAuthorRepository::new();
+        author_repository
+            .expect_find_by_id_with_tx()
+            .return_once(move |_, _, _| Ok(Some(author)));
+        author_repository.expect_update().returning(|_, _| Ok(404));
+
+        let mut tm = MockTransactionManager::new();
+        tm.expect_begin().returning(|_, _| Ok(()));
+        tm.expect_commit()
+            .returning(|_| Err(DomainError::Unexpected("commit failed".to_string())));
+        let interactor = UpdateAuthorInteractor::new(author_repository, tm);
+        let author_data = UpdateAuthorDto::new(author_id_str.to_string(), "New Name".to_string());
+
+        let result = interactor.update("user1", author_data).await;
+
+        assert!(matches!(result, Err(UseCaseError::Unexpected(_))));
     }
 
     #[tokio::test]
@@ -342,7 +402,7 @@ mod tests {
         author_repository
             .expect_update()
             .withf(|_, author| author.yomi() == "")
-            .returning(|_, _| Ok(()));
+            .returning(|_, _| Ok(405));
 
         let interactor = UpdateAuthorInteractor::new(author_repository, make_transaction_manager());
         let mut author_data =

--- a/src/use_case/interactor/author.rs
+++ b/src/use_case/interactor/author.rs
@@ -269,6 +269,23 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn create_author_commit_failure_returns_no_result() {
+        let mut author_repository = MockAuthorRepository::new();
+        author_repository.expect_create().returning(|_, _| Ok(303));
+
+        let mut tm = MockTransactionManager::new();
+        tm.expect_begin().returning(|_, _| Ok(()));
+        tm.expect_commit()
+            .returning(|_| Err(DomainError::Unexpected("commit failed".to_string())));
+        let interactor = CreateAuthorInteractor::new(author_repository, tm);
+        let author_data = CreateAuthorDto::new("Test Author".to_string());
+
+        let result = interactor.create("user1", author_data).await;
+
+        assert!(matches!(result, Err(UseCaseError::Unexpected(_))));
+    }
+
+    #[tokio::test]
     async fn create_author_fails_with_empty_name() {
         // Given
         let author_repository = MockAuthorRepository::new();
@@ -376,6 +393,34 @@ mod tests {
         tm.expect_begin().returning(|_, _| Ok(()));
         tm.expect_commit()
             .returning(|_| Err(DomainError::Unexpected("commit failed".to_string())));
+        let interactor = UpdateAuthorInteractor::new(author_repository, tm);
+        let author_data = UpdateAuthorDto::new(author_id_str.to_string(), "New Name".to_string());
+
+        let result = interactor.update("user1", author_data).await;
+
+        assert!(matches!(result, Err(UseCaseError::Unexpected(_))));
+    }
+
+    #[tokio::test]
+    async fn update_author_repository_failure_returns_no_result() {
+        let author_id_str = "006099b4-6c42-4ec4-8645-f6bd5b63eddc";
+        let author = Author::new(
+            AuthorId::try_from(author_id_str).unwrap(),
+            AuthorName::new("Old Name".to_string()).unwrap(),
+            OffsetDateTime::UNIX_EPOCH,
+        )
+        .unwrap();
+        let mut author_repository = MockAuthorRepository::new();
+        author_repository
+            .expect_find_by_id_with_tx()
+            .return_once(move |_, _, _| Ok(Some(author)));
+        author_repository
+            .expect_update()
+            .returning(|_, _| Err(DomainError::Unexpected("event insert failed".to_string())));
+
+        let mut tm = MockTransactionManager::new();
+        tm.expect_begin().returning(|_, _| Ok(()));
+        tm.expect_commit().times(0);
         let interactor = UpdateAuthorInteractor::new(author_repository, tm);
         let author_data = UpdateAuthorDto::new(author_id_str.to_string(), "New Name".to_string());
 

--- a/src/use_case/interactor/author.rs
+++ b/src/use_case/interactor/author.rs
@@ -18,8 +18,8 @@ use crate::{
         dto::{
             author::{CreateAuthorDto, UpdateAuthorDto},
             mutation::{
-                AuthorMutationResultDto, DeleteAuthorResultDto, EntityMutationResultDto,
-                MutationResultDto,
+                AuthorMutationResultDto, DeleteAuthorResultDto, MutationResultDto,
+                SingleEventMutationResultDto,
             },
         },
         error::UseCaseError,
@@ -68,7 +68,7 @@ where
         let event_set_id = tx.event_set_id().hyphenated().to_string();
         self.transaction_manager.commit(tx).await?;
 
-        Ok(EntityMutationResultDto::new(
+        Ok(SingleEventMutationResultDto::new(
             author.into(),
             event_set_id,
             event_id,
@@ -137,7 +137,7 @@ where
         let event_set_id = tx.event_set_id().hyphenated().to_string();
         self.transaction_manager.commit(tx).await?;
 
-        Ok(EntityMutationResultDto::new(
+        Ok(SingleEventMutationResultDto::new(
             author.into(),
             event_set_id,
             event_id,

--- a/src/use_case/interactor/author.rs
+++ b/src/use_case/interactor/author.rs
@@ -226,7 +226,7 @@ mod tests {
         author_repository
             .expect_create()
             .with(always(), always())
-            .returning(|_, _| Ok(303));
+            .returning(|_, _| Ok(303.into()));
 
         let interactor = CreateAuthorInteractor::new(author_repository, make_transaction_manager());
         let mut author_data = CreateAuthorDto::new("Test Author".to_string());
@@ -245,7 +245,7 @@ mod tests {
         assert_eq!(dto.created_at, dto.updated_at);
         assert!(dto.created_at >= before);
         assert!(dto.created_at <= after);
-        assert_eq!(dto.event_id, 303);
+        assert_eq!(dto.event_id.value(), 303);
     }
 
     #[tokio::test]
@@ -271,7 +271,9 @@ mod tests {
     #[tokio::test]
     async fn create_author_commit_failure_returns_no_result() {
         let mut author_repository = MockAuthorRepository::new();
-        author_repository.expect_create().returning(|_, _| Ok(303));
+        author_repository
+            .expect_create()
+            .returning(|_, _| Ok(303.into()));
 
         let mut tm = MockTransactionManager::new();
         tm.expect_begin().returning(|_, _| Ok(()));
@@ -352,7 +354,7 @@ mod tests {
         author_repository
             .expect_update()
             .with(always(), always())
-            .returning(|_, _| Ok(404));
+            .returning(|_, _| Ok(404.into()));
 
         let interactor = UpdateAuthorInteractor::new(author_repository, make_transaction_manager());
         let author_data = UpdateAuthorDto::new(author_id_str.to_string(), "New Name".to_string());
@@ -371,7 +373,7 @@ mod tests {
         assert!(updated.updated_at >= previous_updated_at);
         assert!(updated.updated_at >= before);
         assert!(updated.updated_at <= after);
-        assert_eq!(updated.event_id, 404);
+        assert_eq!(updated.event_id.value(), 404);
     }
 
     #[tokio::test]
@@ -387,7 +389,9 @@ mod tests {
         author_repository
             .expect_find_by_id_with_tx()
             .return_once(move |_, _, _| Ok(Some(author)));
-        author_repository.expect_update().returning(|_, _| Ok(404));
+        author_repository
+            .expect_update()
+            .returning(|_, _| Ok(404.into()));
 
         let mut tm = MockTransactionManager::new();
         tm.expect_begin().returning(|_, _| Ok(()));
@@ -447,7 +451,7 @@ mod tests {
         author_repository
             .expect_update()
             .withf(|_, author| author.yomi() == "")
-            .returning(|_, _| Ok(405));
+            .returning(|_, _| Ok(405.into()));
 
         let interactor = UpdateAuthorInteractor::new(author_repository, make_transaction_manager());
         let mut author_data =

--- a/src/use_case/interactor/book.rs
+++ b/src/use_case/interactor/book.rs
@@ -24,7 +24,8 @@ use crate::{
         dto::{
             book::{BookDto, CreateBookDto, ImportBookEntryDto, TimeInfo, UpdateBookDto},
             mutation::{
-                BookMutationResultDto, DeleteBookResultDto, ImportBooksResultDto, MutationResultDto,
+                BookMutationResultDto, DeleteBookResultDto, EntityMutationResultDto,
+                ImportBooksResultDto, MutationResultDto,
             },
         },
         error::UseCaseError,
@@ -87,11 +88,15 @@ where
             .transaction_manager
             .begin(&user_id, EventSetOperation::CreateBook)
             .await?;
-        self.book_repository.create(&mut tx, &book).await?;
+        let event_id = self.book_repository.create(&mut tx, &book).await?;
         let event_set_id = tx.event_set_id().hyphenated().to_string();
         self.transaction_manager.commit(tx).await?;
 
-        Ok(MutationResultDto::new(book.into(), event_set_id))
+        Ok(EntityMutationResultDto::new(
+            book.into(),
+            event_set_id,
+            event_id,
+        ))
     }
 }
 
@@ -176,11 +181,15 @@ where
         };
         book.update(update, OffsetDateTime::now_utc());
 
-        self.book_repository.update(&mut tx, &book).await?;
+        let event_id = self.book_repository.update(&mut tx, &book).await?;
         let event_set_id = tx.event_set_id().hyphenated().to_string();
         self.transaction_manager.commit(tx).await?;
 
-        Ok(MutationResultDto::new(book.into(), event_set_id))
+        Ok(EntityMutationResultDto::new(
+            book.into(),
+            event_set_id,
+            event_id,
+        ))
     }
 }
 
@@ -354,7 +363,7 @@ where
                 input.updated_at,
             )?;
 
-            self.book_repository.create(&mut tx, &book).await?;
+            let _event_id = self.book_repository.create(&mut tx, &book).await?;
             result_books.push(book);
         }
 
@@ -445,7 +454,7 @@ mod tests {
         book_repository
             .expect_create()
             .with(always(), always())
-            .returning(|_, _| Ok(()));
+            .returning(|_, _| Ok(101));
 
         let interactor = CreateBookInteractor::new(book_repository, make_transaction_manager());
         let book_data = CreateBookDto::new(
@@ -468,6 +477,36 @@ mod tests {
         assert_eq!(dto.title, "New Book");
         assert!(dto.owned);
         assert_eq!(dto.created_at, dto.updated_at);
+        assert_eq!(dto.event_id, 101);
+    }
+
+    #[tokio::test]
+    async fn create_book_repository_failure_returns_no_result() {
+        let mut book_repository = MockBookRepository::new();
+        book_repository
+            .expect_create()
+            .returning(|_, _| Err(DomainError::Unexpected("event insert failed".to_string())));
+
+        let interactor = CreateBookInteractor::new(book_repository, {
+            let mut tm = MockTransactionManager::new();
+            tm.expect_begin().returning(|_, _| Ok(()));
+            tm.expect_commit().times(0);
+            tm
+        });
+        let book_data = CreateBookDto::new(
+            "New Book".to_string(),
+            vec![],
+            "".to_string(),
+            false,
+            true,
+            50,
+            BookFormat::Unknown,
+            BookStore::Unknown,
+        );
+
+        let result = interactor.create("user1", book_data).await;
+
+        assert!(matches!(result, Err(UseCaseError::Unexpected(_))));
     }
 
     #[tokio::test]
@@ -508,7 +547,7 @@ mod tests {
         book_repository
             .expect_update()
             .with(always(), always())
-            .returning(|_, _| Ok(()));
+            .returning(|_, _| Ok(202));
 
         let interactor = UpdateBookInteractor::new(book_repository, make_transaction_manager());
         let book_data = UpdateBookDto::new(
@@ -531,6 +570,39 @@ mod tests {
         let dto = result.unwrap();
         assert_eq!(dto.title, "Updated Book");
         assert_eq!(dto.priority, 70);
+        assert_eq!(dto.event_id, 202);
+    }
+
+    #[tokio::test]
+    async fn update_book_commit_failure_returns_no_result() {
+        let book_uuid = Uuid::new_v4();
+        let book = make_book(book_uuid);
+        let mut book_repository = MockBookRepository::new();
+        book_repository
+            .expect_find_by_id_with_tx()
+            .return_once(move |_, _, _| Ok(Some(book)));
+        book_repository.expect_update().returning(|_, _| Ok(202));
+
+        let mut tm = MockTransactionManager::new();
+        tm.expect_begin().returning(|_, _| Ok(()));
+        tm.expect_commit()
+            .returning(|_| Err(DomainError::Unexpected("commit failed".to_string())));
+        let interactor = UpdateBookInteractor::new(book_repository, tm);
+        let book_data = UpdateBookDto::new(
+            book_uuid.hyphenated().to_string(),
+            "Updated Book".to_string(),
+            vec![],
+            "".to_string(),
+            true,
+            false,
+            70,
+            BookFormat::Unknown,
+            BookStore::Unknown,
+        );
+
+        let result = interactor.update("user1", book_data).await;
+
+        assert!(matches!(result, Err(UseCaseError::Unexpected(_))));
     }
 
     #[tokio::test]
@@ -668,7 +740,7 @@ mod tests {
         book_repository
             .expect_create()
             .times(super::MAX_BOOK_BATCH)
-            .returning(|_, _| Ok(()));
+            .returning(|_, _| Ok(1));
 
         let interactor = ImportBooksInteractor::new(
             book_repository,
@@ -725,7 +797,7 @@ mod tests {
         book_repository
             .expect_create()
             .times(2)
-            .returning(|_, _| Ok(()));
+            .returning(|_, _| Ok(1));
 
         let interactor = ImportBooksInteractor::new(
             book_repository,
@@ -772,7 +844,7 @@ mod tests {
             .expect_create()
             .withf(|_, book| book.author_ids().len() == 1)
             .times(1)
-            .returning(|_, _| Ok(()));
+            .returning(|_, _| Ok(1));
 
         let interactor = ImportBooksInteractor::new(
             book_repository,

--- a/src/use_case/interactor/book.rs
+++ b/src/use_case/interactor/book.rs
@@ -510,6 +510,32 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn create_book_commit_failure_returns_no_result() {
+        let mut book_repository = MockBookRepository::new();
+        book_repository.expect_create().returning(|_, _| Ok(101));
+
+        let mut tm = MockTransactionManager::new();
+        tm.expect_begin().returning(|_, _| Ok(()));
+        tm.expect_commit()
+            .returning(|_| Err(DomainError::Unexpected("commit failed".to_string())));
+        let interactor = CreateBookInteractor::new(book_repository, tm);
+        let book_data = CreateBookDto::new(
+            "New Book".to_string(),
+            vec![],
+            "".to_string(),
+            false,
+            true,
+            50,
+            BookFormat::Unknown,
+            BookStore::Unknown,
+        );
+
+        let result = interactor.create("user1", book_data).await;
+
+        assert!(matches!(result, Err(UseCaseError::Unexpected(_))));
+    }
+
+    #[tokio::test]
     async fn create_book_fails_with_empty_title() {
         // Given
         let book_repository = MockBookRepository::new();
@@ -587,6 +613,39 @@ mod tests {
         tm.expect_begin().returning(|_, _| Ok(()));
         tm.expect_commit()
             .returning(|_| Err(DomainError::Unexpected("commit failed".to_string())));
+        let interactor = UpdateBookInteractor::new(book_repository, tm);
+        let book_data = UpdateBookDto::new(
+            book_uuid.hyphenated().to_string(),
+            "Updated Book".to_string(),
+            vec![],
+            "".to_string(),
+            true,
+            false,
+            70,
+            BookFormat::Unknown,
+            BookStore::Unknown,
+        );
+
+        let result = interactor.update("user1", book_data).await;
+
+        assert!(matches!(result, Err(UseCaseError::Unexpected(_))));
+    }
+
+    #[tokio::test]
+    async fn update_book_repository_failure_returns_no_result() {
+        let book_uuid = Uuid::new_v4();
+        let book = make_book(book_uuid);
+        let mut book_repository = MockBookRepository::new();
+        book_repository
+            .expect_find_by_id_with_tx()
+            .return_once(move |_, _, _| Ok(Some(book)));
+        book_repository
+            .expect_update()
+            .returning(|_, _| Err(DomainError::Unexpected("event insert failed".to_string())));
+
+        let mut tm = MockTransactionManager::new();
+        tm.expect_begin().returning(|_, _| Ok(()));
+        tm.expect_commit().times(0);
         let interactor = UpdateBookInteractor::new(book_repository, tm);
         let book_data = UpdateBookDto::new(
             book_uuid.hyphenated().to_string(),

--- a/src/use_case/interactor/book.rs
+++ b/src/use_case/interactor/book.rs
@@ -454,7 +454,7 @@ mod tests {
         book_repository
             .expect_create()
             .with(always(), always())
-            .returning(|_, _| Ok(101));
+            .returning(|_, _| Ok(101.into()));
 
         let interactor = CreateBookInteractor::new(book_repository, make_transaction_manager());
         let book_data = CreateBookDto::new(
@@ -477,7 +477,7 @@ mod tests {
         assert_eq!(dto.title, "New Book");
         assert!(dto.owned);
         assert_eq!(dto.created_at, dto.updated_at);
-        assert_eq!(dto.event_id, 101);
+        assert_eq!(dto.event_id.value(), 101);
     }
 
     #[tokio::test]
@@ -512,7 +512,9 @@ mod tests {
     #[tokio::test]
     async fn create_book_commit_failure_returns_no_result() {
         let mut book_repository = MockBookRepository::new();
-        book_repository.expect_create().returning(|_, _| Ok(101));
+        book_repository
+            .expect_create()
+            .returning(|_, _| Ok(101.into()));
 
         let mut tm = MockTransactionManager::new();
         tm.expect_begin().returning(|_, _| Ok(()));
@@ -573,7 +575,7 @@ mod tests {
         book_repository
             .expect_update()
             .with(always(), always())
-            .returning(|_, _| Ok(202));
+            .returning(|_, _| Ok(202.into()));
 
         let interactor = UpdateBookInteractor::new(book_repository, make_transaction_manager());
         let book_data = UpdateBookDto::new(
@@ -596,7 +598,7 @@ mod tests {
         let dto = result.unwrap();
         assert_eq!(dto.title, "Updated Book");
         assert_eq!(dto.priority, 70);
-        assert_eq!(dto.event_id, 202);
+        assert_eq!(dto.event_id.value(), 202);
     }
 
     #[tokio::test]
@@ -607,7 +609,9 @@ mod tests {
         book_repository
             .expect_find_by_id_with_tx()
             .return_once(move |_, _, _| Ok(Some(book)));
-        book_repository.expect_update().returning(|_, _| Ok(202));
+        book_repository
+            .expect_update()
+            .returning(|_, _| Ok(202.into()));
 
         let mut tm = MockTransactionManager::new();
         tm.expect_begin().returning(|_, _| Ok(()));
@@ -799,7 +803,7 @@ mod tests {
         book_repository
             .expect_create()
             .times(super::MAX_BOOK_BATCH)
-            .returning(|_, _| Ok(1));
+            .returning(|_, _| Ok(1.into()));
 
         let interactor = ImportBooksInteractor::new(
             book_repository,
@@ -856,7 +860,7 @@ mod tests {
         book_repository
             .expect_create()
             .times(2)
-            .returning(|_, _| Ok(1));
+            .returning(|_, _| Ok(1.into()));
 
         let interactor = ImportBooksInteractor::new(
             book_repository,
@@ -903,7 +907,7 @@ mod tests {
             .expect_create()
             .withf(|_, book| book.author_ids().len() == 1)
             .times(1)
-            .returning(|_, _| Ok(1));
+            .returning(|_, _| Ok(1.into()));
 
         let interactor = ImportBooksInteractor::new(
             book_repository,

--- a/src/use_case/interactor/book.rs
+++ b/src/use_case/interactor/book.rs
@@ -24,8 +24,8 @@ use crate::{
         dto::{
             book::{BookDto, CreateBookDto, ImportBookEntryDto, TimeInfo, UpdateBookDto},
             mutation::{
-                BookMutationResultDto, DeleteBookResultDto, EntityMutationResultDto,
-                ImportBooksResultDto, MutationResultDto,
+                BookMutationResultDto, DeleteBookResultDto, ImportBooksResultDto,
+                MutationResultDto, SingleEventMutationResultDto,
             },
         },
         error::UseCaseError,
@@ -92,7 +92,7 @@ where
         let event_set_id = tx.event_set_id().hyphenated().to_string();
         self.transaction_manager.commit(tx).await?;
 
-        Ok(EntityMutationResultDto::new(
+        Ok(SingleEventMutationResultDto::new(
             book.into(),
             event_set_id,
             event_id,
@@ -185,7 +185,7 @@ where
         let event_set_id = tx.event_set_id().hyphenated().to_string();
         self.transaction_manager.commit(tx).await?;
 
-        Ok(EntityMutationResultDto::new(
+        Ok(SingleEventMutationResultDto::new(
             book.into(),
             event_set_id,
             event_id,

--- a/src/use_case/interactor/mutation.rs
+++ b/src/use_case/interactor/mutation.rs
@@ -365,7 +365,7 @@ mod tests {
                 Ok(EntityMutationResultDto::new(
                     make_book_dto(&book_id),
                     "event-set".to_string(),
-                    101,
+                    101.into(),
                 ))
             });
 
@@ -406,7 +406,7 @@ mod tests {
                 Ok(EntityMutationResultDto::new(
                     make_book_dto(&book_id),
                     "event-set".to_string(),
-                    102,
+                    102.into(),
                 ))
             });
 
@@ -478,7 +478,7 @@ mod tests {
                         updated_at: time::OffsetDateTime::UNIX_EPOCH,
                     },
                     "event-set".to_string(),
-                    103,
+                    103.into(),
                 ))
             });
 
@@ -513,7 +513,7 @@ mod tests {
                         updated_at: time::OffsetDateTime::UNIX_EPOCH,
                     },
                     "event-set".to_string(),
-                    104,
+                    104.into(),
                 ))
             });
 

--- a/src/use_case/interactor/mutation.rs
+++ b/src/use_case/interactor/mutation.rs
@@ -183,7 +183,7 @@ mod tests {
     use mockall::predicate::{always, eq};
 
     use crate::common::types::{BookFormat, BookStore};
-    use crate::use_case::dto::mutation::MutationResultDto;
+    use crate::use_case::dto::mutation::{EntityMutationResultDto, MutationResultDto};
     use crate::use_case::error::UseCaseError;
     use crate::use_case::{
         dto::{
@@ -362,9 +362,10 @@ mod tests {
             .expect_create()
             .with(always(), always())
             .returning(move |_, _| {
-                Ok(MutationResultDto::new(
+                Ok(EntityMutationResultDto::new(
                     make_book_dto(&book_id),
                     "event-set".to_string(),
+                    101,
                 ))
             });
 
@@ -402,9 +403,10 @@ mod tests {
             .expect_update()
             .with(always(), always())
             .returning(move |_, _| {
-                Ok(MutationResultDto::new(
+                Ok(EntityMutationResultDto::new(
                     make_book_dto(&book_id),
                     "event-set".to_string(),
+                    102,
                 ))
             });
 
@@ -467,7 +469,7 @@ mod tests {
             .expect_create()
             .with(always(), always())
             .returning(|_, data| {
-                Ok(MutationResultDto::new(
+                Ok(EntityMutationResultDto::new(
                     AuthorDto {
                         id: "006099b4-6c42-4ec4-8645-f6bd5b63eddc".to_string(),
                         name: data.name.clone(),
@@ -476,6 +478,7 @@ mod tests {
                         updated_at: time::OffsetDateTime::UNIX_EPOCH,
                     },
                     "event-set".to_string(),
+                    103,
                 ))
             });
 
@@ -501,7 +504,7 @@ mod tests {
             .expect_update()
             .with(always(), always())
             .returning(|_, data| {
-                Ok(MutationResultDto::new(
+                Ok(EntityMutationResultDto::new(
                     AuthorDto {
                         id: "006099b4-6c42-4ec4-8645-f6bd5b63eddc".to_string(),
                         name: data.name.clone(),
@@ -510,6 +513,7 @@ mod tests {
                         updated_at: time::OffsetDateTime::UNIX_EPOCH,
                     },
                     "event-set".to_string(),
+                    104,
                 ))
             });
 

--- a/src/use_case/interactor/mutation.rs
+++ b/src/use_case/interactor/mutation.rs
@@ -183,7 +183,7 @@ mod tests {
     use mockall::predicate::{always, eq};
 
     use crate::common::types::{BookFormat, BookStore};
-    use crate::use_case::dto::mutation::{EntityMutationResultDto, MutationResultDto};
+    use crate::use_case::dto::mutation::{MutationResultDto, SingleEventMutationResultDto};
     use crate::use_case::error::UseCaseError;
     use crate::use_case::{
         dto::{
@@ -362,7 +362,7 @@ mod tests {
             .expect_create()
             .with(always(), always())
             .returning(move |_, _| {
-                Ok(EntityMutationResultDto::new(
+                Ok(SingleEventMutationResultDto::new(
                     make_book_dto(&book_id),
                     "event-set".to_string(),
                     101.into(),
@@ -403,7 +403,7 @@ mod tests {
             .expect_update()
             .with(always(), always())
             .returning(move |_, _| {
-                Ok(EntityMutationResultDto::new(
+                Ok(SingleEventMutationResultDto::new(
                     make_book_dto(&book_id),
                     "event-set".to_string(),
                     102.into(),
@@ -469,7 +469,7 @@ mod tests {
             .expect_create()
             .with(always(), always())
             .returning(|_, data| {
-                Ok(EntityMutationResultDto::new(
+                Ok(SingleEventMutationResultDto::new(
                     AuthorDto {
                         id: "006099b4-6c42-4ec4-8645-f6bd5b63eddc".to_string(),
                         name: data.name.clone(),
@@ -504,7 +504,7 @@ mod tests {
             .expect_update()
             .with(always(), always())
             .returning(|_, data| {
-                Ok(EntityMutationResultDto::new(
+                Ok(SingleEventMutationResultDto::new(
                     AuthorDto {
                         id: "006099b4-6c42-4ec4-8645-f6bd5b63eddc".to_string(),
                         name: data.name.clone(),

--- a/src/use_case/interactor/mutation.rs
+++ b/src/use_case/interactor/mutation.rs
@@ -388,8 +388,9 @@ mod tests {
         let result = interactor.create_book("user1", book_data).await;
 
         // Then
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap().id, expected_dto.id);
+        let result = result.unwrap();
+        assert_eq!(result.id, expected_dto.id);
+        assert_eq!(result.event_id.value(), 101);
     }
 
     #[tokio::test]
@@ -430,8 +431,9 @@ mod tests {
         let result = interactor.update_book("user1", book_data).await;
 
         // Then
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap().id, expected_dto.id);
+        let result = result.unwrap();
+        assert_eq!(result.id, expected_dto.id);
+        assert_eq!(result.event_id.value(), 102);
     }
 
     #[tokio::test]
@@ -492,8 +494,9 @@ mod tests {
         let result = interactor.create_author("user1", author_data).await;
 
         // Then
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap().name, "New Author");
+        let result = result.unwrap();
+        assert_eq!(result.name, "New Author");
+        assert_eq!(result.event_id.value(), 103);
     }
 
     #[tokio::test]
@@ -530,8 +533,9 @@ mod tests {
         let result = interactor.update_author("user1", author_data).await;
 
         // Then
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap().name, "Updated Author");
+        let result = result.unwrap();
+        assert_eq!(result.name, "Updated Author");
+        assert_eq!(result.event_id.value(), 104);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- return the database-generated entity event ID from Book and Author create/update repositories
- propagate the ID through a dedicated `EntityMutationResultDto<T>`
- expose required `eventId: ID!` fields on Book and Author mutation payloads
- verify returned IDs against event history and use them as restore inputs
- document the distinction between operation-level `eventSetId` and snapshot-level `eventId`

## Why

Create and update mutations currently expose only the event set for the logical operation. Clients need the exact recorded entity snapshot ID to inspect history and restore directly without an additional lookup.

Delete, restore, import, and registration payload semantics remain unchanged because those operations do not guarantee exactly one newly recorded entity event.

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo test --locked` (154 passed)
- `cargo test --locked -p bookshelf-e2e --test graphql_history --test graphql_restore -- --test-threads=1` (12 passed)
- generated schema freshness comparison


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 書籍・著者の作成および更新結果に、対象イベントを特定する `eventId` を追加しました。
  * `eventSetId` と併せて、記録された履歴イベントを確認できます。
  * 返却された `eventId` を復元操作の指定に利用できるようになりました。
  * 削除・復元・一括インポート・ユーザー登録の結果形式は変更ありません。

* **テスト**
  * 作成・更新、履歴照会、復元に関する検証を強化しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->