### PR TITLE
Add GraphQL author merge mutation

### DIFF
--- a/.agent/plans/20260820-add-merge-author.md
+++ b/.agent/plans/20260820-add-merge-author.md
@@ -16,6 +16,8 @@ After this change an authenticated client can call `mergeAuthor(sourceAuthorId:,
   - [x] plan updated
 - [x] Milestone 4: Run formatting, clippy, unit tests, and schema verification; record the unavailable external E2E environment.
   - [x] plan updated
+- [x] Milestone 5: Address PR review feedback by serializing Book snapshot reads, expanding merge-loop tests, and testing mutation delegation.
+  - [x] plan updated
 
 Plan created 2026-08-20 UTC.
 
@@ -27,6 +29,9 @@ Plan created 2026-08-20 UTC.
 - Observation: The first dependency resolution attempted inside the sandbox could not resolve crates.io; retrying with approved network access populated the cache and all subsequent checks ran normally.
   Evidence: the initial check reported `Could not resolve host: index.crates.io`; the approved retry downloaded the locked dependencies and completed.
 
+- Observation: Locking only the two Author rows does not serialize a full Book snapshot against concurrent `updateBook` operations, so either mutation could overwrite fields read before the other committed.
+  Evidence: PR review identified that `find_by_id_with_tx` and the merge lookup both read Book rows without `FOR UPDATE`; both transaction-aware reads now lock the base Book row, and multi-book merge locks are ordered by Book ID.
+
 ## Decision Log
 
 - Decision: Keep merge orchestration in a dedicated use-case interactor and use existing repository mutation methods for book updates and source deletion.
@@ -37,9 +42,13 @@ Plan created 2026-08-20 UTC.
   Rationale: Concurrent inverse merges otherwise acquire row locks in opposite order and can deadlock.
   Date/Author: 2026-08-20 / Codex
 
+- Decision: Require both ordinary Book updates and author merge to acquire a Book row lock while reading the snapshot they will rewrite.
+  Rationale: A lock on only the source Author does not protect mutable Book fields or `book_author` snapshots from lost updates. Sharing the row-lock convention makes either transaction wait and then read the committed state; ordering merge locks by Book ID avoids lock-order inversions across multi-book merges.
+  Date/Author: 2026-08-21 / Codex
+
 ## Outcomes & Retrospective
 
-The `mergeAuthor` mutation is implemented from GraphQL through PostgreSQL persistence. It locks authors deterministically, moves and records every affected book, records typed source and destination author events in one event set, preserves the destination entity state, and rejects invalid restore semantics. The generated schema matches `schema.graphql`; formatting, clippy, and all 165 non-database unit tests pass. The external E2E scenario was added but could not be run locally because no test server or database URL was supplied.
+The `mergeAuthor` mutation is implemented from GraphQL through PostgreSQL persistence. It locks authors and affected books deterministically, moves and records every affected book, records typed source and destination author events in one event set, preserves the destination entity state, and rejects invalid restore semantics. Merge-loop tests cover source replacement, destination deduplication, preservation of other authors, multiple updates, and mutation delegation. The generated schema matches `schema.graphql`; formatting, clippy, and all non-database unit tests pass. The external E2E scenario was added but could not be run locally because no test server or database URL was supplied.
 
 ## Context and Orientation
 
@@ -87,6 +96,8 @@ Validation transcripts will be added as milestones complete.
     Finished `dev` profile ...
 
 Plan updated 2026-08-20 UTC after implementation and validation. The E2E execution limitation is recorded so a future contributor can run the committed scenario in the configured CI environment.
+
+Plan updated 2026-08-21 UTC after PR review. Transaction-aware Book reads now share the row-lock invariant, and the unit suite exercises the previously uncovered merge loop and mutation delegation.
 
 ## Interfaces and Dependencies
 

--- a/.agent/plans/20260820-add-merge-author.md
+++ b/.agent/plans/20260820-add-merge-author.md
@@ -18,6 +18,8 @@ After this change an authenticated client can call `mergeAuthor(sourceAuthorId:,
   - [x] plan updated
 - [x] Milestone 5: Address PR review feedback by serializing Book snapshot reads, expanding merge-loop tests, and testing mutation delegation.
   - [x] plan updated
+- [x] Milestone 6: Align merge lock acquisition with updateBook by locking Book rows before Author rows, preventing a Book/Author deadlock cycle.
+  - [x] plan updated
 
 Plan created 2026-08-20 UTC.
 
@@ -32,6 +34,9 @@ Plan created 2026-08-20 UTC.
 - Observation: Locking only the two Author rows does not serialize a full Book snapshot against concurrent `updateBook` operations, so either mutation could overwrite fields read before the other committed.
   Evidence: PR review identified that `find_by_id_with_tx` and the merge lookup both read Book rows without `FOR UPDATE`; both transaction-aware reads now lock the base Book row, and multi-book merge locks are ordered by Book ID.
 
+- Observation: Adding Book locks after Author locks introduced an Author-to-Book order opposite to `updateBook`, whose Book lock is followed by foreign-key locks on newly associated Authors.
+  Evidence: a merge holding the destination Author and waiting for a Book could cycle with an update holding that Book and waiting for the destination Author. Merge now locks Books first, matching `updateBook`, then locks Authors in UUID order.
+
 ## Decision Log
 
 - Decision: Keep merge orchestration in a dedicated use-case interactor and use existing repository mutation methods for book updates and source deletion.
@@ -44,6 +49,10 @@ Plan created 2026-08-20 UTC.
 
 - Decision: Require both ordinary Book updates and author merge to acquire a Book row lock while reading the snapshot they will rewrite.
   Rationale: A lock on only the source Author does not protect mutable Book fields or `book_author` snapshots from lost updates. Sharing the row-lock convention makes either transaction wait and then read the committed state; ordering merge locks by Book ID avoids lock-order inversions across multi-book merges.
+  Date/Author: 2026-08-21 / Codex
+
+- Decision: Acquire merge locks in Book-ID order first and Author-UUID order second.
+  Rationale: `updateBook` necessarily locks its Book before `book_author` inserts take Author foreign-key locks. Giving merge the same entity-class order removes the Book/Author deadlock cycle while retaining deterministic ordering within each class.
   Date/Author: 2026-08-21 / Codex
 
 ## Outcomes & Retrospective
@@ -98,6 +107,8 @@ Validation transcripts will be added as milestones complete.
 Plan updated 2026-08-20 UTC after implementation and validation. The E2E execution limitation is recorded so a future contributor can run the committed scenario in the configured CI environment.
 
 Plan updated 2026-08-21 UTC after PR review. Transaction-aware Book reads now share the row-lock invariant, and the unit suite exercises the previously uncovered merge loop and mutation delegation.
+
+Plan updated 2026-08-21 UTC after the follow-up concurrency review. Merge now follows the same Book-before-Author lock order as updateBook, and a mock sequence test guards that repository call order.
 
 ## Interfaces and Dependencies
 

--- a/.agent/plans/20260820-add-merge-author.md
+++ b/.agent/plans/20260820-add-merge-author.md
@@ -20,6 +20,8 @@ After this change an authenticated client can call `mergeAuthor(sourceAuthorId:,
   - [x] plan updated
 - [x] Milestone 6: Align merge lock acquisition with updateBook by locking Book rows before Author rows, preventing a Book/Author deadlock cycle.
   - [x] plan updated
+- [x] Milestone 7: Refresh Book associations after lock waits, assert complete merge event payloads, and add PostgreSQL repository coverage.
+  - [x] plan updated
 
 Plan created 2026-08-20 UTC.
 
@@ -37,6 +39,9 @@ Plan created 2026-08-20 UTC.
 - Observation: Adding Book locks after Author locks introduced an Author-to-Book order opposite to `updateBook`, whose Book lock is followed by foreign-key locks on newly associated Authors.
   Evidence: a merge holding the destination Author and waiting for a Book could cycle with an update holding that Book and waiting for the destination Author. Merge now locks Books first, matching `updateBook`, then locks Authors in UUID order.
 
+- Observation: Under PostgreSQL Read Committed, a statement snapshot is established before `SELECT ... FOR UPDATE` finishes waiting, so association aggregation in that same statement can remain stale.
+  Evidence: the merge lookup now uses one statement to lock ordered Book IDs and a second statement with a fresh snapshot to re-check the source relation and load all current Author IDs.
+
 ## Decision Log
 
 - Decision: Keep merge orchestration in a dedicated use-case interactor and use existing repository mutation methods for book updates and source deletion.
@@ -53,6 +58,10 @@ Plan created 2026-08-20 UTC.
 
 - Decision: Acquire merge locks in Book-ID order first and Author-UUID order second.
   Rationale: `updateBook` necessarily locks its Book before `book_author` inserts take Author foreign-key locks. Giving merge the same entity-class order removes the Book/Author deadlock cycle while retaining deterministic ordering within each class.
+  Date/Author: 2026-08-21 / Codex
+
+- Decision: Separate merge Book locking from Book/Author snapshot loading into two SQL statements.
+  Rationale: A fresh Read Committed snapshot after lock acquisition prevents a concurrent update that completed during the wait from having its relationship changes overwritten by stale `book_author` aggregation.
   Date/Author: 2026-08-21 / Codex
 
 ## Outcomes & Retrospective
@@ -109,6 +118,8 @@ Plan updated 2026-08-20 UTC after implementation and validation. The E2E executi
 Plan updated 2026-08-21 UTC after PR review. Transaction-aware Book reads now share the row-lock invariant, and the unit suite exercises the previously uncovered merge loop and mutation delegation.
 
 Plan updated 2026-08-21 UTC after the follow-up concurrency review. Merge now follows the same Book-before-Author lock order as updateBook, and a mock sequence test guards that repository call order.
+
+Plan updated 2026-08-21 UTC after the snapshot review. Book locks and association reads are separate statements, event predicates cover the complete merge history contract, and a PostgreSQL feature test covers result scope, author restoration, and ordering.
 
 ## Interfaces and Dependencies
 

--- a/.agent/plans/20260820-add-merge-author.md
+++ b/.agent/plans/20260820-add-merge-author.md
@@ -42,6 +42,9 @@ Plan created 2026-08-20 UTC.
 - Observation: Under PostgreSQL Read Committed, a statement snapshot is established before `SELECT ... FOR UPDATE` finishes waiting, so association aggregation in that same statement can remain stale.
   Evidence: the merge lookup now uses one statement to lock ordered Book IDs and a second statement with a fresh snapshot to re-check the source relation and load all current Author IDs.
 
+- Observation: Existing Book repository fixtures use fixed Book IDs and intentionally allow the same ID for different users, so comparing a user1 result ID against a user2 fixture did not prove user scoping.
+  Evidence: the first CI run of the new PostgreSQL test failed because both users' `book_entity1` values shared an ID. The test now rebuilds the user2 Book with a unique ID before asserting exclusion.
+
 ## Decision Log
 
 - Decision: Keep merge orchestration in a dedicated use-case interactor and use existing repository mutation methods for book updates and source deletion.
@@ -120,6 +123,8 @@ Plan updated 2026-08-21 UTC after PR review. Transaction-aware Book reads now sh
 Plan updated 2026-08-21 UTC after the follow-up concurrency review. Merge now follows the same Book-before-Author lock order as updateBook, and a mock sequence test guards that repository call order.
 
 Plan updated 2026-08-21 UTC after the snapshot review. Book locks and association reads are separate statements, event predicates cover the complete merge history contract, and a PostgreSQL feature test covers result scope, author restoration, and ordering.
+
+Plan updated 2026-08-21 UTC after CI exposed a fixed-ID fixture collision. The cross-user Book now has a unique ID so the scope assertion tests ownership rather than fixture identity reuse.
 
 ## Interfaces and Dependencies
 

--- a/.agent/plans/20260820-add-merge-author.md
+++ b/.agent/plans/20260820-add-merge-author.md
@@ -1,0 +1,93 @@
+# Add the GraphQL author merge mutation
+
+This ExecPlan is a living document maintained according to `.agent/PLANS.md`. It records the implementation of a GraphQL mutation that moves every book relationship from one author to another, deletes the source author, and records the entire logical operation atomically.
+
+## Purpose / Big Picture
+
+After this change an authenticated client can call `mergeAuthor(sourceAuthorId:, destinationAuthorId:)`. Every book associated with the source will instead reference the destination, the source will disappear, and the unchanged destination plus the merge event-set identifier will be returned. Book updates, source deletion, and destination participation will share one PostgreSQL transaction and one event set, so a failure cannot leave a partial merge.
+
+## Progress
+
+- [x] Milestone 1: Add domain operations, typed event metadata, transaction-aware repository APIs, migration, and repository coverage.
+  - [x] plan updated
+- [x] Milestone 2: Add the merge use case, deterministic author locking, restore guard, composition delegation, and unit tests.
+  - [x] plan updated
+- [x] Milestone 3: Expose `mergeAuthor` through GraphQL and dependency injection, update architecture documentation, and add E2E coverage.
+  - [x] plan updated
+- [x] Milestone 4: Run formatting, clippy, unit tests, and schema verification; record the unavailable external E2E environment.
+  - [x] plan updated
+
+Plan created 2026-08-20 UTC.
+
+## Surprises & Discoveries
+
+- Observation: The local environment does not define `TEST_SERVER_URL` or `DATABASE_URL`, so the server/PostgreSQL-backed E2E suite cannot be executed in this task environment.
+  Evidence: `printenv TEST_SERVER_URL` and `printenv DATABASE_URL` both produced no value. The new E2E scenario remains compiled in `e2e/tests/graphql_authors.rs` for the configured CI environment.
+
+- Observation: The first dependency resolution attempted inside the sandbox could not resolve crates.io; retrying with approved network access populated the cache and all subsequent checks ran normally.
+  Evidence: the initial check reported `Could not resolve host: index.crates.io`; the approved retry downloaded the locked dependencies and completed.
+
+## Decision Log
+
+- Decision: Keep merge orchestration in a dedicated use-case interactor and use existing repository mutation methods for book updates and source deletion.
+  Rationale: This preserves the transaction/event-set invariant while avoiding a merge-specific persistence service or domain method.
+  Date/Author: 2026-08-20 / Codex
+
+- Decision: Lock both authors by ascending UUID while preserving their original source and destination roles after lookup.
+  Rationale: Concurrent inverse merges otherwise acquire row locks in opposite order and can deadlock.
+  Date/Author: 2026-08-20 / Codex
+
+## Outcomes & Retrospective
+
+The `mergeAuthor` mutation is implemented from GraphQL through PostgreSQL persistence. It locks authors deterministically, moves and records every affected book, records typed source and destination author events in one event set, preserves the destination entity state, and rejects invalid restore semantics. The generated schema matches `schema.graphql`; formatting, clippy, and all 165 non-database unit tests pass. The external E2E scenario was added but could not be run locally because no test server or database URL was supplied.
+
+## Context and Orientation
+
+`src/domain/entity/event.rs` defines per-entity and event-set operation enums. Domain repository traits live in `src/domain/repository/`; PostgreSQL adapters in `src/infrastructure/` implement them using `PgTransaction`. Use-case traits and interactors in `src/use_case/` own transaction boundaries. `src/presentation/graphql/` converts GraphQL arguments and payloads, while `src/dependency_injection.rs` composes concrete implementations. The `e2e` crate exercises the running GraphQL API against PostgreSQL.
+
+An event set groups all events produced by one logical user operation. A transaction-aware repository method accepts the same mutable transaction opened by the use case; it must not open another transaction or create another event set. A destination participation event is an event-only write: it records that the destination took part without modifying the author row or timestamp.
+
+## Plan of Work
+
+First extend operation enums and the migration lookup values. Introduce typed source-delete metadata and a write-only `NewAuthorEvent` input, then update PostgreSQL repositories so source-book lookup and destination event append use the caller's transaction. Preserve ordinary deletes by passing no metadata.
+
+Next implement `MergeAuthorInteractor`. Validate IDs before opening the transaction, lock authors in UUID order, map the results back to source and destination, load source books, rebuild each book with only its author IDs changed, update each book, delete the source with typed merge metadata, append the destination participation event, and commit. Reject `merge_as_destination` as an author restore source. Delegate the new operation through `MutationInteractor`.
+
+Finally add `MergeAuthorPayload`, the GraphQL resolver, and concrete dependency injection. Update event-recording and database documentation. Add unit tests for changed logic and GraphQL E2E tests that verify relationships, payload shape, event metadata, event-set membership, and no-book behavior.
+
+## Concrete Steps
+
+Work from `/home/hiterm/ghq/github.com/hiterm/bookshelf-api`. Inspect changes with `git --no-pager diff`. Run focused tests while implementing, then run the mandatory pre-commit commands in order: `cargo fmt --check`, `cargo clippy --all-targets --locked -- -D warnings`, and `cargo test --locked`. Run the E2E test command documented by the existing `e2e` crate when its PostgreSQL environment is available.
+
+## Validation and Acceptance
+
+The generated GraphQL schema must contain `mergeAuthor(sourceAuthorId: ID!, destinationAuthorId: ID!): MergeAuthorPayload!`, and the payload must contain only `author` and `eventSetId`. A successful test scenario must show the source is no longer queryable, every former source book references the destination exactly once, other authors remain attached, and the destination timestamps are unchanged. Event-set detail must contain one update per moved book, one source delete with merge metadata, and one destination `merge_as_destination` event with source metadata. Invalid identical IDs and `merge_as_destination` restore attempts must return validation errors. Any repository or commit failure must avoid committing.
+
+## Idempotence and Recovery
+
+The migration inserts lookup values with `ON CONFLICT DO NOTHING`, so rerunning it is harmless. The merge itself is atomic but not idempotent after success because the source no longer exists; retrying a completed request returns not found without modifying the destination. Before commit, dropping a failed PostgreSQL transaction rolls back all partial writes.
+
+## Artifacts and Notes
+
+Validation transcripts will be added as milestones complete.
+
+    cargo fmt --check
+    # exit 0
+
+    cargo clippy --all-targets --locked -- -D warnings
+    Finished `dev` profile ...
+
+    cargo test --locked
+    test result: ok. 165 passed; 0 failed
+
+    cargo run --quiet --bin gen_schema --locked | diff schema.graphql -
+    # exit 0, no diff
+
+    cargo check --locked -p bookshelf-e2e --tests
+    Finished `dev` profile ...
+
+Plan updated 2026-08-20 UTC after implementation and validation. The E2E execution limitation is recorded so a future contributor can run the committed scenario in the configured CI environment.
+
+## Interfaces and Dependencies
+
+Add `MergeAuthorInputDto`, `MergeAuthorUseCase::merge`, and `MutationUseCase::merge_author`, returning `MutationResultDto<AuthorDto>`. `MergeAuthorInteractor<AR, BR, AER, TM>` requires all three repositories to use `TM::Transaction`. Add `BookRepository::find_by_author_id_with_tx`, typed optional metadata to `AuthorRepository::delete`, and `AuthorEventRepository::append(&mut Transaction, &NewAuthorEvent)`. The destination event uses operation `merge_as_destination`; the event set uses `merge_author`.

--- a/docs/architecture/event-recording.md
+++ b/docs/architecture/event-recording.md
@@ -11,6 +11,10 @@ Every `create`, `update`, `delete`, and `restore` operation on any entity
 records an event inside the same database transaction. This applies to
 existing entities (`Book`, `Author`) and any new entity added in the future.
 
+An event `extra` object always contains a numeric `version`. If it contains a
+`type`, that version describes the schema for that type; otherwise it describes
+the extra schema for the event operation itself.
+
 ## Transaction boundary (use-case layer)
 
 The transaction boundary is owned by the use-case layer via the
@@ -58,6 +62,12 @@ in particular, an import can record multiple Book and Author events under one
   reads `tx.event_set_id()` for event recording, and inserts the per-event
   `<entity>_event` rows. Domain repository traits expose only an associated
   `Transaction` type; they carry no other event knowledge.
+
+Normally the entity repository records an event while changing entity state.
+When an entity participates in a logical operation without changing state, a
+transaction-aware event repository write may record that participation. It
+must receive the transaction opened by the use case, derive `user_id` and
+`event_set_id` from it, and must not open another transaction or event set.
 
 ## Adding a new entity or mutation operation
 

--- a/docs/database.md
+++ b/docs/database.md
@@ -26,6 +26,7 @@ Lookup table for valid `event_set.operation` values.
 | `restore_author`| An author restore was performed                  |
 | `import_books`  | A bulk import of books was performed             |
 | `snapshot_all`  | A point-in-time snapshot of all entities (system)|
+| `merge_author`  | One author was merged into another               |
 
 ### `event_set`
 
@@ -53,6 +54,7 @@ Lookup table for valid per-event `operation` values.
 | `delete`   | Entity was deleted; only id stored, data fields are NULL     |
 | `restore`  | Entity state was restored; data fields populated, `extra` set|
 | `snapshot` | Point-in-time capture; all data fields populated             |
+| `merge_as_destination` | Unchanged author participated as merge destination |
 
 ### `book_event`
 
@@ -126,7 +128,11 @@ evolution without breaking existing consumers.
 
 ### All other operations
 
-`extra` is `NULL` for `create`, `update`, `delete`, and `snapshot` events.
+`extra` is normally `NULL` for `create`, `update`, `delete`, and `snapshot`
+events. A merge source uses a `delete` event with
+`{"type":"merge","version":1,"destination_author_id":"<uuid>"}`. The
+unchanged destination uses `merge_as_destination` with
+`{"version":1,"source_author_id":"<uuid>"}`; its snapshot columns are NULL.
 
 ## Version History
 

--- a/e2e/tests/graphql_authors.rs
+++ b/e2e/tests/graphql_authors.rs
@@ -119,6 +119,48 @@ async fn e2e_graphql_authors_resolve_shared_and_empty_books() -> Result<()> {
 
 #[tokio::test]
 #[serial]
+async fn e2e_graphql_merge_author_moves_books_and_returns_destination() -> Result<()> {
+    let (_user_id, token) = create_test_user().await?;
+    let source_id = create_test_author("Merge Source", &token).await?;
+    let destination_id = create_test_author("Merge Destination", &token).await?;
+    let book_id = create_test_book("Merged Book", &source_id, &token).await?;
+
+    let mutation = format!(
+        r#"mutation {{ mergeAuthor(sourceAuthorId: "{}", destinationAuthorId: "{}") {{ author {{ id name books {{ id }} }} eventSetId }} }}"#,
+        source_id, destination_id
+    );
+    let (_, response) = graphql_request(&mutation, Some(&token)).await?;
+    assert_no_graphql_errors(&response, "merge author");
+    let payload = &response["data"]["mergeAuthor"];
+    assert_eq!(
+        payload["author"]["id"].as_str(),
+        Some(destination_id.as_str())
+    );
+    assert_eq!(
+        payload["author"]["books"][0]["id"].as_str(),
+        Some(book_id.as_str())
+    );
+    assert!(payload["eventSetId"].as_str().is_some());
+    assert!(payload.get("eventId").is_none());
+
+    let query = format!(
+        r#"{{ source: author(id: "{}") {{ id }} destination: author(id: "{}") {{ id books {{ id }} }} }}"#,
+        source_id, destination_id
+    );
+    let (_, response) = graphql_request(&query, Some(&token)).await?;
+    assert!(response["data"]["source"].is_null());
+    assert_eq!(
+        response["data"]["destination"]["books"][0]["id"].as_str(),
+        Some(book_id.as_str())
+    );
+
+    delete_test_book(&book_id, &token).await?;
+    delete_test_author(&destination_id, &token).await?;
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
 async fn e2e_graphql_create_author() -> Result<()> {
     let (_user_id, token) = create_test_user().await?;
 

--- a/migrations/20260820000000_add_merge_author_operations.sql
+++ b/migrations/20260820000000_add_merge_author_operations.sql
@@ -1,0 +1,7 @@
+INSERT INTO event_operation (operation)
+VALUES ('merge_as_destination')
+ON CONFLICT DO NOTHING;
+
+INSERT INTO event_set_operation (operation)
+VALUES ('merge_author')
+ON CONFLICT DO NOTHING;

--- a/schema.graphql
+++ b/schema.graphql
@@ -171,6 +171,11 @@ A scalar that can represent any JSON value.
 """
 scalar JSON
 
+type MergeAuthorPayload {
+	author: Author!
+	eventSetId: ID!
+}
+
 type Mutation {
 	registerUser: User!
 	createBook(bookData: CreateBookInput!): BookMutationPayload!
@@ -179,6 +184,7 @@ type Mutation {
 	createAuthor(authorData: CreateAuthorInput!): AuthorMutationPayload!
 	updateAuthor(authorData: UpdateAuthorInput!): AuthorMutationPayload!
 	deleteAuthor(authorId: ID!): DeleteAuthorPayload!
+	mergeAuthor(sourceAuthorId: ID!, destinationAuthorId: ID!): MergeAuthorPayload!
 	restoreBook(eventId: ID!): RestoreBookPayload!
 	restoreAuthor(eventId: ID!): RestoreAuthorPayload!
 	"""

--- a/src/dependency_injection.rs
+++ b/src/dependency_injection.rs
@@ -10,7 +10,10 @@ use crate::{
     },
     presentation::graphql::{mutation::Mutation, query::Query, schema::build_schema},
     use_case::interactor::{
-        author::{CreateAuthorInteractor, DeleteAuthorInteractor, UpdateAuthorInteractor},
+        author::{
+            CreateAuthorInteractor, DeleteAuthorInteractor, MergeAuthorInteractor,
+            UpdateAuthorInteractor,
+        },
         book::{
             CreateBookInteractor, DeleteBookInteractor, ImportBooksInteractor, UpdateBookInteractor,
         },
@@ -38,6 +41,12 @@ pub type MI = MutationInteractor<
     CreateAuthorInteractor<PgAuthorRepository, PgTransactionManager>,
     UpdateAuthorInteractor<PgAuthorRepository, PgTransactionManager>,
     DeleteAuthorInteractor<PgAuthorRepository, PgTransactionManager>,
+    MergeAuthorInteractor<
+        PgAuthorRepository,
+        PgBookRepository,
+        PgAuthorEventRepository,
+        PgTransactionManager,
+    >,
     RestoreBookInteractor<PgBookRepository, PgBookEventRepository, PgTransactionManager>,
     RestoreAuthorInteractor<PgAuthorRepository, PgAuthorEventRepository, PgTransactionManager>,
     ImportBooksInteractor<PgBookRepository, PgAuthorRepository, PgTransactionManager>,
@@ -75,6 +84,12 @@ pub fn dependency_injection(
         UpdateAuthorInteractor::new(author_repository.clone(), transaction_manager.clone());
     let delete_author_use_case =
         DeleteAuthorInteractor::new(author_repository.clone(), transaction_manager.clone());
+    let merge_author_use_case = MergeAuthorInteractor::new(
+        author_repository.clone(),
+        book_repository.clone(),
+        author_event_repository.clone(),
+        transaction_manager.clone(),
+    );
     let import_books_use_case = ImportBooksInteractor::new(
         book_repository.clone(),
         author_repository.clone(),
@@ -99,6 +114,7 @@ pub fn dependency_injection(
         create_author_use_case,
         update_author_use_case,
         delete_author_use_case,
+        merge_author_use_case,
         restore_book_use_case,
         restore_author_use_case,
         import_books_use_case,

--- a/src/domain/entity/event.rs
+++ b/src/domain/entity/event.rs
@@ -38,6 +38,7 @@ pub enum EventOperation {
     Delete,
     Restore,
     Snapshot,
+    MergeAsDestination,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -52,6 +53,7 @@ pub enum EventSetOperation {
     RestoreAuthor,
     ImportBooks,
     SnapshotAll,
+    MergeAuthor,
 }
 
 impl EventSetOperation {
@@ -67,6 +69,7 @@ impl EventSetOperation {
             EventSetOperation::RestoreAuthor => "restore_author",
             EventSetOperation::ImportBooks => "import_books",
             EventSetOperation::SnapshotAll => "snapshot_all",
+            EventSetOperation::MergeAuthor => "merge_author",
         }
     }
 }
@@ -86,6 +89,7 @@ impl TryFrom<&str> for EventSetOperation {
             "restore_author" => Ok(EventSetOperation::RestoreAuthor),
             "import_books" => Ok(EventSetOperation::ImportBooks),
             "snapshot_all" => Ok(EventSetOperation::SnapshotAll),
+            "merge_author" => Ok(EventSetOperation::MergeAuthor),
             _ => Err(format!("Unknown event set operation: {}", value)),
         }
     }
@@ -99,6 +103,7 @@ impl EventOperation {
             EventOperation::Delete => "delete",
             EventOperation::Restore => "restore",
             EventOperation::Snapshot => "snapshot",
+            EventOperation::MergeAsDestination => "merge_as_destination",
         }
     }
 }
@@ -113,6 +118,7 @@ impl TryFrom<&str> for EventOperation {
             "delete" => Ok(EventOperation::Delete),
             "restore" => Ok(EventOperation::Restore),
             "snapshot" => Ok(EventOperation::Snapshot),
+            "merge_as_destination" => Ok(EventOperation::MergeAsDestination),
             _ => Err(format!("Unknown event operation: {}", value)),
         }
     }
@@ -138,6 +144,7 @@ mod tests {
             EventOperation::Delete,
             EventOperation::Restore,
             EventOperation::Snapshot,
+            EventOperation::MergeAsDestination,
         ];
         for variant in &variants {
             let s = variant.as_str();
@@ -163,6 +170,7 @@ mod tests {
         assert_eq!(EventSetOperation::RestoreAuthor.as_str(), "restore_author");
         assert_eq!(EventSetOperation::ImportBooks.as_str(), "import_books");
         assert_eq!(EventSetOperation::SnapshotAll.as_str(), "snapshot_all");
+        assert_eq!(EventSetOperation::MergeAuthor.as_str(), "merge_author");
     }
 
     #[test]
@@ -178,6 +186,7 @@ mod tests {
             EventSetOperation::RestoreAuthor,
             EventSetOperation::ImportBooks,
             EventSetOperation::SnapshotAll,
+            EventSetOperation::MergeAuthor,
         ];
         for variant in &variants {
             let s = variant.as_str();
@@ -228,4 +237,32 @@ pub struct AuthorEvent {
     pub changed_at: OffsetDateTime,
     // Operation-specific extra data (e.g. source_event_id for restore)
     pub extra: Option<Value>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct NewAuthorEvent {
+    pub operation: EventOperation,
+    pub author_id: AuthorId,
+    pub name: Option<String>,
+    pub yomi: Option<String>,
+    pub author_created_at: Option<OffsetDateTime>,
+    pub author_updated_at: Option<OffsetDateTime>,
+    pub extra: Option<Value>,
+}
+
+impl NewAuthorEvent {
+    pub fn merge_as_destination(author_id: AuthorId, source_author_id: &AuthorId) -> Self {
+        Self {
+            operation: EventOperation::MergeAsDestination,
+            author_id,
+            name: None,
+            yomi: None,
+            author_created_at: None,
+            author_updated_at: None,
+            extra: Some(serde_json::json!({
+                "version": 1,
+                "source_author_id": source_author_id.to_string(),
+            })),
+        }
+    }
 }

--- a/src/domain/repository/author_event_repository.rs
+++ b/src/domain/repository/author_event_repository.rs
@@ -2,13 +2,25 @@ use async_trait::async_trait;
 use mockall::automock;
 
 use crate::domain::{
-    entity::{author::AuthorId, event::AuthorEvent, event_set::EventSetId, user::UserId},
+    entity::{
+        author::AuthorId,
+        event::{AuthorEvent, EventId, NewAuthorEvent},
+        event_set::EventSetId,
+        user::UserId,
+    },
     error::DomainError,
 };
 
-#[automock]
+#[automock(type Transaction = ();)]
 #[async_trait]
 pub trait AuthorEventRepository: Send + Sync + 'static {
+    type Transaction: Send;
+
+    async fn append(
+        &self,
+        tx: &mut Self::Transaction,
+        event: &NewAuthorEvent,
+    ) -> Result<EventId, DomainError>;
     async fn find_by_author(
         &self,
         user_id: &UserId,

--- a/src/domain/repository/author_repository.rs
+++ b/src/domain/repository/author_repository.rs
@@ -13,6 +13,11 @@ use crate::domain::{
     error::DomainError,
 };
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DeleteAuthorEventExtra {
+    Merge { destination_author_id: AuthorId },
+}
+
 #[automock(type Transaction = ();)]
 #[async_trait]
 pub trait AuthorRepository: Send + Sync + 'static {
@@ -57,6 +62,7 @@ pub trait AuthorRepository: Send + Sync + 'static {
         &self,
         tx: &mut Self::Transaction,
         author_id: &AuthorId,
+        extra: Option<DeleteAuthorEventExtra>,
     ) -> Result<(), DomainError>;
     // Upserts or deletes the entity and records a restore event in one transaction.
     // author=Some means upsert; author=None means delete (only author_id is used).

--- a/src/domain/repository/book_repository.rs
+++ b/src/domain/repository/book_repository.rs
@@ -37,6 +37,12 @@ pub trait BookRepository: Send + Sync + 'static {
         user_id: &UserId,
         author_ids: &[AuthorId],
     ) -> Result<HashMap<AuthorId, Vec<Book>>, DomainError>;
+    async fn find_by_author_id_with_tx(
+        &self,
+        tx: &mut Self::Transaction,
+        user_id: &UserId,
+        author_id: &AuthorId,
+    ) -> Result<Vec<Book>, DomainError>;
     async fn update(&self, tx: &mut Self::Transaction, book: &Book)
     -> Result<EventId, DomainError>;
     async fn delete(&self, tx: &mut Self::Transaction, book_id: &BookId)

--- a/src/infrastructure/author_event_repository.rs
+++ b/src/infrastructure/author_event_repository.rs
@@ -7,13 +7,14 @@ use uuid::Uuid;
 use crate::domain::{
     entity::{
         author::AuthorId,
-        event::{AuthorEvent, EventOperation},
+        event::{AuthorEvent, EventId, EventOperation, NewAuthorEvent},
         event_set::EventSetId,
         user::UserId,
     },
     error::DomainError,
     repository::author_event_repository::AuthorEventRepository,
 };
+use crate::infrastructure::transaction::PgTransaction;
 
 #[derive(sqlx::FromRow)]
 struct AuthorEventRow {
@@ -60,6 +61,36 @@ impl PgAuthorEventRepository {
 
 #[async_trait]
 impl AuthorEventRepository for PgAuthorEventRepository {
+    type Transaction = PgTransaction;
+
+    async fn append(
+        &self,
+        tx: &mut Self::Transaction,
+        event: &NewAuthorEvent,
+    ) -> Result<EventId, DomainError> {
+        let user_id = tx.user_id().clone();
+        let (event_id,): (i64,) = sqlx::query_as(
+            "INSERT INTO author_event
+               (event_set_id, operation, author_id, user_id, name, yomi,
+                author_created_at, author_updated_at, extra)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+             RETURNING event_id",
+        )
+        .bind(tx.event_set_id())
+        .bind(event.operation.as_str())
+        .bind(event.author_id.to_uuid())
+        .bind(user_id.as_str())
+        .bind(&event.name)
+        .bind(&event.yomi)
+        .bind(event.author_created_at)
+        .bind(event.author_updated_at)
+        .bind(&event.extra)
+        .fetch_one(tx.as_mut())
+        .await?;
+
+        Ok(EventId::from(event_id))
+    }
+
     async fn find_by_author(
         &self,
         user_id: &UserId,

--- a/src/infrastructure/author_repository.rs
+++ b/src/infrastructure/author_repository.rs
@@ -14,7 +14,7 @@ use crate::domain::{
         user::UserId,
     },
     error::DomainError,
-    repository::author_repository::AuthorRepository,
+    repository::author_repository::{AuthorRepository, DeleteAuthorEventExtra},
 };
 use crate::infrastructure::transaction::PgTransaction;
 
@@ -283,6 +283,7 @@ impl AuthorRepository for PgAuthorRepository {
         &self,
         tx: &mut Self::Transaction,
         author_id: &AuthorId,
+        extra: Option<DeleteAuthorEventExtra>,
     ) -> Result<(), DomainError> {
         let user_id = tx.user_id().clone();
         // Lock the author row to prevent concurrent inserts into book_author after the count check.
@@ -338,13 +339,23 @@ impl AuthorRepository for PgAuthorRepository {
             }
         }
 
+        let extra = extra.map(|extra| match extra {
+            DeleteAuthorEventExtra::Merge {
+                destination_author_id,
+            } => json!({
+                "type": "merge",
+                "version": 1,
+                "destination_author_id": destination_author_id.to_string(),
+            }),
+        });
         sqlx::query(
-            "INSERT INTO author_event (event_set_id, operation, author_id, user_id)
-             VALUES ($1, 'delete', $2, $3)",
+            "INSERT INTO author_event (event_set_id, operation, author_id, user_id, extra)
+             VALUES ($1, 'delete', $2, $3, $4)",
         )
         .bind(tx.event_set_id())
         .bind(author_id.to_uuid())
         .bind(user_id.as_str())
+        .bind(extra)
         .execute(tx.as_mut())
         .await?;
 
@@ -600,7 +611,7 @@ mod tests {
     ) -> Result<(), DomainError> {
         let tm = PgTransactionManager::new(pool.clone());
         let mut tx = tm.begin(user_id, EventSetOperation::DeleteAuthor).await?;
-        author_repository.delete(&mut tx, author_id).await?;
+        author_repository.delete(&mut tx, author_id, None).await?;
         tm.commit(tx).await
     }
 

--- a/src/infrastructure/book_repository.rs
+++ b/src/infrastructure/book_repository.rs
@@ -970,7 +970,20 @@ mod tests {
 
         let user1_book1 = book_entity1(&user1_author_ids)?;
         let user1_book2 = book_entity2(&user1_author_ids[..1])?;
-        let user2_book = book_entity1(&user2_author_ids)?;
+        let user2_book_template = book_entity1(&user2_author_ids)?.destructure();
+        let user2_book = Book::new(
+            BookId::new(Uuid::new_v4())?,
+            user2_book_template.title,
+            user2_book_template.author_ids,
+            user2_book_template.isbn,
+            user2_book_template.read,
+            user2_book_template.owned,
+            user2_book_template.priority,
+            user2_book_template.format,
+            user2_book_template.store,
+            user2_book_template.created_at,
+            user2_book_template.updated_at,
+        )?;
         create_book(&pool, &book_repository, &user1_id, &user1_book1).await?;
         create_book(&pool, &book_repository, &user1_id, &user1_book2).await?;
         create_book(&pool, &book_repository, &user2_id, &user2_book).await?;

--- a/src/infrastructure/book_repository.rs
+++ b/src/infrastructure/book_repository.rs
@@ -341,6 +341,40 @@ impl BookRepository for PgBookRepository {
         Ok(books_by_author)
     }
 
+    async fn find_by_author_id_with_tx(
+        &self,
+        tx: &mut Self::Transaction,
+        user_id: &UserId,
+        author_id: &AuthorId,
+    ) -> Result<Vec<Book>, DomainError> {
+        let rows: Vec<BookRow> = sqlx::query_as(
+            "WITH authors_of_book_and_user AS (
+                SELECT book_id, array_agg(author_id) AS author_ids
+                FROM book_author
+                WHERE user_id = $1
+                GROUP BY book_id
+            )
+            SELECT book.id, book.title, authors.author_ids, book.isbn, book.read,
+                   book.owned, book.priority, book.format, book.store,
+                   book.created_at, book.updated_at
+            FROM book
+            JOIN authors_of_book_and_user authors ON authors.book_id = book.id
+            WHERE book.user_id = $1
+              AND EXISTS (
+                  SELECT 1 FROM book_author requested
+                  WHERE requested.user_id = $1
+                    AND requested.book_id = book.id
+                    AND requested.author_id = $2
+              )",
+        )
+        .bind(user_id.as_str())
+        .bind(author_id.to_uuid())
+        .fetch_all(tx.as_mut())
+        .await?;
+
+        rows.into_iter().map(book_from_row).collect()
+    }
+
     async fn update(
         &self,
         tx: &mut Self::Transaction,

--- a/src/infrastructure/book_repository.rs
+++ b/src/infrastructure/book_repository.rs
@@ -236,7 +236,24 @@ impl BookRepository for PgBookRepository {
         user_id: &UserId,
         book_id: &BookId,
     ) -> Result<Option<Book>, DomainError> {
-        find_book_by_id_with_executor(tx.as_mut(), user_id, book_id).await
+        let row: Option<BookRow> = sqlx::query_as(
+            "SELECT book.id, book.title,
+                    (SELECT array_agg(book_author.author_id)
+                     FROM book_author
+                     WHERE book_author.user_id = book.user_id
+                       AND book_author.book_id = book.id) AS author_ids,
+                    book.isbn, book.read, book.owned, book.priority, book.format,
+                    book.store, book.created_at, book.updated_at
+             FROM book
+             WHERE book.user_id = $1 AND book.id = $2
+             FOR UPDATE OF book",
+        )
+        .bind(user_id.as_str())
+        .bind(book_id.to_uuid())
+        .fetch_optional(tx.as_mut())
+        .await?;
+
+        row.map(book_from_row).transpose()
     }
 
     async fn find_all(&self, user_id: &UserId) -> Result<Vec<Book>, DomainError> {
@@ -348,24 +365,23 @@ impl BookRepository for PgBookRepository {
         author_id: &AuthorId,
     ) -> Result<Vec<Book>, DomainError> {
         let rows: Vec<BookRow> = sqlx::query_as(
-            "WITH authors_of_book_and_user AS (
-                SELECT book_id, array_agg(author_id) AS author_ids
-                FROM book_author
-                WHERE user_id = $1
-                GROUP BY book_id
-            )
-            SELECT book.id, book.title, authors.author_ids, book.isbn, book.read,
-                   book.owned, book.priority, book.format, book.store,
-                   book.created_at, book.updated_at
+            "SELECT book.id, book.title,
+                    (SELECT array_agg(book_author.author_id)
+                     FROM book_author
+                     WHERE book_author.user_id = book.user_id
+                       AND book_author.book_id = book.id) AS author_ids,
+                   book.isbn, book.read, book.owned, book.priority, book.format,
+                   book.store, book.created_at, book.updated_at
             FROM book
-            JOIN authors_of_book_and_user authors ON authors.book_id = book.id
             WHERE book.user_id = $1
               AND EXISTS (
                   SELECT 1 FROM book_author requested
                   WHERE requested.user_id = $1
                     AND requested.book_id = book.id
                     AND requested.author_id = $2
-              )",
+              )
+            ORDER BY book.id
+            FOR UPDATE OF book",
         )
         .bind(user_id.as_str())
         .bind(author_id.to_uuid())

--- a/src/infrastructure/book_repository.rs
+++ b/src/infrastructure/book_repository.rs
@@ -364,6 +364,30 @@ impl BookRepository for PgBookRepository {
         user_id: &UserId,
         author_id: &AuthorId,
     ) -> Result<Vec<Book>, DomainError> {
+        // Acquire all Book locks first. Reading book_author in a later statement
+        // gives Read Committed a fresh snapshot after any lock wait completes.
+        let locked_book_ids: Vec<Uuid> = sqlx::query_scalar(
+            "SELECT book.id
+             FROM book
+             WHERE book.user_id = $1
+               AND EXISTS (
+                   SELECT 1 FROM book_author requested
+                   WHERE requested.user_id = $1
+                     AND requested.book_id = book.id
+                     AND requested.author_id = $2
+               )
+             ORDER BY book.id
+             FOR UPDATE OF book",
+        )
+        .bind(user_id.as_str())
+        .bind(author_id.to_uuid())
+        .fetch_all(tx.as_mut())
+        .await?;
+
+        if locked_book_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+
         let rows: Vec<BookRow> = sqlx::query_as(
             "SELECT book.id, book.title,
                     (SELECT array_agg(book_author.author_id)
@@ -374,17 +398,18 @@ impl BookRepository for PgBookRepository {
                    book.store, book.created_at, book.updated_at
             FROM book
             WHERE book.user_id = $1
+              AND book.id = ANY($3)
               AND EXISTS (
                   SELECT 1 FROM book_author requested
                   WHERE requested.user_id = $1
                     AND requested.book_id = book.id
                     AND requested.author_id = $2
               )
-            ORDER BY book.id
-            FOR UPDATE OF book",
+            ORDER BY book.id",
         )
         .bind(user_id.as_str())
         .bind(author_id.to_uuid())
+        .bind(&locked_book_ids)
         .fetch_all(tx.as_mut())
         .await?;
 
@@ -927,6 +952,51 @@ mod tests {
         );
         assert_eq!(result[&user1_author_ids[1]], vec![shared_book]);
         assert!(result[&empty_author_id].is_empty());
+
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn find_by_author_id_with_tx_returns_fresh_scoped_books_in_id_order(
+        pool: PgPool,
+    ) -> anyhow::Result<()> {
+        let user_repository = PgUserRepository::new(pool.clone());
+        let author_repository = PgAuthorRepository::new(pool.clone());
+        let book_repository = PgBookRepository::new(pool.clone());
+        let user1_id = prepare_user(&user_repository, "user1").await?;
+        let user2_id = prepare_user(&user_repository, "user2").await?;
+        let user1_author_ids = prepare_authors1(&pool, &user1_id, &author_repository).await?;
+        let user2_author_ids = prepare_authors1(&pool, &user2_id, &author_repository).await?;
+
+        let user1_book1 = book_entity1(&user1_author_ids)?;
+        let user1_book2 = book_entity2(&user1_author_ids[..1])?;
+        let user2_book = book_entity1(&user2_author_ids)?;
+        create_book(&pool, &book_repository, &user1_id, &user1_book1).await?;
+        create_book(&pool, &book_repository, &user1_id, &user1_book2).await?;
+        create_book(&pool, &book_repository, &user2_id, &user2_book).await?;
+
+        let tm = PgTransactionManager::new(pool.clone());
+        let mut tx = tm.begin(&user1_id, EventSetOperation::MergeAuthor).await?;
+        let books = book_repository
+            .find_by_author_id_with_tx(&mut tx, &user1_id, &user1_author_ids[0])
+            .await?;
+
+        assert_eq!(books.len(), 2);
+        assert!(
+            books
+                .windows(2)
+                .all(|books| { books[0].id().to_uuid() < books[1].id().to_uuid() })
+        );
+        assert!(books.iter().all(|book| {
+            book.author_ids().contains(&user1_author_ids[0]) && book.id() != user2_book.id()
+        }));
+        let shared = books
+            .iter()
+            .find(|book| book.id() == user1_book1.id())
+            .expect("shared user1 book should be returned");
+        assert_eq!(shared.author_ids().len(), 2);
+        assert!(shared.author_ids().contains(&user1_author_ids[1]));
+        tm.commit(tx).await?;
 
         Ok(())
     }

--- a/src/presentation/graphql/mutation.rs
+++ b/src/presentation/graphql/mutation.rs
@@ -10,7 +10,8 @@ use crate::{
 use super::object::{
     Author, AuthorMutationPayload, Book, BookMutationPayload, CreateAuthorInput, CreateBookInput,
     DeleteAuthorPayload, DeleteBookPayload, ImportBookInput, ImportBooksPayload,
-    RestoreAuthorPayload, RestoreBookPayload, UpdateAuthorInput, UpdateBookInput, User,
+    MergeAuthorPayload, RestoreAuthorPayload, RestoreBookPayload, UpdateAuthorInput,
+    UpdateBookInput, User,
 };
 
 pub struct Mutation<MUC> {
@@ -133,6 +134,29 @@ where
             .await?;
         Ok(DeleteAuthorPayload {
             author_id: ID(result.value),
+            event_set_id: ID(result.event_set_id),
+        })
+    }
+
+    async fn merge_author(
+        &self,
+        ctx: &Context<'_>,
+        source_author_id: ID,
+        destination_author_id: ID,
+    ) -> Result<MergeAuthorPayload, PresentationalError> {
+        let claims = get_claims(ctx)?;
+        let result = self
+            .mutation_use_case
+            .merge_author(
+                &claims.sub,
+                crate::use_case::dto::author::MergeAuthorInputDto {
+                    source_author_id: source_author_id.to_string(),
+                    destination_author_id: destination_author_id.to_string(),
+                },
+            )
+            .await?;
+        Ok(MergeAuthorPayload {
+            author: result.value.into(),
             event_set_id: ID(result.event_set_id),
         })
     }

--- a/src/presentation/graphql/object.rs
+++ b/src/presentation/graphql/object.rs
@@ -504,6 +504,12 @@ pub struct AuthorMutationPayload {
     pub event_id: ID,
 }
 
+#[derive(SimpleObject)]
+pub struct MergeAuthorPayload {
+    pub author: Author,
+    pub event_set_id: ID,
+}
+
 impl AuthorMutationPayload {
     pub fn new(author: Author, event_set_id: ID, event_id: ID) -> Self {
         Self {

--- a/src/use_case/dto/author.rs
+++ b/src/use_case/dto/author.rs
@@ -46,6 +46,11 @@ pub struct UpdateAuthorDto {
     pub yomi: Option<String>,
 }
 
+pub struct MergeAuthorInputDto {
+    pub source_author_id: String,
+    pub destination_author_id: String,
+}
+
 impl UpdateAuthorDto {
     pub fn new(id: String, name: String) -> Self {
         Self {

--- a/src/use_case/interactor/author.rs
+++ b/src/use_case/interactor/author.rs
@@ -89,6 +89,14 @@ where
             .begin(&user_id, EventSetOperation::MergeAuthor)
             .await?;
 
+        // Book updates lock their Book row before book_author inserts acquire
+        // foreign-key locks on Author rows. Merge uses the same Book -> Author
+        // order to avoid a deadlock cycle with a concurrent updateBook.
+        let books = self
+            .book_repository
+            .find_by_author_id_with_tx(&mut tx, &user_id, &source_id)
+            .await?;
+
         let (first_id, second_id) = if source_id.to_uuid() < destination_id.to_uuid() {
             (&source_id, &destination_id)
         } else {
@@ -121,10 +129,6 @@ where
             )
         };
 
-        let books = self
-            .book_repository
-            .find_by_author_id_with_tx(&mut tx, &user_id, &source_id)
-            .await?;
         for mut book in books {
             let mut author_ids: Vec<_> = book
                 .author_ids()
@@ -334,7 +338,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use mockall::predicate::always;
+    use mockall::{Sequence, predicate::always};
     use time::OffsetDateTime;
     use uuid::Uuid;
 
@@ -849,20 +853,23 @@ mod tests {
             timestamp,
         )
         .unwrap();
+        let mut sequence = Sequence::new();
+        let mut book_repository = MockBookRepository::new();
+        book_repository
+            .expect_find_by_author_id_with_tx()
+            .in_sequence(&mut sequence)
+            .returning(|_, _, _| Ok(vec![]));
         let mut author_repository = MockAuthorRepository::new();
         let mut locked = vec![source.clone(), destination.clone()].into_iter();
         author_repository
             .expect_find_by_id_with_tx()
             .times(2)
+            .in_sequence(&mut sequence)
             .returning(move |_, _, _| Ok(Some(locked.next().unwrap())));
         author_repository
             .expect_delete()
             .with(always(), always(), always())
             .returning(|_, _, _| Ok(()));
-        let mut book_repository = MockBookRepository::new();
-        book_repository
-            .expect_find_by_author_id_with_tx()
-            .returning(|_, _, _| Ok(vec![]));
         let mut event_repository = MockAuthorEventRepository::new();
         event_repository
             .expect_append()

--- a/src/use_case/interactor/author.rs
+++ b/src/use_case/interactor/author.rs
@@ -19,7 +19,7 @@ use crate::{
     },
     use_case::{
         dto::{
-            author::{CreateAuthorDto, MergeAuthorInputDto, UpdateAuthorDto},
+            author::{AuthorDto, CreateAuthorDto, MergeAuthorInputDto, UpdateAuthorDto},
             mutation::{
                 AuthorMutationResultDto, DeleteAuthorResultDto, MutationResultDto,
                 SingleEventMutationResultDto,
@@ -72,7 +72,7 @@ where
         &self,
         user_id: &str,
         input: MergeAuthorInputDto,
-    ) -> Result<MutationResultDto<crate::use_case::dto::author::AuthorDto>, UseCaseError> {
+    ) -> Result<MutationResultDto<AuthorDto>, UseCaseError> {
         let user_id = UserId::new(user_id.to_string())?;
         let source_id_text = input.source_author_id;
         let destination_id_text = input.destination_author_id;
@@ -336,11 +336,18 @@ where
 mod tests {
     use mockall::predicate::always;
     use time::OffsetDateTime;
+    use uuid::Uuid;
 
     use crate::{
-        common::time::normalize_timestamp_for_persistence,
+        common::{
+            time::normalize_timestamp_for_persistence,
+            types::{BookFormat, BookStore},
+        },
         domain::{
-            entity::author::{Author, AuthorId, AuthorName},
+            entity::{
+                author::{Author, AuthorId, AuthorName},
+                book::{Book, BookId, BookTitle, Isbn, OwnedFlag, Priority, ReadFlag},
+            },
             error::DomainError,
             repository::{
                 author_event_repository::MockAuthorEventRepository,
@@ -880,5 +887,110 @@ mod tests {
 
         assert_eq!(result.value.id, destination_id);
         assert_eq!(result.value.name, "Destination");
+    }
+
+    #[tokio::test]
+    async fn merge_author_moves_multiple_books_without_duplicate_destination() {
+        let source_id = "006099b4-6c42-4ec4-8645-f6bd5b63eddc";
+        let destination_id = "106099b4-6c42-4ec4-8645-f6bd5b63eddc";
+        let other_id = AuthorId::try_from("206099b4-6c42-4ec4-8645-f6bd5b63eddc").unwrap();
+        let source_author_id = AuthorId::try_from(source_id).unwrap();
+        let destination_author_id = AuthorId::try_from(destination_id).unwrap();
+        let timestamp = OffsetDateTime::UNIX_EPOCH;
+        let source = Author::new(
+            source_author_id.clone(),
+            AuthorName::new("Source".to_string()).unwrap(),
+            timestamp,
+        )
+        .unwrap();
+        let destination = Author::new(
+            destination_author_id.clone(),
+            AuthorName::new("Destination".to_string()).unwrap(),
+            timestamp,
+        )
+        .unwrap();
+        let make_book = |title: &str, author_ids: Vec<AuthorId>| {
+            Book::new(
+                BookId::new(Uuid::new_v4()).unwrap(),
+                BookTitle::new(title.to_string()).unwrap(),
+                author_ids,
+                Isbn::new(String::new()).unwrap(),
+                ReadFlag::new(false),
+                OwnedFlag::new(false),
+                Priority::new(50).unwrap(),
+                BookFormat::Unknown,
+                BookStore::Unknown,
+                timestamp,
+                timestamp,
+            )
+            .unwrap()
+        };
+        let books = vec![
+            make_book(
+                "Needs destination",
+                vec![source_author_id.clone(), other_id.clone()],
+            ),
+            make_book(
+                "Already has destination",
+                vec![
+                    source_author_id.clone(),
+                    destination_author_id.clone(),
+                    other_id.clone(),
+                ],
+            ),
+        ];
+
+        let mut author_repository = MockAuthorRepository::new();
+        let mut locked = vec![source, destination].into_iter();
+        author_repository
+            .expect_find_by_id_with_tx()
+            .times(2)
+            .returning(move |_, _, _| Ok(Some(locked.next().unwrap())));
+        author_repository
+            .expect_delete()
+            .returning(|_, _, _| Ok(()));
+        let mut book_repository = MockBookRepository::new();
+        book_repository
+            .expect_find_by_author_id_with_tx()
+            .return_once(move |_, _, _| Ok(books));
+        let expected_source = source_author_id.clone();
+        let expected_destination = destination_author_id.clone();
+        let expected_other = other_id.clone();
+        book_repository
+            .expect_update()
+            .times(2)
+            .withf(move |_, book| {
+                !book.author_ids().contains(&expected_source)
+                    && book
+                        .author_ids()
+                        .iter()
+                        .filter(|id| *id == &expected_destination)
+                        .count()
+                        == 1
+                    && book.author_ids().contains(&expected_other)
+            })
+            .returning(|_, _| Ok(1.into()));
+        let mut event_repository = MockAuthorEventRepository::new();
+        event_repository
+            .expect_append()
+            .returning(|_, _| Ok(2.into()));
+        let interactor = MergeAuthorInteractor::new(
+            author_repository,
+            book_repository,
+            event_repository,
+            make_transaction_manager(),
+        );
+
+        let result = interactor
+            .merge(
+                "user1",
+                crate::use_case::dto::author::MergeAuthorInputDto {
+                    source_author_id: source_id.to_string(),
+                    destination_author_id: destination_id.to_string(),
+                },
+            )
+            .await;
+
+        assert!(result.is_ok());
     }
 }

--- a/src/use_case/interactor/author.rs
+++ b/src/use_case/interactor/author.rs
@@ -6,30 +6,174 @@ use crate::{
     domain::{
         entity::{
             author::{Author, AuthorId, AuthorName, AuthorUpdate, validate_author_yomi},
-            event::EventSetOperation,
+            book::BookUpdate,
+            event::{EventSetOperation, NewAuthorEvent},
             user::UserId,
         },
         repository::{
-            author_repository::AuthorRepository,
+            author_event_repository::AuthorEventRepository,
+            author_repository::{AuthorRepository, DeleteAuthorEventExtra},
+            book_repository::BookRepository,
             transaction::{TransactionEventSet, TransactionManager},
         },
     },
     use_case::{
         dto::{
-            author::{CreateAuthorDto, UpdateAuthorDto},
+            author::{CreateAuthorDto, MergeAuthorInputDto, UpdateAuthorDto},
             mutation::{
                 AuthorMutationResultDto, DeleteAuthorResultDto, MutationResultDto,
                 SingleEventMutationResultDto,
             },
         },
         error::UseCaseError,
-        traits::author::{CreateAuthorUseCase, DeleteAuthorUseCase, UpdateAuthorUseCase},
+        traits::author::{
+            CreateAuthorUseCase, DeleteAuthorUseCase, MergeAuthorUseCase, UpdateAuthorUseCase,
+        },
     },
 };
 
 pub struct CreateAuthorInteractor<AR, TM> {
     author_repository: AR,
     transaction_manager: TM,
+}
+
+pub struct MergeAuthorInteractor<AR, BR, AER, TM> {
+    author_repository: AR,
+    book_repository: BR,
+    author_event_repository: AER,
+    transaction_manager: TM,
+}
+
+impl<AR, BR, AER, TM> MergeAuthorInteractor<AR, BR, AER, TM> {
+    pub fn new(
+        author_repository: AR,
+        book_repository: BR,
+        author_event_repository: AER,
+        transaction_manager: TM,
+    ) -> Self {
+        Self {
+            author_repository,
+            book_repository,
+            author_event_repository,
+            transaction_manager,
+        }
+    }
+}
+
+#[async_trait]
+impl<AR, BR, AER, TM> MergeAuthorUseCase for MergeAuthorInteractor<AR, BR, AER, TM>
+where
+    TM: TransactionManager,
+    AR: AuthorRepository<Transaction = TM::Transaction>,
+    BR: BookRepository<Transaction = TM::Transaction>,
+    AER: AuthorEventRepository<Transaction = TM::Transaction>,
+{
+    async fn merge(
+        &self,
+        user_id: &str,
+        input: MergeAuthorInputDto,
+    ) -> Result<MutationResultDto<crate::use_case::dto::author::AuthorDto>, UseCaseError> {
+        let user_id = UserId::new(user_id.to_string())?;
+        let source_id_text = input.source_author_id;
+        let destination_id_text = input.destination_author_id;
+        let source_id = AuthorId::try_from(source_id_text.as_str())?;
+        let destination_id = AuthorId::try_from(destination_id_text.as_str())?;
+        if source_id == destination_id {
+            return Err(UseCaseError::Validation(
+                "source and destination authors must differ".to_string(),
+            ));
+        }
+
+        let mut tx = self
+            .transaction_manager
+            .begin(&user_id, EventSetOperation::MergeAuthor)
+            .await?;
+
+        let (first_id, second_id) = if source_id.to_uuid() < destination_id.to_uuid() {
+            (&source_id, &destination_id)
+        } else {
+            (&destination_id, &source_id)
+        };
+        let first = self
+            .author_repository
+            .find_by_id_with_tx(&mut tx, &user_id, first_id)
+            .await?;
+        let second = self
+            .author_repository
+            .find_by_id_with_tx(&mut tx, &user_id, second_id)
+            .await?;
+        let find_or_not_found = |author: Option<Author>, id: &str| {
+            author.ok_or_else(|| UseCaseError::NotFound {
+                entity_type: "author",
+                entity_id: id.to_string(),
+                user_id: user_id.clone().into_string(),
+            })
+        };
+        let (source_author, destination_author) = if first_id == &source_id {
+            (
+                find_or_not_found(first, &source_id_text)?,
+                find_or_not_found(second, &destination_id_text)?,
+            )
+        } else {
+            (
+                find_or_not_found(second, &source_id_text)?,
+                find_or_not_found(first, &destination_id_text)?,
+            )
+        };
+
+        let books = self
+            .book_repository
+            .find_by_author_id_with_tx(&mut tx, &user_id, &source_id)
+            .await?;
+        for mut book in books {
+            let mut author_ids: Vec<_> = book
+                .author_ids()
+                .iter()
+                .filter(|id| *id != &source_id)
+                .cloned()
+                .collect();
+            if !author_ids.contains(&destination_id) {
+                author_ids.push(destination_id.clone());
+            }
+            book.update(
+                BookUpdate {
+                    title: book.title().clone(),
+                    author_ids,
+                    isbn: book.isbn().clone(),
+                    read: book.read().clone(),
+                    owned: book.owned().clone(),
+                    priority: book.priority().clone(),
+                    format: book.format().clone(),
+                    store: book.store().clone(),
+                },
+                OffsetDateTime::now_utc(),
+            );
+            self.book_repository.update(&mut tx, &book).await?;
+        }
+
+        self.author_repository
+            .delete(
+                &mut tx,
+                source_author.id(),
+                Some(DeleteAuthorEventExtra::Merge {
+                    destination_author_id: destination_id.clone(),
+                }),
+            )
+            .await?;
+        self.author_event_repository
+            .append(
+                &mut tx,
+                &NewAuthorEvent::merge_as_destination(destination_id, source_author.id()),
+            )
+            .await?;
+        let event_set_id = tx.event_set_id().hyphenated().to_string();
+        self.transaction_manager.commit(tx).await?;
+
+        Ok(MutationResultDto::new(
+            destination_author.into(),
+            event_set_id,
+        ))
+    }
 }
 
 impl<AR, TM> CreateAuthorInteractor<AR, TM> {
@@ -178,7 +322,9 @@ where
             .transaction_manager
             .begin(&user_id, EventSetOperation::DeleteAuthor)
             .await?;
-        self.author_repository.delete(&mut tx, &author_id).await?;
+        self.author_repository
+            .delete(&mut tx, &author_id, None)
+            .await?;
         let event_set_id = tx.event_set_id().hyphenated().to_string();
         self.transaction_manager.commit(tx).await?;
 
@@ -197,16 +343,21 @@ mod tests {
             entity::author::{Author, AuthorId, AuthorName},
             error::DomainError,
             repository::{
-                author_repository::MockAuthorRepository, transaction::MockTransactionManager,
+                author_event_repository::MockAuthorEventRepository,
+                author_repository::MockAuthorRepository, book_repository::MockBookRepository,
+                transaction::MockTransactionManager,
             },
         },
         use_case::{
             dto::author::{CreateAuthorDto, UpdateAuthorDto},
             error::UseCaseError,
             interactor::author::{
-                CreateAuthorInteractor, DeleteAuthorInteractor, UpdateAuthorInteractor,
+                CreateAuthorInteractor, DeleteAuthorInteractor, MergeAuthorInteractor,
+                UpdateAuthorInteractor,
             },
-            traits::author::{CreateAuthorUseCase, DeleteAuthorUseCase, UpdateAuthorUseCase},
+            traits::author::{
+                CreateAuthorUseCase, DeleteAuthorUseCase, MergeAuthorUseCase, UpdateAuthorUseCase,
+            },
         },
     };
 
@@ -559,8 +710,8 @@ mod tests {
         let mut author_repository = MockAuthorRepository::new();
         author_repository
             .expect_delete()
-            .with(always(), always())
-            .returning(|_, _| Ok(()));
+            .with(always(), always(), always())
+            .returning(|_, _, _| Ok(()));
 
         let interactor = DeleteAuthorInteractor::new(author_repository, make_transaction_manager());
 
@@ -579,8 +730,8 @@ mod tests {
         let mut author_repository = MockAuthorRepository::new();
         author_repository
             .expect_delete()
-            .with(always(), always())
-            .returning(|_, _| {
+            .with(always(), always(), always())
+            .returning(|_, _, _| {
                 Err(DomainError::NotFound {
                     entity_type: "author",
                     entity_id: "006099b4-6c42-4ec4-8645-f6bd5b63eddc".to_string(),
@@ -605,8 +756,8 @@ mod tests {
         let mut author_repository = MockAuthorRepository::new();
         author_repository
             .expect_delete()
-            .with(always(), always())
-            .returning(|_, _| {
+            .with(always(), always(), always())
+            .returning(|_, _, _| {
                 Err(DomainError::HasAssociatedBooks {
                     author_id: "006099b4-6c42-4ec4-8645-f6bd5b63eddc".to_string(),
                     user_id: "user1".to_string(),
@@ -649,5 +800,85 @@ mod tests {
 
         // Then
         assert!(matches!(result, Err(UseCaseError::Validation(_))));
+    }
+
+    #[tokio::test]
+    async fn merge_author_rejects_identical_ids_before_transaction() {
+        let id = "006099b4-6c42-4ec4-8645-f6bd5b63eddc";
+        let interactor = MergeAuthorInteractor::new(
+            MockAuthorRepository::new(),
+            MockBookRepository::new(),
+            MockAuthorEventRepository::new(),
+            MockTransactionManager::new(),
+        );
+
+        let result = interactor
+            .merge(
+                "user1",
+                crate::use_case::dto::author::MergeAuthorInputDto {
+                    source_author_id: id.to_string(),
+                    destination_author_id: id.to_string(),
+                },
+            )
+            .await;
+
+        assert!(matches!(result, Err(UseCaseError::Validation(_))));
+    }
+
+    #[tokio::test]
+    async fn merge_author_without_books_deletes_source_and_records_destination() {
+        let source_id = "006099b4-6c42-4ec4-8645-f6bd5b63eddc";
+        let destination_id = "106099b4-6c42-4ec4-8645-f6bd5b63eddc";
+        let timestamp = OffsetDateTime::UNIX_EPOCH;
+        let source = Author::new(
+            AuthorId::try_from(source_id).unwrap(),
+            AuthorName::new("Source".to_string()).unwrap(),
+            timestamp,
+        )
+        .unwrap();
+        let destination = Author::new(
+            AuthorId::try_from(destination_id).unwrap(),
+            AuthorName::new("Destination".to_string()).unwrap(),
+            timestamp,
+        )
+        .unwrap();
+        let mut author_repository = MockAuthorRepository::new();
+        let mut locked = vec![source.clone(), destination.clone()].into_iter();
+        author_repository
+            .expect_find_by_id_with_tx()
+            .times(2)
+            .returning(move |_, _, _| Ok(Some(locked.next().unwrap())));
+        author_repository
+            .expect_delete()
+            .with(always(), always(), always())
+            .returning(|_, _, _| Ok(()));
+        let mut book_repository = MockBookRepository::new();
+        book_repository
+            .expect_find_by_author_id_with_tx()
+            .returning(|_, _, _| Ok(vec![]));
+        let mut event_repository = MockAuthorEventRepository::new();
+        event_repository
+            .expect_append()
+            .returning(|_, _| Ok(1.into()));
+        let interactor = MergeAuthorInteractor::new(
+            author_repository,
+            book_repository,
+            event_repository,
+            make_transaction_manager(),
+        );
+
+        let result = interactor
+            .merge(
+                "user1",
+                crate::use_case::dto::author::MergeAuthorInputDto {
+                    source_author_id: source_id.to_string(),
+                    destination_author_id: destination_id.to_string(),
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.value.id, destination_id);
+        assert_eq!(result.value.name, "Destination");
     }
 }

--- a/src/use_case/interactor/author.rs
+++ b/src/use_case/interactor/author.rs
@@ -351,11 +351,13 @@ mod tests {
             entity::{
                 author::{Author, AuthorId, AuthorName},
                 book::{Book, BookId, BookTitle, Isbn, OwnedFlag, Priority, ReadFlag},
+                event::EventOperation,
             },
             error::DomainError,
             repository::{
                 author_event_repository::MockAuthorEventRepository,
-                author_repository::MockAuthorRepository, book_repository::MockBookRepository,
+                author_repository::{DeleteAuthorEventExtra, MockAuthorRepository},
+                book_repository::MockBookRepository,
                 transaction::MockTransactionManager,
             },
         },
@@ -868,11 +870,32 @@ mod tests {
             .returning(move |_, _, _| Ok(Some(locked.next().unwrap())));
         author_repository
             .expect_delete()
-            .with(always(), always(), always())
+            .withf(move |_, author_id, extra| {
+                author_id.to_string() == source_id
+                    && matches!(
+                        extra,
+                        Some(DeleteAuthorEventExtra::Merge {
+                            destination_author_id
+                        }) if destination_author_id.to_string() == destination_id
+                    )
+            })
             .returning(|_, _, _| Ok(()));
         let mut event_repository = MockAuthorEventRepository::new();
         event_repository
             .expect_append()
+            .withf(move |_, event| {
+                event.operation == EventOperation::MergeAsDestination
+                    && event.author_id.to_string() == destination_id
+                    && event.name.is_none()
+                    && event.yomi.is_none()
+                    && event.author_created_at.is_none()
+                    && event.author_updated_at.is_none()
+                    && event.extra
+                        == Some(serde_json::json!({
+                            "version": 1,
+                            "source_author_id": source_id,
+                        }))
+            })
             .returning(|_, _| Ok(1.into()));
         let interactor = MergeAuthorInteractor::new(
             author_repository,
@@ -955,6 +978,15 @@ mod tests {
             .returning(move |_, _, _| Ok(Some(locked.next().unwrap())));
         author_repository
             .expect_delete()
+            .withf(move |_, author_id, extra| {
+                author_id.to_string() == source_id
+                    && matches!(
+                        extra,
+                        Some(DeleteAuthorEventExtra::Merge {
+                            destination_author_id
+                        }) if destination_author_id.to_string() == destination_id
+                    )
+            })
             .returning(|_, _, _| Ok(()));
         let mut book_repository = MockBookRepository::new();
         book_repository
@@ -980,6 +1012,19 @@ mod tests {
         let mut event_repository = MockAuthorEventRepository::new();
         event_repository
             .expect_append()
+            .withf(move |_, event| {
+                event.operation == EventOperation::MergeAsDestination
+                    && event.author_id.to_string() == destination_id
+                    && event.name.is_none()
+                    && event.yomi.is_none()
+                    && event.author_created_at.is_none()
+                    && event.author_updated_at.is_none()
+                    && event.extra
+                        == Some(serde_json::json!({
+                            "version": 1,
+                            "source_author_id": source_id,
+                        }))
+            })
             .returning(|_, _| Ok(2.into()));
         let interactor = MergeAuthorInteractor::new(
             author_repository,

--- a/src/use_case/interactor/event.rs
+++ b/src/use_case/interactor/event.rs
@@ -195,6 +195,9 @@ where
                 self.transaction_manager.commit(tx).await?;
                 Ok(MutationResultDto::new(None, event_set_id))
             }
+            EventOperation::MergeAsDestination => Err(UseCaseError::Validation(
+                "merge_as_destination events cannot be restored".to_string(),
+            )),
         }
     }
 }
@@ -293,6 +296,9 @@ where
                 self.transaction_manager.commit(tx).await?;
                 Ok(MutationResultDto::new(None, event_set_id))
             }
+            EventOperation::MergeAsDestination => Err(UseCaseError::Validation(
+                "merge_as_destination events cannot be restored".to_string(),
+            )),
         }
     }
 }

--- a/src/use_case/interactor/mutation.rs
+++ b/src/use_case/interactor/mutation.rs
@@ -2,18 +2,20 @@ use async_trait::async_trait;
 
 use crate::use_case::{
     dto::{
-        author::{CreateAuthorDto, UpdateAuthorDto},
+        author::{AuthorDto, CreateAuthorDto, MergeAuthorInputDto, UpdateAuthorDto},
         book::{CreateBookDto, ImportBookEntryDto, UpdateBookDto},
         mutation::{
             AuthorMutationResultDto, BookMutationResultDto, DeleteAuthorResultDto,
-            DeleteBookResultDto, ImportBooksResultDto, RestoreAuthorResultDto,
+            DeleteBookResultDto, ImportBooksResultDto, MutationResultDto, RestoreAuthorResultDto,
             RestoreBookResultDto,
         },
         user::UserDto,
     },
     error::UseCaseError,
     traits::{
-        author::{CreateAuthorUseCase, DeleteAuthorUseCase, UpdateAuthorUseCase},
+        author::{
+            CreateAuthorUseCase, DeleteAuthorUseCase, MergeAuthorUseCase, UpdateAuthorUseCase,
+        },
         book::{CreateBookUseCase, DeleteBookUseCase, ImportBooksUseCase, UpdateBookUseCase},
         event::{RestoreAuthorUseCase, RestoreBookUseCase},
         mutation::MutationUseCase,
@@ -21,7 +23,7 @@ use crate::use_case::{
     },
 };
 
-pub struct MutationInteractor<RUUC, CBUC, UBUC, DBUC, CAUC, UAUC, DAUC, RBUC, RAUC, IBUC> {
+pub struct MutationInteractor<RUUC, CBUC, UBUC, DBUC, CAUC, UAUC, DAUC, MAUC, RBUC, RAUC, IBUC> {
     register_user_use_case: RUUC,
     create_book_use_case: CBUC,
     update_book_use_case: UBUC,
@@ -29,13 +31,14 @@ pub struct MutationInteractor<RUUC, CBUC, UBUC, DBUC, CAUC, UAUC, DAUC, RBUC, RA
     create_author_use_case: CAUC,
     update_author_use_case: UAUC,
     delete_author_use_case: DAUC,
+    merge_author_use_case: MAUC,
     restore_book_use_case: RBUC,
     restore_author_use_case: RAUC,
     import_books_use_case: IBUC,
 }
 
-impl<RUUC, CBUC, UBUC, DBUC, CAUC, UAUC, DAUC, RBUC, RAUC, IBUC>
-    MutationInteractor<RUUC, CBUC, UBUC, DBUC, CAUC, UAUC, DAUC, RBUC, RAUC, IBUC>
+impl<RUUC, CBUC, UBUC, DBUC, CAUC, UAUC, DAUC, MAUC, RBUC, RAUC, IBUC>
+    MutationInteractor<RUUC, CBUC, UBUC, DBUC, CAUC, UAUC, DAUC, MAUC, RBUC, RAUC, IBUC>
 {
     // This constructor takes many arguments because MutationInteractor composes all
     // mutation use cases via dependency injection. Splitting it would reduce clarity
@@ -49,6 +52,7 @@ impl<RUUC, CBUC, UBUC, DBUC, CAUC, UAUC, DAUC, RBUC, RAUC, IBUC>
         create_author_use_case: CAUC,
         update_author_use_case: UAUC,
         delete_author_use_case: DAUC,
+        merge_author_use_case: MAUC,
         restore_book_use_case: RBUC,
         restore_author_use_case: RAUC,
         import_books_use_case: IBUC,
@@ -61,6 +65,7 @@ impl<RUUC, CBUC, UBUC, DBUC, CAUC, UAUC, DAUC, RBUC, RAUC, IBUC>
             create_author_use_case,
             update_author_use_case,
             delete_author_use_case,
+            merge_author_use_case,
             restore_book_use_case,
             restore_author_use_case,
             import_books_use_case,
@@ -69,8 +74,8 @@ impl<RUUC, CBUC, UBUC, DBUC, CAUC, UAUC, DAUC, RBUC, RAUC, IBUC>
 }
 
 #[async_trait]
-impl<RUUC, CBUC, UBUC, DBUC, CAUC, UAUC, DAUC, RBUC, RAUC, IBUC> MutationUseCase
-    for MutationInteractor<RUUC, CBUC, UBUC, DBUC, CAUC, UAUC, DAUC, RBUC, RAUC, IBUC>
+impl<RUUC, CBUC, UBUC, DBUC, CAUC, UAUC, DAUC, MAUC, RBUC, RAUC, IBUC> MutationUseCase
+    for MutationInteractor<RUUC, CBUC, UBUC, DBUC, CAUC, UAUC, DAUC, MAUC, RBUC, RAUC, IBUC>
 where
     RUUC: RegisterUserUseCase,
     CBUC: CreateBookUseCase,
@@ -79,6 +84,7 @@ where
     CAUC: CreateAuthorUseCase,
     UAUC: UpdateAuthorUseCase,
     DAUC: DeleteAuthorUseCase,
+    MAUC: MergeAuthorUseCase,
     RBUC: RestoreBookUseCase,
     RAUC: RestoreAuthorUseCase,
     IBUC: ImportBooksUseCase,
@@ -151,6 +157,14 @@ where
         Ok(result)
     }
 
+    async fn merge_author(
+        &self,
+        user_id: &str,
+        input: MergeAuthorInputDto,
+    ) -> Result<MutationResultDto<AuthorDto>, UseCaseError> {
+        self.merge_author_use_case.merge(user_id, input).await
+    }
+
     async fn restore_book(
         &self,
         user_id: &str,
@@ -193,7 +207,10 @@ mod tests {
         },
         interactor::mutation::MutationInteractor,
         traits::{
-            author::{MockCreateAuthorUseCase, MockDeleteAuthorUseCase, MockUpdateAuthorUseCase},
+            author::{
+                MockCreateAuthorUseCase, MockDeleteAuthorUseCase, MockMergeAuthorUseCase,
+                MockUpdateAuthorUseCase,
+            },
             book::{
                 MockCreateBookUseCase, MockDeleteBookUseCase, MockImportBooksUseCase,
                 MockUpdateBookUseCase,
@@ -214,6 +231,7 @@ mod tests {
         MockCreateAuthorUseCase,
         MockUpdateAuthorUseCase,
         MockDeleteAuthorUseCase,
+        MockMergeAuthorUseCase,
         MockRestoreBookUseCase,
         MockRestoreAuthorUseCase,
         MockImportBooksUseCase,
@@ -227,6 +245,7 @@ mod tests {
         create_author: MockCreateAuthorUseCase,
         update_author: MockUpdateAuthorUseCase,
         delete_author: MockDeleteAuthorUseCase,
+        merge_author: MockMergeAuthorUseCase,
         restore_book: MockRestoreBookUseCase,
         restore_author: MockRestoreAuthorUseCase,
         import_books: MockImportBooksUseCase,
@@ -242,6 +261,7 @@ mod tests {
                 create_author: MockCreateAuthorUseCase::new(),
                 update_author: MockUpdateAuthorUseCase::new(),
                 delete_author: MockDeleteAuthorUseCase::new(),
+                merge_author: MockMergeAuthorUseCase::new(),
                 restore_book: MockRestoreBookUseCase::new(),
                 restore_author: MockRestoreAuthorUseCase::new(),
                 import_books: MockImportBooksUseCase::new(),
@@ -307,6 +327,7 @@ mod tests {
                 self.create_author,
                 self.update_author,
                 self.delete_author,
+                self.merge_author,
                 self.restore_book,
                 self.restore_author,
                 self.import_books,

--- a/src/use_case/interactor/mutation.rs
+++ b/src/use_case/interactor/mutation.rs
@@ -303,6 +303,11 @@ mod tests {
             self
         }
 
+        fn with_merge_author(mut self, mock: MockMergeAuthorUseCase) -> Self {
+            self.merge_author = mock;
+            self
+        }
+
         fn with_restore_book(mut self, mock: MockRestoreBookUseCase) -> Self {
             self.restore_book = mock;
             self
@@ -584,6 +589,43 @@ mod tests {
 
         // Then
         assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn merge_author_delegates_to_sub_use_case() {
+        let mut mock_merge_author = MockMergeAuthorUseCase::new();
+        mock_merge_author
+            .expect_merge()
+            .with(eq("user1"), always())
+            .returning(|_, _| {
+                Ok(MutationResultDto::new(
+                    AuthorDto {
+                        id: "106099b4-6c42-4ec4-8645-f6bd5b63eddc".to_string(),
+                        name: "Destination".to_string(),
+                        yomi: String::new(),
+                        created_at: OffsetDateTime::UNIX_EPOCH,
+                        updated_at: OffsetDateTime::UNIX_EPOCH,
+                    },
+                    "event-set".to_string(),
+                ))
+            });
+        let interactor = InteractorBuilder::new()
+            .with_merge_author(mock_merge_author)
+            .build();
+
+        let result = interactor
+            .merge_author(
+                "user1",
+                crate::use_case::dto::author::MergeAuthorInputDto {
+                    source_author_id: "006099b4-6c42-4ec4-8645-f6bd5b63eddc".to_string(),
+                    destination_author_id: "106099b4-6c42-4ec4-8645-f6bd5b63eddc".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.value.name, "Destination");
+        assert_eq!(result.event_set_id, "event-set");
     }
 
     #[tokio::test]

--- a/src/use_case/traits/author.rs
+++ b/src/use_case/traits/author.rs
@@ -3,7 +3,7 @@ use mockall::automock;
 
 use crate::use_case::{
     dto::{
-        author::{CreateAuthorDto, MergeAuthorInputDto, UpdateAuthorDto},
+        author::{AuthorDto, CreateAuthorDto, MergeAuthorInputDto, UpdateAuthorDto},
         mutation::{AuthorMutationResultDto, DeleteAuthorResultDto, MutationResultDto},
     },
     error::UseCaseError,
@@ -26,7 +26,7 @@ pub trait MergeAuthorUseCase: Send + Sync + 'static {
         &self,
         user_id: &str,
         input: MergeAuthorInputDto,
-    ) -> Result<MutationResultDto<crate::use_case::dto::author::AuthorDto>, UseCaseError>;
+    ) -> Result<MutationResultDto<AuthorDto>, UseCaseError>;
 }
 
 #[automock]

--- a/src/use_case/traits/author.rs
+++ b/src/use_case/traits/author.rs
@@ -3,8 +3,8 @@ use mockall::automock;
 
 use crate::use_case::{
     dto::{
-        author::{CreateAuthorDto, UpdateAuthorDto},
-        mutation::{AuthorMutationResultDto, DeleteAuthorResultDto},
+        author::{CreateAuthorDto, MergeAuthorInputDto, UpdateAuthorDto},
+        mutation::{AuthorMutationResultDto, DeleteAuthorResultDto, MutationResultDto},
     },
     error::UseCaseError,
 };
@@ -17,6 +17,16 @@ pub trait CreateAuthorUseCase: Send + Sync + 'static {
         user_id: &str,
         author_data: CreateAuthorDto,
     ) -> Result<AuthorMutationResultDto, UseCaseError>;
+}
+
+#[automock]
+#[async_trait]
+pub trait MergeAuthorUseCase: Send + Sync + 'static {
+    async fn merge(
+        &self,
+        user_id: &str,
+        input: MergeAuthorInputDto,
+    ) -> Result<MutationResultDto<crate::use_case::dto::author::AuthorDto>, UseCaseError>;
 }
 
 #[automock]

--- a/src/use_case/traits/mutation.rs
+++ b/src/use_case/traits/mutation.rs
@@ -3,11 +3,11 @@ use mockall::automock;
 
 use crate::use_case::{
     dto::{
-        author::{CreateAuthorDto, UpdateAuthorDto},
+        author::{AuthorDto, CreateAuthorDto, MergeAuthorInputDto, UpdateAuthorDto},
         book::{CreateBookDto, ImportBookEntryDto, UpdateBookDto},
         mutation::{
             AuthorMutationResultDto, BookMutationResultDto, DeleteAuthorResultDto,
-            DeleteBookResultDto, ImportBooksResultDto, RestoreAuthorResultDto,
+            DeleteBookResultDto, ImportBooksResultDto, MutationResultDto, RestoreAuthorResultDto,
             RestoreBookResultDto,
         },
         user::UserDto,
@@ -49,6 +49,11 @@ pub trait MutationUseCase: Send + Sync + 'static {
         user_id: &str,
         author_id: &str,
     ) -> Result<DeleteAuthorResultDto, UseCaseError>;
+    async fn merge_author(
+        &self,
+        user_id: &str,
+        input: MergeAuthorInputDto,
+    ) -> Result<MutationResultDto<AuthorDto>, UseCaseError>;
     async fn restore_book(
         &self,
         user_id: &str,


### PR DESCRIPTION
## Summary

- add the mergeAuthor GraphQL mutation and payload
- move source author book relationships to the destination in one transaction
- record book updates, source deletion metadata, and destination participation in one event set
- add event operations, migration, architecture documentation, unit tests, and an E2E scenario

## Validation

- cargo fmt --check
- cargo clippy --all-targets --locked -- -D warnings
- cargo test --locked (165 passed)
- cargo check --locked -p bookshelf-e2e --tests
- generated GraphQL schema matches schema.graphql

## Notes

The server-backed E2E scenario was not executed locally because TEST_SERVER_URL and DATABASE_URL were not configured. It compiles successfully and is available for the configured CI environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 著者を別の著者へ統合するGraphQLミューテーションを追加しました。
  * 統合元の書籍を統合先へ移し、統合元の著者を削除します。
  * 統合結果の著者情報とイベントセットIDを返します。
  * 統合処理を一括記録し、関連イベントを追跡できるようにしました。

* **バグ修正**
  * 統合先として記録された著者イベントを復元対象から除外し、不正な復元を防止します。

* **テスト**
  * 著者統合後の書籍移行、著者削除、レスポンス内容を検証するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->