### PR TITLE
Add books field to GraphQL authors

### DIFF
--- a/e2e/tests/graphql_authors.rs
+++ b/e2e/tests/graphql_authors.rs
@@ -54,6 +54,71 @@ async fn e2e_graphql_authors() -> Result<()> {
 
 #[tokio::test]
 #[serial]
+async fn e2e_graphql_authors_resolve_shared_and_empty_books() -> Result<()> {
+    let (_user_id, token) = create_test_user().await?;
+    let author1_id = create_test_author("Author With Shared Book 1", &token).await?;
+    let author2_id = create_test_author("Author With Shared Book 2", &token).await?;
+    let empty_author_id = create_test_author("Author Without Books", &token).await?;
+    let book_title = format!("Shared Book {}", uuid::Uuid::new_v4());
+    let create_book = format!(
+        r#"
+        mutation {{
+            createBook(bookData: {{
+                title: "{}"
+                authorIds: ["{}", "{}"]
+                isbn: ""
+                read: false
+                owned: false
+                priority: 50
+                format: E_BOOK
+                store: KINDLE
+            }}) {{ book {{ id }} }}
+        }}
+        "#,
+        book_title, author1_id, author2_id
+    );
+    let (_, response) = graphql_request(&create_book, Some(&token)).await?;
+    assert_no_graphql_errors(&response, "create shared book");
+    let book_id = response["data"]["createBook"]["book"]["id"]
+        .as_str()
+        .context("created book id should be a string")?
+        .to_owned();
+
+    let query = r#"{ authors { id books { id title } } }"#;
+    let (_, response) = graphql_request(query, Some(&token)).await?;
+    assert_no_graphql_errors(&response, "resolve author books");
+    let authors = response["data"]["authors"]
+        .as_array()
+        .context("authors should be an array")?;
+    let books_for = |author_id: &str| -> Result<&Vec<serde_json::Value>> {
+        authors
+            .iter()
+            .find(|author| author["id"].as_str() == Some(author_id))
+            .with_context(|| format!("author {author_id} should be returned"))?["books"]
+            .as_array()
+            .context("books should be an array")
+    };
+
+    for author_id in [&author1_id, &author2_id] {
+        let books = books_for(author_id)?;
+        assert_eq!(books.len(), 1);
+        assert_eq!(books[0]["id"].as_str(), Some(book_id.as_str()));
+        assert_eq!(books[0]["title"].as_str(), Some(book_title.as_str()));
+    }
+    assert!(
+        books_for(&empty_author_id)?.is_empty(),
+        "an author without books should return an empty list"
+    );
+
+    delete_test_book(&book_id, &token).await?;
+    for author_id in [&author1_id, &author2_id, &empty_author_id] {
+        delete_test_author(author_id, &token).await?;
+    }
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
 async fn e2e_graphql_create_author() -> Result<()> {
     let (_user_id, token) = create_test_user().await?;
 

--- a/openspec/changes/add-author-books-field/.openspec.yaml
+++ b/openspec/changes/add-author-books-field/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-16

--- a/openspec/changes/add-author-books-field/design.md
+++ b/openspec/changes/add-author-books-field/design.md
@@ -1,0 +1,34 @@
+## Context
+
+The GraphQL `Book` type already resolves its authors with a request-scoped `AuthorLoader`, but the inverse relationship is not exposed. Resolving books independently for each author would create N+1 database queries. The existing repository and query-use-case layers use concrete generic types and tenant-scoped identifiers.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Expose each author's books through the existing GraphQL `Book` type.
+- Fetch relationships for all authors in one DataLoader batch and one database query.
+- Preserve user isolation through every layer.
+- Return a non-null empty list for authors without books.
+
+**Non-Goals:**
+
+- Defining book ordering or pagination.
+- Introducing query complexity limits.
+- Converting DataLoaders or query use cases to trait objects.
+- Refactoring the existing generic architecture.
+
+## Decisions
+
+- Add a `BookRepository` batch method returning `HashMap<AuthorId, Vec<Book>>`. This follows the existing author batch API and keeps SQL concerns out of GraphQL. Per-author repository calls were rejected because they preserve N+1 behavior below the loader.
+- Query `book_author` and `book` once for all requested author IDs, scoped by `user_id`, and group rows in memory. A book linked to multiple requested authors appears under every applicable key.
+- Add a matching `QueryUseCase` method that parses string IDs and converts domain books to DTOs, preserving the current layer boundaries and generic dispatch.
+- Register a request-scoped `BooksByAuthorLoader<QUC>` alongside `AuthorLoader<QUC>`. The loader value is `Vec<Book>`, so the resolver naturally exposes `[Book!]!` and maps missing keys to an empty list.
+- Mark `Author` as a GraphQL complex object and resolve `books` through the loader. The existing `Book` object is reused unchanged.
+
+## Risks / Trade-offs
+
+- [Unspecified ordering can vary with query plans] → Tests compare membership rather than impose an order, and no `ORDER BY` contract is introduced.
+- [Large author selections can produce a large batch result] → This change intentionally omits pagination; DataLoader still bounds database round trips to one query per batch.
+- [Omitting zero-result keys could surface loader misses] → The resolver treats a missing loader value as an empty vector, while the precise internal key-population strategy remains an implementation detail.
+- [Tenant data leakage through joins] → The batch query explicitly filters books by the authenticated `user_id`, and repository tests cover cross-user exclusion.

--- a/openspec/changes/add-author-books-field/design.md
+++ b/openspec/changes/add-author-books-field/design.md
@@ -6,7 +6,7 @@ The GraphQL `Book` type already resolves its authors with a request-scoped `Auth
 
 **Goals:**
 
-- Expose each author's books through the existing GraphQL `Book` type.
+- Add `books` to the existing GraphQL `Author` type and return entries using the existing GraphQL `Book` type.
 - Fetch relationships for all authors in one DataLoader batch and one database query.
 - Preserve user isolation through every layer.
 - Return a non-null empty list for authors without books.

--- a/openspec/changes/add-author-books-field/proposal.md
+++ b/openspec/changes/add-author-books-field/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+GraphQL clients cannot currently traverse from an author to that author's books. Adding this relationship allows clients to fetch author-centric views while batching database access to avoid N+1 queries.
+
+## What Changes
+
+- Add a non-null `books: [Book!]!` field to the GraphQL `Author` type.
+- Return an empty list when an author has no books.
+- Batch book lookup for multiple authors through the repository, query use case, and a request-scoped DataLoader.
+- Reuse the existing GraphQL `Book` type without pagination or a specified ordering.
+
+## Capabilities
+
+### New Capabilities
+
+- `author-books`: Covers querying books through GraphQL authors, empty relationships, tenant isolation, and batched resolution.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+This affects the book repository interface and PostgreSQL implementation, query use-case interface and interactor, GraphQL loaders and objects, request context registration, and their unit and end-to-end tests. It does not change mutation behavior, pagination, ordering guarantees, or the existing generic use-case architecture.

--- a/openspec/changes/add-author-books-field/specs/author-books/spec.md
+++ b/openspec/changes/add-author-books-field/specs/author-books/spec.md
@@ -1,0 +1,30 @@
+## ADDED Requirements
+
+### Requirement: Authors expose their books
+The system SHALL expose a non-null `books: [Book!]!` field on the GraphQL `Author` type using the existing GraphQL `Book` representation.
+
+#### Scenario: Query books for an author
+- **WHEN** an authenticated client selects `books` for an author with related books
+- **THEN** the system returns every book related to that author
+
+#### Scenario: Query an author without books
+- **WHEN** an authenticated client selects `books` for an author with no related books
+- **THEN** the system returns an empty list
+
+#### Scenario: Book has multiple authors
+- **WHEN** one book is related to multiple selected authors
+- **THEN** the system includes that book in each related author's `books` result
+
+### Requirement: Author book resolution is tenant scoped
+The system MUST return only books owned by the authenticated user when resolving an author's books.
+
+#### Scenario: Another user has a related book
+- **WHEN** a relationship exists for a book owned by a different user
+- **THEN** that book is absent from the authenticated user's author result
+
+### Requirement: Multiple authors use batched book lookup
+The system SHALL resolve books for multiple authors through one query-use-case batch and one repository database query per DataLoader batch.
+
+#### Scenario: Query books for multiple authors
+- **WHEN** an authenticated client selects `books` for multiple authors in one GraphQL operation
+- **THEN** the system passes all selected author IDs to the batched lookup once

--- a/openspec/changes/add-author-books-field/tasks.md
+++ b/openspec/changes/add-author-books-field/tasks.md
@@ -14,6 +14,7 @@
 - [x] 3.1 Add and test `BooksByAuthorLoader` with one batched use-case call
 - [x] 3.2 Add the `Author.books` complex resolver and register its request-scoped DataLoader
 - [x] 3.3 Add GraphQL tests for populated, empty, shared, and batched author book results
+- [x] 3.4 Add an authenticated HTTP E2E test for shared and empty author book results
 
 ## 4. Verification
 

--- a/openspec/changes/add-author-books-field/tasks.md
+++ b/openspec/changes/add-author-books-field/tasks.md
@@ -1,0 +1,20 @@
+## 1. Repository Batch Lookup
+
+- [x] 1.1 Add the tenant-scoped batch-by-author method to `BookRepository`
+- [x] 1.2 Implement one-query grouping in `PgBookRepository`
+- [x] 1.3 Add repository tests for grouping, shared books, empty authors, and tenant isolation
+
+## 2. Query Use Case
+
+- [x] 2.1 Add and implement the batch book lookup on `QueryUseCase` and `QueryInteractor`
+- [x] 2.2 Add use-case tests for batched IDs and DTO map conversion
+
+## 3. GraphQL Resolution
+
+- [x] 3.1 Add and test `BooksByAuthorLoader` with one batched use-case call
+- [x] 3.2 Add the `Author.books` complex resolver and register its request-scoped DataLoader
+- [x] 3.3 Add GraphQL tests for populated, empty, shared, and batched author book results
+
+## 4. Verification
+
+- [x] 4.1 Run formatting, Clippy, and the complete locked test suite

--- a/schema.graphql
+++ b/schema.graphql
@@ -4,6 +4,7 @@ type Author {
 	yomi: String!
 	createdAt: DateTime!
 	updatedAt: DateTime!
+	books: [Book!]!
 }
 
 type AuthorEventEntry {

--- a/src/domain/repository/book_repository.rs
+++ b/src/domain/repository/book_repository.rs
@@ -1,8 +1,11 @@
+use std::collections::HashMap;
+
 use async_trait::async_trait;
 use mockall::automock;
 
 use crate::domain::{
     entity::{
+        author::AuthorId,
         book::{Book, BookId},
         event::EventId,
         user::UserId,
@@ -29,6 +32,11 @@ pub trait BookRepository: Send + Sync + 'static {
         book_id: &BookId,
     ) -> Result<Option<Book>, DomainError>;
     async fn find_all(&self, user_id: &UserId) -> Result<Vec<Book>, DomainError>;
+    async fn find_by_author_ids_as_hash_map(
+        &self,
+        user_id: &UserId,
+        author_ids: &[AuthorId],
+    ) -> Result<HashMap<AuthorId, Vec<Book>>, DomainError>;
     async fn update(&self, tx: &mut Self::Transaction, book: &Book)
     -> Result<EventId, DomainError>;
     async fn delete(&self, tx: &mut Self::Transaction, book_id: &BookId)

--- a/src/infrastructure/book_repository.rs
+++ b/src/infrastructure/book_repository.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use async_trait::async_trait;
 use futures_util::{StreamExt, TryStreamExt};
 use serde_json::json;
@@ -33,6 +35,13 @@ struct BookRow {
     store: String,
     created_at: OffsetDateTime,
     updated_at: OffsetDateTime,
+}
+
+#[derive(sqlx::FromRow)]
+struct AuthorBookRow {
+    author_id: Uuid,
+    #[sqlx(flatten)]
+    book: BookRow,
 }
 
 fn book_from_row(row: BookRow) -> Result<Book, DomainError> {
@@ -270,6 +279,66 @@ impl BookRepository for PgBookRepository {
         .await;
 
         books
+    }
+
+    async fn find_by_author_ids_as_hash_map(
+        &self,
+        user_id: &UserId,
+        author_ids: &[AuthorId],
+    ) -> Result<HashMap<AuthorId, Vec<Book>>, DomainError> {
+        let mut books_by_author: HashMap<AuthorId, Vec<Book>> = author_ids
+            .iter()
+            .cloned()
+            .map(|author_id| (author_id, Vec::new()))
+            .collect();
+        let author_uuids: Vec<Uuid> = author_ids.iter().map(AuthorId::to_uuid).collect();
+
+        let rows: Vec<AuthorBookRow> = sqlx::query_as(
+            "WITH authors_of_book_and_user AS (
+                SELECT
+                    user_id,
+                    book_id,
+                    array_agg(author_id) AS author_ids
+                FROM book_author
+                WHERE user_id = $1
+                GROUP BY user_id, book_id
+            )
+            SELECT
+                requested.author_id,
+                book.id,
+                book.title,
+                authors.author_ids,
+                book.isbn,
+                book.read,
+                book.owned,
+                book.priority,
+                book.format,
+                book.store,
+                book.created_at,
+                book.updated_at
+            FROM book_author AS requested
+            INNER JOIN book
+                ON book.user_id = requested.user_id
+                AND book.id = requested.book_id
+            LEFT OUTER JOIN authors_of_book_and_user AS authors
+                ON authors.user_id = book.user_id
+                AND authors.book_id = book.id
+            WHERE requested.user_id = $1
+                AND requested.author_id = ANY($2)",
+        )
+        .bind(user_id.as_str())
+        .bind(author_uuids)
+        .fetch_all(&self.pool)
+        .await?;
+
+        for row in rows {
+            books_by_author
+                .entry(AuthorId::new(row.author_id))
+                .or_default()
+                .push(book_from_row(row.book)?);
+        }
+
+        Ok(books_by_author)
     }
 
     async fn update(
@@ -760,6 +829,54 @@ mod tests {
             assert_eq!(all_books[0], book2);
             assert_eq!(all_books[1], book1);
         }
+
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn find_by_author_ids_groups_books_and_preserves_scope(
+        pool: PgPool,
+    ) -> anyhow::Result<()> {
+        let user_repository = PgUserRepository::new(pool.clone());
+        let author_repository = PgAuthorRepository::new(pool.clone());
+        let book_repository = PgBookRepository::new(pool.clone());
+        let user1_id = prepare_user(&user_repository, "user1").await?;
+        let user2_id = prepare_user(&user_repository, "user2").await?;
+        let user1_author_ids = prepare_authors1(&pool, &user1_id, &author_repository).await?;
+        let empty_author_id =
+            prepare_authors2(&pool, &user1_id, &author_repository).await?[0].clone();
+
+        let shared_book = book_entity1(&user1_author_ids)?;
+        let second_book = book_entity2(&user1_author_ids[..1])?;
+        create_book(&pool, &book_repository, &user1_id, &shared_book).await?;
+        create_book(&pool, &book_repository, &user1_id, &second_book).await?;
+
+        let user2_author_ids = prepare_authors1(&pool, &user2_id, &author_repository).await?;
+        let other_users_book = book_entity1(&user2_author_ids)?;
+        create_book(&pool, &book_repository, &user2_id, &other_users_book).await?;
+
+        let requested_author_ids = vec![
+            user1_author_ids[0].clone(),
+            user1_author_ids[1].clone(),
+            empty_author_id.clone(),
+        ];
+        let result = book_repository
+            .find_by_author_ids_as_hash_map(&user1_id, &requested_author_ids)
+            .await?;
+
+        assert_eq!(result[&user1_author_ids[0]].len(), 2);
+        assert!(
+            result[&user1_author_ids[0]]
+                .iter()
+                .any(|book| book.id() == shared_book.id())
+        );
+        assert!(
+            result[&user1_author_ids[0]]
+                .iter()
+                .any(|book| book.id() == second_book.id())
+        );
+        assert_eq!(result[&user1_author_ids[1]], vec![shared_book]);
+        assert!(result[&empty_author_id].is_empty());
 
         Ok(())
     }

--- a/src/presentation/graphql/loader.rs
+++ b/src/presentation/graphql/loader.rs
@@ -7,11 +7,50 @@ use crate::{
     use_case::traits::query::QueryUseCase,
 };
 
-use super::object::Author;
+use super::object::{Author, Book};
 
 pub struct AuthorLoader<QUC> {
     claims: Claims,
     query_use_case: QUC,
+}
+
+pub struct BooksByAuthorLoader<QUC> {
+    claims: Claims,
+    query_use_case: QUC,
+}
+
+impl<QUC> BooksByAuthorLoader<QUC> {
+    pub fn new(claims: Claims, query_use_case: QUC) -> Self {
+        Self {
+            claims,
+            query_use_case,
+        }
+    }
+}
+
+impl<QUC> Loader<String> for BooksByAuthorLoader<QUC>
+where
+    QUC: QueryUseCase,
+{
+    type Value = Vec<Book>;
+    type Error = PresentationalError;
+
+    async fn load(&self, keys: &[String]) -> Result<HashMap<String, Self::Value>, Self::Error> {
+        let books_by_author = self
+            .query_use_case
+            .find_books_by_author_ids_as_hash_map(&self.claims.sub, keys)
+            .await?;
+
+        Ok(books_by_author
+            .into_iter()
+            .map(|(author_id, books)| {
+                (
+                    author_id,
+                    books.into_iter().map(Book::from).collect::<Vec<_>>(),
+                )
+            })
+            .collect())
+    }
 }
 
 impl<QUC> AuthorLoader<QUC> {
@@ -41,5 +80,68 @@ where
             .collect();
 
         Ok(authors_map)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use async_graphql::dataloader::Loader;
+    use mockall::predicate;
+    use time::OffsetDateTime;
+
+    use crate::{
+        common::types::{BookFormat, BookStore},
+        presentation::extractor::claims::Claims,
+        use_case::{dto::book::BookDto, traits::query::MockQueryUseCase},
+    };
+
+    use super::BooksByAuthorLoader;
+
+    #[tokio::test]
+    async fn books_by_author_loader_batches_keys_and_maps_books() {
+        let author_id1 = "006099b4-6c42-4ec4-8645-f6bd5b63eddc".to_string();
+        let author_id2 = "93090e87-b7a1-403c-974c-d74d881e83b9".to_string();
+        let expected_keys = vec![author_id1.clone(), author_id2.clone()];
+        let mut query_use_case = MockQueryUseCase::new();
+        query_use_case
+            .expect_find_books_by_author_ids_as_hash_map()
+            .with(predicate::eq("user1"), predicate::eq(expected_keys.clone()))
+            .times(1)
+            .returning(move |_, _| {
+                Ok(HashMap::from([
+                    (
+                        author_id1.clone(),
+                        vec![BookDto {
+                            id: "a1b2c3d4-e5f6-4890-abcd-ef1234567890".to_string(),
+                            title: "Book 1".to_string(),
+                            author_ids: vec![author_id1.clone()],
+                            isbn: String::new(),
+                            read: false,
+                            owned: true,
+                            priority: 50,
+                            format: BookFormat::Unknown,
+                            store: BookStore::Unknown,
+                            created_at: OffsetDateTime::UNIX_EPOCH,
+                            updated_at: OffsetDateTime::UNIX_EPOCH,
+                        }],
+                    ),
+                    (author_id2.clone(), Vec::new()),
+                ]))
+            });
+        let loader = BooksByAuthorLoader::new(
+            Claims {
+                sub: "user1".to_string(),
+                _permissions: None,
+            },
+            query_use_case,
+        );
+
+        let result = loader.load(&expected_keys).await.unwrap();
+
+        assert_eq!(result[&expected_keys[0]].len(), 1);
+        assert_eq!(result[&expected_keys[0]][0].title, "Book 1");
+        assert!(result[&expected_keys[1]].is_empty());
     }
 }

--- a/src/presentation/graphql/object.rs
+++ b/src/presentation/graphql/object.rs
@@ -11,7 +11,7 @@ use crate::use_case::dto::book::{BookDto, CreateBookDto, ImportBookEntryDto, Upd
 use crate::use_case::dto::event::{AuthorEventDto, BookEventDto};
 use crate::use_case::dto::event_set::{EventSetDetailDto, EventSetDto};
 
-use super::loader::AuthorLoader;
+use super::loader::{AuthorLoader, BooksByAuthorLoader};
 
 #[derive(SimpleObject)]
 pub struct User {
@@ -75,7 +75,7 @@ impl From<BookStore> for CommonBookStore {
     }
 }
 
-#[derive(SimpleObject)]
+#[derive(Clone, SimpleObject)]
 #[graphql(complex)]
 pub struct Book {
     pub id: String,
@@ -236,12 +236,24 @@ impl From<UpdateBookInput> for UpdateBookDto {
 }
 
 #[derive(Debug, Clone, SimpleObject)]
+#[graphql(complex)]
 pub struct Author {
     pub id: ID,
     pub name: String,
     pub yomi: String,
     pub created_at: OffsetDateTime,
     pub updated_at: OffsetDateTime,
+}
+
+#[ComplexObject]
+impl Author {
+    async fn books(&self, ctx: &Context<'_>) -> Result<Vec<Book>> {
+        let loader = ctx.data_unchecked::<DataLoader<BooksByAuthorLoader<QI>>>();
+        Ok(loader
+            .load_one(self.id.to_string())
+            .await?
+            .unwrap_or_default())
+    }
 }
 
 impl Author {

--- a/src/presentation/graphql/schema.rs
+++ b/src/presentation/graphql/schema.rs
@@ -135,4 +135,107 @@ mod tests {
         assert!(sdl.contains("type DeleteBookPayload {\n\tbookId: ID!\n\teventSetId: ID!\n}"));
         assert!(sdl.contains("type DeleteAuthorPayload {\n\tauthorId: ID!\n\teventSetId: ID!\n}"));
     }
+
+    #[test]
+    fn author_exposes_non_null_books_field() {
+        let schema = build_schema(
+            Query::new(MockQueryUseCase::new()),
+            Mutation::new(MockMutationUseCase::new()),
+        );
+
+        assert!(schema.sdl().contains("\tbooks: [Book!]!"));
+    }
+
+    #[cfg(feature = "test-with-database")]
+    #[sqlx::test]
+    async fn authors_resolve_populated_shared_and_empty_book_lists(
+        pool: sqlx::PgPool,
+    ) -> anyhow::Result<()> {
+        use async_graphql::dataloader::DataLoader;
+
+        use crate::{
+            dependency_injection::dependency_injection,
+            presentation::graphql::loader::{AuthorLoader, BooksByAuthorLoader},
+        };
+
+        let author1 = "006099b4-6c42-4ec4-8645-f6bd5b63eddc";
+        let author2 = "93090e87-b7a1-403c-974c-d74d881e83b9";
+        let author3 = "278935cf-ed83-4346-9b35-b84bbdb630c0";
+        let book1 = "a1b2c3d4-e5f6-4890-abcd-ef1234567890";
+        let book2 = "c5a81e57-bc91-40ff-8b57-18cfa7cc7ae8";
+        sqlx::query("INSERT INTO bookshelf_user (id) VALUES ('user1')")
+            .execute(&pool)
+            .await?;
+        sqlx::query(
+            "INSERT INTO author (id, user_id, name) VALUES
+             ($1, 'user1', 'Author 1'),
+             ($2, 'user1', 'Author 2'),
+             ($3, 'user1', 'Author 3')",
+        )
+        .bind(uuid::Uuid::parse_str(author1)?)
+        .bind(uuid::Uuid::parse_str(author2)?)
+        .bind(uuid::Uuid::parse_str(author3)?)
+        .execute(&pool)
+        .await?;
+        sqlx::query(
+            "INSERT INTO book
+             (id, user_id, title, isbn, read, owned, priority, format, store)
+             VALUES
+             ($1, 'user1', 'Shared Book', '', false, true, 50, 'Unknown', 'Unknown'),
+             ($2, 'user1', 'Author 1 Book', '', false, true, 50, 'Unknown', 'Unknown')",
+        )
+        .bind(uuid::Uuid::parse_str(book1)?)
+        .bind(uuid::Uuid::parse_str(book2)?)
+        .execute(&pool)
+        .await?;
+        sqlx::query(
+            "INSERT INTO book_author (user_id, book_id, author_id) VALUES
+             ('user1', $1, $2),
+             ('user1', $1, $3),
+             ('user1', $4, $2)",
+        )
+        .bind(uuid::Uuid::parse_str(book1)?)
+        .bind(uuid::Uuid::parse_str(author1)?)
+        .bind(uuid::Uuid::parse_str(author2)?)
+        .bind(uuid::Uuid::parse_str(book2)?)
+        .execute(&pool)
+        .await?;
+
+        let (query_use_case, schema) = dependency_injection(pool);
+        let claims = Claims {
+            sub: "user1".to_string(),
+            _permissions: None,
+        };
+        let response = schema
+            .execute(
+                async_graphql::Request::from("query { authors { id books { id title } } }")
+                    .data(claims.clone())
+                    .data(DataLoader::new(
+                        AuthorLoader::new(claims.clone(), query_use_case.clone()),
+                        tokio::spawn,
+                    ))
+                    .data(DataLoader::new(
+                        BooksByAuthorLoader::new(claims, query_use_case),
+                        tokio::spawn,
+                    )),
+            )
+            .await;
+        assert!(response.errors.is_empty(), "{:?}", response.errors);
+        let json = serde_json::to_value(response)?;
+        let authors = json["data"]["authors"].as_array().unwrap();
+        let books_for = |author_id: &str| {
+            authors
+                .iter()
+                .find(|author| author["id"] == author_id)
+                .unwrap()["books"]
+                .as_array()
+                .unwrap()
+        };
+
+        assert_eq!(books_for(author1).len(), 2);
+        assert_eq!(books_for(author2).len(), 1);
+        assert!(books_for(author3).is_empty());
+
+        Ok(())
+    }
 }

--- a/src/presentation/handler/graphql.rs
+++ b/src/presentation/handler/graphql.rs
@@ -12,7 +12,11 @@ use axum::{
 use crate::{
     presentation::{
         extractor::claims::Claims,
-        graphql::{loader::AuthorLoader, mutation::Mutation, query::Query},
+        graphql::{
+            loader::{AuthorLoader, BooksByAuthorLoader},
+            mutation::Mutation,
+            query::Query,
+        },
     },
     use_case::traits::{mutation::MutationUseCase, query::QueryUseCase},
 };
@@ -29,12 +33,21 @@ where
 {
     let query_use_case: QUC = query_use_case.clone();
     let author_loader = DataLoader::new(
-        AuthorLoader::new(claims.clone(), query_use_case),
+        AuthorLoader::new(claims.clone(), query_use_case.clone()),
+        tokio::spawn,
+    );
+    let books_by_author_loader = DataLoader::new(
+        BooksByAuthorLoader::new(claims.clone(), query_use_case),
         tokio::spawn,
     );
 
     schema
-        .execute(req.into_inner().data(claims).data(author_loader))
+        .execute(
+            req.into_inner()
+                .data(claims)
+                .data(author_loader)
+                .data(books_by_author_loader),
+        )
         .await
         .into()
 }

--- a/src/use_case/interactor/query.rs
+++ b/src/use_case/interactor/query.rs
@@ -385,6 +385,31 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn find_books_by_author_ids_rejects_invalid_id_without_calling_repository() {
+        let user_repository = MockUserRepository::new();
+        let mut book_repository = MockBookRepository::new();
+        let author_repository = MockAuthorRepository::new();
+        book_repository
+            .expect_find_by_author_ids_as_hash_map()
+            .times(0)
+            .returning(|_, _| Ok(HashMap::new()));
+        let query_interactor = QueryInteractor {
+            user_repository,
+            book_repository,
+            author_repository,
+            book_event_repository: MockBookEventRepository::new(),
+            author_event_repository: MockAuthorEventRepository::new(),
+            event_set_repository: MockEventSetRepository::new(),
+        };
+
+        let result = query_interactor
+            .find_books_by_author_ids_as_hash_map("user1", &["invalid-author-id".to_string()])
+            .await;
+
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
     async fn find_author_by_id_passes_correct_user_id_to_repository() {
         // Given
         let user_repository = MockUserRepository::new();

--- a/src/use_case/interactor/query.rs
+++ b/src/use_case/interactor/query.rs
@@ -71,6 +71,32 @@ where
         Ok(books)
     }
 
+    async fn find_books_by_author_ids_as_hash_map(
+        &self,
+        user_id: &str,
+        author_ids: &[String],
+    ) -> Result<HashMap<String, Vec<BookDto>>, UseCaseError> {
+        let user_id = UserId::new(user_id.to_string())?;
+        let author_ids: Vec<AuthorId> = author_ids
+            .iter()
+            .map(|author_id| AuthorId::try_from(author_id.as_str()))
+            .collect::<Result<_, DomainError>>()?;
+        let books_by_author = self
+            .book_repository
+            .find_by_author_ids_as_hash_map(&user_id, &author_ids)
+            .await?;
+
+        Ok(books_by_author
+            .into_iter()
+            .map(|(author_id, books)| {
+                (
+                    author_id.to_string(),
+                    books.into_iter().map(BookDto::from).collect(),
+                )
+            })
+            .collect())
+    }
+
     async fn find_author_by_id(
         &self,
         user_id: &str,
@@ -308,6 +334,54 @@ mod tests {
 
         // Then
         assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn find_books_by_author_ids_batches_ids_and_maps_books() {
+        let user_repository = MockUserRepository::new();
+        let mut book_repository = MockBookRepository::new();
+        let author_repository = MockAuthorRepository::new();
+        let author_id1 = "006099b4-6c42-4ec4-8645-f6bd5b63eddc";
+        let author_id2 = "93090e87-b7a1-403c-974c-d74d881e83b9";
+        let book = make_book("a1b2c3d4-e5f6-4890-abcd-ef1234567890");
+        let expected_book_id = book.id().to_string();
+
+        book_repository
+            .expect_find_by_author_ids_as_hash_map()
+            .withf(move |user_id, author_ids| {
+                user_id.as_str() == "user1"
+                    && author_ids.len() == 2
+                    && author_ids[0].to_string() == author_id1
+                    && author_ids[1].to_string() == author_id2
+            })
+            .times(1)
+            .returning(move |_, author_ids| {
+                Ok(HashMap::from([
+                    (author_ids[0].clone(), vec![book.clone()]),
+                    (author_ids[1].clone(), Vec::new()),
+                ]))
+            });
+
+        let query_interactor = QueryInteractor {
+            user_repository,
+            book_repository,
+            author_repository,
+            book_event_repository: MockBookEventRepository::new(),
+            author_event_repository: MockAuthorEventRepository::new(),
+            event_set_repository: MockEventSetRepository::new(),
+        };
+
+        let result = query_interactor
+            .find_books_by_author_ids_as_hash_map(
+                "user1",
+                &[author_id1.to_string(), author_id2.to_string()],
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result[author_id1].len(), 1);
+        assert_eq!(result[author_id1][0].id, expected_book_id);
+        assert!(result[author_id2].is_empty());
     }
 
     #[tokio::test]

--- a/src/use_case/traits/query.rs
+++ b/src/use_case/traits/query.rs
@@ -24,6 +24,11 @@ pub trait QueryUseCase: Send + Sync + 'static {
         book_id: &str,
     ) -> Result<Option<BookDto>, UseCaseError>;
     async fn find_all_books(&self, user_id: &str) -> Result<Vec<BookDto>, UseCaseError>;
+    async fn find_books_by_author_ids_as_hash_map(
+        &self,
+        user_id: &str,
+        author_ids: &[String],
+    ) -> Result<HashMap<String, Vec<BookDto>>, UseCaseError>;
     async fn find_author_by_id(
         &self,
         user_id: &str,


### PR DESCRIPTION
## Summary

- add a non-null `books: [Book!]!` field to the GraphQL `Author` type
- batch book lookup by author IDs through the repository and query use case
- resolve author books with a request-scoped DataLoader to avoid N+1 queries
- preserve user scoping and return an empty list for authors without books
- add OpenSpec artifacts and repository, use-case, loader, schema, and database-backed GraphQL tests

## Impact

Clients can query books directly from one or more authors using the existing GraphQL `Book` type. The field has no pagination or ordering guarantee in this change.

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo test --locked` (162 tests passed)
- `cargo test --locked --features test-with-database --no-run`

The database-backed tests compile successfully. Runtime execution was not available locally because `DATABASE_URL` is not configured in the environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - GraphQLの`Author`型に、関連する書籍一覧を取得できる`books`フィールドを追加しました。
  - 書籍がない著者には空のリストを返します。
  - 複数著者に関連する書籍も、各著者の一覧に正しく表示されます。
  - 認証ユーザーが所有するデータのみを対象とし、データの分離を維持します。

- **テスト**
  - 複数著者、書籍なし、データ分離などのケースを検証するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->