### PR TITLE
Document OpenSpec ExecPlan exception

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,6 +98,8 @@ cargo clippy --fix --allow-dirty --allow-staged --all-targets --locked -- -D war
 
 When writing complex features or significant refactors, use an ExecPlan (as described in .agent/PLANS.md) from design to implementation.
 
+When using OpenSpec to manage a change, an ExecPlan is not required.
+
 Store all ExecPlan files in `.agent/plans/`. Name each file with a `yyyymmdd-` prefix (the creation date) followed by a short kebab-case description of the task (e.g. `.agent/plans/20251001-add-auth-flow.md`). Always use the creation date, even for long-running tasks.
 
 Each milestone commit must include the ExecPlan file with that milestone's checkbox and "plan updated" sub-task checked off, and any new discoveries recorded in the Surprises & Discoveries section. Do not batch plan updates across milestones.


### PR DESCRIPTION
## Summary

- clarify that changes managed with OpenSpec do not require an ExecPlan

## Testing

- not run (documentation-only change)