### PR TITLE
Bulk update Books during author merge

### DIFF
--- a/e2e/tests/graphql_authors.rs
+++ b/e2e/tests/graphql_authors.rs
@@ -123,7 +123,29 @@ async fn e2e_graphql_merge_author_moves_books_and_returns_destination() -> Resul
     let (_user_id, token) = create_test_user().await?;
     let source_id = create_test_author("Merge Source", &token).await?;
     let destination_id = create_test_author("Merge Destination", &token).await?;
-    let book_id = create_test_book("Merged Book", &source_id, &token).await?;
+    let book1_id = create_test_book("Merged Book 1", &source_id, &token).await?;
+    let book2_id = create_test_book("Merged Book 2", &source_id, &token).await?;
+    let create_shared_book = format!(
+        r#"mutation {{
+            createBook(bookData: {{
+                title: "Merged Book With Destination"
+                authorIds: ["{}", "{}"]
+                isbn: ""
+                read: false
+                owned: false
+                priority: 50
+                format: E_BOOK
+                store: KINDLE
+            }}) {{ book {{ id }} }}
+        }}"#,
+        source_id, destination_id
+    );
+    let (_, response) = graphql_request(&create_shared_book, Some(&token)).await?;
+    assert_no_graphql_errors(&response, "create merge book with destination");
+    let shared_book_id = response["data"]["createBook"]["book"]["id"]
+        .as_str()
+        .context("shared merge book id should be a string")?
+        .to_owned();
 
     let mutation = format!(
         r#"mutation {{ mergeAuthor(sourceAuthorId: "{}", destinationAuthorId: "{}") {{ author {{ id name books {{ id }} }} eventSetId }} }}"#,
@@ -136,11 +158,21 @@ async fn e2e_graphql_merge_author_moves_books_and_returns_destination() -> Resul
         payload["author"]["id"].as_str(),
         Some(destination_id.as_str())
     );
+    let merged_book_ids: std::collections::HashSet<&str> = payload["author"]["books"]
+        .as_array()
+        .context("merged destination books should be an array")?
+        .iter()
+        .filter_map(|book| book["id"].as_str())
+        .collect();
     assert_eq!(
-        payload["author"]["books"][0]["id"].as_str(),
-        Some(book_id.as_str())
+        merged_book_ids,
+        [&*book1_id, &*book2_id, &*shared_book_id]
+            .into_iter()
+            .collect()
     );
-    assert!(payload["eventSetId"].as_str().is_some());
+    let event_set_id = payload["eventSetId"]
+        .as_str()
+        .context("merge should return eventSetId")?;
     assert!(payload.get("eventId").is_none());
 
     let query = format!(
@@ -150,11 +182,52 @@ async fn e2e_graphql_merge_author_moves_books_and_returns_destination() -> Resul
     let (_, response) = graphql_request(&query, Some(&token)).await?;
     assert!(response["data"]["source"].is_null());
     assert_eq!(
-        response["data"]["destination"]["books"][0]["id"].as_str(),
-        Some(book_id.as_str())
+        response["data"]["destination"]["books"]
+            .as_array()
+            .unwrap()
+            .len(),
+        3
     );
 
-    delete_test_book(&book_id, &token).await?;
+    let event_set_query = format!(
+        r#"{{ eventSet(id: "{}") {{
+            operation
+            bookEvents {{ bookId operation authorIds }}
+            authorEvents {{ authorId operation extra }}
+        }} }}"#,
+        event_set_id
+    );
+    let (_, response) = graphql_request(&event_set_query, Some(&token)).await?;
+    assert_no_graphql_errors(&response, "merge event set");
+    let event_set = &response["data"]["eventSet"];
+    assert_eq!(event_set["operation"].as_str(), Some("merge_author"));
+    let book_events = event_set["bookEvents"]
+        .as_array()
+        .context("merge book events should be an array")?;
+    assert_eq!(book_events.len(), 3);
+    for event in book_events {
+        assert_eq!(event["operation"].as_str(), Some("update"));
+        assert_eq!(
+            event["authorIds"].as_array().unwrap(),
+            &[serde_json::Value::String(destination_id.clone())]
+        );
+    }
+    let author_events = event_set["authorEvents"]
+        .as_array()
+        .context("merge author events should be an array")?;
+    assert_eq!(author_events.len(), 2);
+    assert!(author_events.iter().any(|event| {
+        event["authorId"].as_str() == Some(source_id.as_str())
+            && event["operation"].as_str() == Some("delete")
+    }));
+    assert!(author_events.iter().any(|event| {
+        event["authorId"].as_str() == Some(destination_id.as_str())
+            && event["operation"].as_str() == Some("merge_as_destination")
+    }));
+
+    for book_id in [&book1_id, &book2_id, &shared_book_id] {
+        delete_test_book(book_id, &token).await?;
+    }
     delete_test_author(&destination_id, &token).await?;
     Ok(())
 }

--- a/openspec/changes/bulk-update-books-in-merge-author/.openspec.yaml
+++ b/openspec/changes/bulk-update-books-in-merge-author/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-23

--- a/openspec/changes/bulk-update-books-in-merge-author/design.md
+++ b/openspec/changes/bulk-update-books-in-merge-author/design.md
@@ -1,0 +1,93 @@
+## Context
+
+`mergeAuthor` locks Books before Authors to remain compatible with the lock
+order used by concurrent Book updates. It then rewrites each Book through the
+domain entity and calls the single-entity repository update once per Book.
+That repository call performs separate statements for the Book row,
+`book_author`, `book_event`, and `book_event_author`, so the merge's SQL round
+trips scale linearly with the number of affected Books.
+
+The existing `create_all()` implementation demonstrates the project's UNNEST
+pattern for bulk Book and event persistence. All writes must remain within the
+use-case-owned transaction and use its user and event-set identifiers.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Persist multiple updated Book aggregates with set-based SQL and a nearly
+  fixed number of database round trips.
+- Produce the same live Book state and one equivalent update event per Book.
+- Preserve tenant isolation, transaction atomicity, and the Book-to-Author lock
+  ordering used by `mergeAuthor`.
+- Treat an empty input as a successful no-op.
+
+**Non-Goals:**
+
+- Changing Author merge rules, Author merge events, Book event semantics, the
+  GraphQL API, or `eventSetId` handling.
+- Adding a merge-specific repository method.
+- Changing the `book_author` primary key or introducing repository-level
+  uniqueness rules.
+- Replacing `Book::update()` with infrastructure-side domain mutation.
+
+## Decisions
+
+### Add a general `BookRepository::update_all()` operation
+
+The trait will accept a transaction and a slice of fully updated Book entities.
+`mergeAuthor` will mutate all fetched entities with `Book::update()` before one
+call to this method. The existing `update()` remains the path for ordinary
+single-Book mutations. A merge-specific operation was rejected because it
+would couple persistence to one use case and blur the domain/persistence
+boundary.
+
+### Use fixed-count, set-based statements
+
+Rust will flatten Book fields and final `(book_id, author_id)` relationships
+into arrays. PostgreSQL UNNEST inputs will drive:
+
+1. one user-scoped Book UPDATE that leaves `created_at` unchanged;
+2. one user-scoped DELETE of relationships absent from the final state;
+3. one INSERT of final relationships with `ON CONFLICT DO NOTHING`;
+4. one bulk INSERT of update event snapshots returning `(event_id, book_id)`;
+5. one bulk INSERT of event-author snapshots.
+
+Empty relationship arrays will still allow the DELETE to remove every author
+from a targeted Book, while relationship and event-author INSERTs may be
+skipped when there is nothing to insert. Loops may prepare arrays but must not
+execute SQL per Book.
+
+### Validate ownership before dependent writes
+
+The Book UPDATE is scoped by both Book id and the transaction's user id. Its
+affected-row count will be compared with the number of distinct input Books.
+Any mismatch returns the same kind of not-found domain failure as a
+single-entity update before relationship or event writes proceed. The enclosing
+transaction ensures callers can roll back all earlier statements if any later
+statement fails.
+
+### Build event-author inputs from returned event identifiers
+
+The event INSERT returns `(event_id, book_id)`. Rust maps each final
+relationship to its Book's event id, then inserts all event-author rows with
+one UNNEST statement. This explicitly snapshots the supplied aggregate state
+and avoids depending on later reads of live relationship rows.
+
+### Preserve existing database uniqueness
+
+The existing `(user_id, book_id, author_id)` primary key remains authoritative.
+The bulk relationship INSERT uses conflict-ignore behavior so a destination
+relationship already present during a merge is a normal condition.
+
+## Risks / Trade-offs
+
+- [Parallel arrays can become misaligned] → Build every field array from the
+  same ordered Book slice and cover multi-Book, distinct-value cases in tests.
+- [Duplicate Book ids would make affected-row validation ambiguous] → Treat
+  input cardinality as distinct aggregate identity and reject an affected-row
+  mismatch; normal use cases provide unique Books from repository reads.
+- [Later bulk statements can fail after live rows change] → Keep every
+  statement on the supplied transaction so rollback restores atomicity.
+- [Bulk SQL is more complex than single-row SQL] → Mirror `create_all()` and
+  assert live relationships and event snapshots in repository tests.

--- a/openspec/changes/bulk-update-books-in-merge-author/proposal.md
+++ b/openspec/changes/bulk-update-books-in-merge-author/proposal.md
@@ -1,0 +1,38 @@
+## Why
+
+`mergeAuthor` currently persists each affected Book through a separate
+`BookRepository::update()` call. Because each update writes the Book, its author
+relationships, and its event snapshot, SQL round trips grow with the number of
+Books linked to the source Author.
+
+## What Changes
+
+- Add a general-purpose `BookRepository::update_all()` operation that persists
+  multiple already-updated Book entities with set-based SQL.
+- Change `mergeAuthor` to continue applying `Book::update()` to every affected
+  Book, then persist all Books with one repository call.
+- Bulk-update Book rows, synchronize `book_author`, create one update event per
+  Book, and record each event's final author snapshot.
+- Preserve the existing merge behavior, lock order, event semantics, GraphQL
+  contract, and database uniqueness constraints.
+- Define an empty bulk update as a successful no-op.
+
+## Capabilities
+
+### New Capabilities
+
+- `bulk-book-update`: Persist multiple updated Book aggregates and their update
+  events using a number of SQL round trips that does not grow with the Book
+  count.
+
+### Modified Capabilities
+
+- None.
+
+## Impact
+
+- Domain repository contract: `src/domain/repository/book_repository.rs`
+- PostgreSQL persistence: `src/infrastructure/book_repository.rs`
+- Author merge orchestration: `src/use_case/interactor/author.rs`
+- Repository, use-case, database integration, and regression tests
+- No GraphQL schema, response, dependency, or database schema change

--- a/openspec/changes/bulk-update-books-in-merge-author/specs/bulk-book-update/spec.md
+++ b/openspec/changes/bulk-update-books-in-merge-author/specs/bulk-book-update/spec.md
@@ -1,0 +1,61 @@
+## ADDED Requirements
+
+### Requirement: Bulk Book updates preserve aggregate state
+The system SHALL persist every supplied updated Book's scalar fields and final
+author relationships in one transaction, scoped to the transaction's user,
+without changing Book creation timestamps.
+
+#### Scenario: Multiple Books have distinct final states
+- **WHEN** multiple updated Books with different scalar fields and author sets are persisted together
+- **THEN** each Book and its author relationships match that Book's supplied final state
+
+#### Scenario: A Book has no final authors
+- **WHEN** a targeted Book is bulk-updated with an empty author set
+- **THEN** all existing author relationships for that Book are removed
+
+#### Scenario: A relationship already exists
+- **WHEN** a supplied final author relationship already exists in `book_author`
+- **THEN** the update succeeds and exactly one relationship remains under the existing primary key constraint
+
+#### Scenario: Input is empty
+- **WHEN** no Books are supplied to the bulk update
+- **THEN** the operation succeeds without changing persistent state or recording events
+
+#### Scenario: A Book is not owned by the transaction user
+- **WHEN** the bulk update includes a Book not owned by the transaction user
+- **THEN** the operation fails without changing that Book or creating dependent relationship or event records for it
+
+### Requirement: Bulk Book updates record equivalent events
+The system SHALL record one `update` Book event for every successfully updated
+Book using the transaction's event set and the Book's supplied post-update
+snapshot, including its final author identifiers.
+
+#### Scenario: Multiple Book update events are recorded
+- **WHEN** multiple Books are successfully persisted together
+- **THEN** each Book has one update event in the same event set with scalar and author snapshots matching its final state
+
+#### Scenario: A Book event has no authors
+- **WHEN** a successfully updated Book has an empty final author set
+- **THEN** its update event is recorded without `book_event_author` rows
+
+### Requirement: Bulk persistence uses set-based database operations
+The system SHALL persist Book rows, relationships, Book events, and event-author
+snapshots without executing a database statement once per supplied Book.
+
+#### Scenario: The number of Books increases
+- **WHEN** the bulk update receives more Books
+- **THEN** SQL round trips for the update remain bounded by the fixed bulk persistence stages rather than increasing per Book
+
+### Requirement: Author merge uses bulk Book persistence
+The system SHALL continue to apply `Book::update()` to each Book linked to the
+source Author and SHALL persist the resulting Book collection through one
+general bulk repository call while retaining the existing Book-before-Author
+lock order.
+
+#### Scenario: Source Books are merged into a destination Author
+- **WHEN** an Author with multiple linked Books is merged into a different Author
+- **THEN** every Book removes the source Author, contains the destination Author exactly once, and is included in one bulk persistence call
+
+#### Scenario: The source Author has no Books
+- **WHEN** an Author with no linked Books is merged
+- **THEN** one empty bulk persistence call succeeds and the existing Author merge behavior continues

--- a/openspec/changes/bulk-update-books-in-merge-author/tasks.md
+++ b/openspec/changes/bulk-update-books-in-merge-author/tasks.md
@@ -23,4 +23,4 @@
 - [x] 4.2 Run repository, use-case, integration, and E2E tests
 - [x] 4.3 Run `cargo fmt --check`, `cargo clippy --all-targets --locked -- -D warnings`, and `cargo test --locked`
 - [x] 4.4 Commit the completed change in logical increments, push the branch, and open a PR with the requested design and performance summary
-- [ ] 4.5 Monitor PR CI, fix change-related failures, and confirm the PR is review-ready
+- [x] 4.5 Monitor PR CI, fix change-related failures, and confirm the PR is review-ready

--- a/openspec/changes/bulk-update-books-in-merge-author/tasks.md
+++ b/openspec/changes/bulk-update-books-in-merge-author/tasks.md
@@ -1,0 +1,26 @@
+## 1. Repository Contract and Persistence
+
+- [x] 1.1 Add the general `BookRepository::update_all()` contract, including the successful empty-slice behavior
+- [x] 1.2 Implement user-scoped set-based Book row updates with affected-row validation
+- [x] 1.3 Implement set-based final `book_author` synchronization, including empty author sets and conflict-safe inserts
+- [x] 1.4 Bulk-create one update event per Book and bulk-create final event-author snapshots
+
+## 2. Author Merge Integration
+
+- [x] 2.1 Update `AuthorCommandInteractor::merge()` to mutate every Book through `Book::update()` and call `update_all()` once without changing lock order
+- [x] 2.2 Update merge use-case tests for one bulk call, final author sets, multiple Books, and the empty collection
+
+## 3. Persistence and Regression Tests
+
+- [x] 3.1 Add repository tests for multi-Book scalar updates, relationship add/remove/replace/conflict behavior, events, and empty input
+- [x] 3.2 Add repository coverage for user isolation and transaction rollback on a bulk failure
+- [x] 3.3 Add or extend real-database merge coverage for multiple Books, pre-existing destination relationships, Book snapshots, Author merge events, and one event set
+- [x] 3.4 Assess E2E coverage and add only the minimum regression scenario if existing tests do not cover the critical multi-Book merge behavior
+
+## 4. Validation and Delivery
+
+- [x] 4.1 Verify `update_all()` contains no per-Book SQL execution and reconcile implementation details with the OpenSpec artifacts
+- [x] 4.2 Run repository, use-case, integration, and E2E tests
+- [x] 4.3 Run `cargo fmt --check`, `cargo clippy --all-targets --locked -- -D warnings`, and `cargo test --locked`
+- [ ] 4.4 Commit the completed change in logical increments, push the branch, and open a PR with the requested design and performance summary
+- [ ] 4.5 Monitor PR CI, fix change-related failures, and confirm the PR is review-ready

--- a/openspec/changes/bulk-update-books-in-merge-author/tasks.md
+++ b/openspec/changes/bulk-update-books-in-merge-author/tasks.md
@@ -22,5 +22,5 @@
 - [x] 4.1 Verify `update_all()` contains no per-Book SQL execution and reconcile implementation details with the OpenSpec artifacts
 - [x] 4.2 Run repository, use-case, integration, and E2E tests
 - [x] 4.3 Run `cargo fmt --check`, `cargo clippy --all-targets --locked -- -D warnings`, and `cargo test --locked`
-- [ ] 4.4 Commit the completed change in logical increments, push the branch, and open a PR with the requested design and performance summary
+- [x] 4.4 Commit the completed change in logical increments, push the branch, and open a PR with the requested design and performance summary
 - [ ] 4.5 Monitor PR CI, fix change-related failures, and confirm the PR is review-ready

--- a/src/domain/repository/book_repository.rs
+++ b/src/domain/repository/book_repository.rs
@@ -50,6 +50,11 @@ pub trait BookRepository: Send + Sync + 'static {
     ) -> Result<Vec<Book>, DomainError>;
     async fn update(&self, tx: &mut Self::Transaction, book: &Book)
     -> Result<EventId, DomainError>;
+    async fn update_all(
+        &self,
+        tx: &mut Self::Transaction,
+        books: &[Book],
+    ) -> Result<(), DomainError>;
     async fn delete(&self, tx: &mut Self::Transaction, book_id: &BookId)
     -> Result<(), DomainError>;
     // Upserts or deletes the entity and records a restore event in one transaction.

--- a/src/infrastructure/book_repository.rs
+++ b/src/infrastructure/book_repository.rs
@@ -665,6 +665,172 @@ impl BookRepository for PgBookRepository {
         Ok(EventId::from(event_id))
     }
 
+    async fn update_all(
+        &self,
+        tx: &mut Self::Transaction,
+        books: &[Book],
+    ) -> Result<(), DomainError> {
+        if books.is_empty() {
+            return Ok(());
+        }
+
+        let user_id = tx.user_id().clone();
+        let ids: Vec<Uuid> = books.iter().map(|book| book.id().to_uuid()).collect();
+        let titles: Vec<&str> = books.iter().map(|book| book.title().as_str()).collect();
+        let isbns: Vec<&str> = books.iter().map(|book| book.isbn().as_str()).collect();
+        let reads: Vec<bool> = books.iter().map(|book| book.read().to_bool()).collect();
+        let owneds: Vec<bool> = books.iter().map(|book| book.owned().to_bool()).collect();
+        let priorities: Vec<i32> = books.iter().map(|book| book.priority().to_i32()).collect();
+        let formats: Vec<String> = books.iter().map(|book| book.format().to_string()).collect();
+        let stores: Vec<String> = books.iter().map(|book| book.store().to_string()).collect();
+        let created_ats: Vec<OffsetDateTime> =
+            books.iter().map(|book| *book.created_at()).collect();
+        let updated_ats: Vec<OffsetDateTime> =
+            books.iter().map(|book| *book.updated_at()).collect();
+
+        let result = sqlx::query(
+            "UPDATE book
+             SET title = input.title,
+                 isbn = input.isbn,
+                 read = input.read,
+                 owned = input.owned,
+                 priority = input.priority,
+                 format = input.format,
+                 store = input.store,
+                 updated_at = input.updated_at
+             FROM UNNEST(
+               $2::uuid[], $3::text[], $4::text[], $5::bool[], $6::bool[],
+               $7::int4[], $8::text[], $9::text[], $10::timestamptz[]
+             ) AS input(id, title, isbn, read, owned, priority, format, store,
+                        updated_at)
+             WHERE book.user_id = $1 AND book.id = input.id",
+        )
+        .bind(user_id.as_str())
+        .bind(&ids)
+        .bind(&titles)
+        .bind(&isbns)
+        .bind(&reads)
+        .bind(&owneds)
+        .bind(&priorities)
+        .bind(&formats)
+        .bind(&stores)
+        .bind(&updated_ats)
+        .execute(tx.as_mut())
+        .await?;
+
+        if result.rows_affected() != books.len() as u64 {
+            let book = &books[0];
+            return Err(DomainError::NotFound {
+                entity_type: "book",
+                entity_id: book.id().to_string(),
+                user_id: user_id.into_string(),
+            });
+        }
+
+        let relationships: Vec<(Uuid, Uuid)> = books
+            .iter()
+            .flat_map(|book| {
+                book.author_ids()
+                    .iter()
+                    .map(move |author_id| (book.id().to_uuid(), author_id.to_uuid()))
+            })
+            .collect();
+        let relationship_book_ids: Vec<Uuid> =
+            relationships.iter().map(|(book_id, _)| *book_id).collect();
+        let author_ids: Vec<Uuid> = relationships
+            .iter()
+            .map(|(_, author_id)| *author_id)
+            .collect();
+
+        sqlx::query(
+            "DELETE FROM book_author existing
+             WHERE existing.user_id = $1
+               AND existing.book_id = ANY($2::uuid[])
+               AND NOT EXISTS (
+                 SELECT 1
+                 FROM UNNEST($3::uuid[], $4::uuid[])
+                   AS final(book_id, author_id)
+                 WHERE final.book_id = existing.book_id
+                   AND final.author_id = existing.author_id
+               )",
+        )
+        .bind(user_id.as_str())
+        .bind(&ids)
+        .bind(&relationship_book_ids)
+        .bind(&author_ids)
+        .execute(tx.as_mut())
+        .await?;
+
+        if !relationships.is_empty() {
+            sqlx::query(
+                "INSERT INTO book_author (user_id, book_id, author_id)
+                 SELECT $1, book_id, author_id
+                 FROM UNNEST($2::uuid[], $3::uuid[]) AS input(book_id, author_id)
+                 ON CONFLICT DO NOTHING",
+            )
+            .bind(user_id.as_str())
+            .bind(&relationship_book_ids)
+            .bind(&author_ids)
+            .execute(tx.as_mut())
+            .await?;
+        }
+
+        let events: Vec<(i64, Uuid)> = sqlx::query_as(
+            "INSERT INTO book_event
+               (event_set_id, operation, book_id, user_id, title, isbn, read,
+                owned, priority, format, store, book_created_at, book_updated_at)
+             SELECT $1, 'update', id, $2, title, isbn, read, owned, priority,
+                    format, store, created_at, updated_at
+             FROM UNNEST(
+               $3::uuid[], $4::text[], $5::text[], $6::bool[], $7::bool[],
+               $8::int4[], $9::text[], $10::text[], $11::timestamptz[],
+               $12::timestamptz[]
+             ) AS input(id, title, isbn, read, owned, priority, format, store,
+                        created_at, updated_at)
+             RETURNING event_id, book_id",
+        )
+        .bind(tx.event_set_id())
+        .bind(user_id.as_str())
+        .bind(&ids)
+        .bind(&titles)
+        .bind(&isbns)
+        .bind(&reads)
+        .bind(&owneds)
+        .bind(&priorities)
+        .bind(&formats)
+        .bind(&stores)
+        .bind(&created_ats)
+        .bind(&updated_ats)
+        .fetch_all(tx.as_mut())
+        .await?;
+        let event_by_book: HashMap<Uuid, i64> = events
+            .into_iter()
+            .map(|(event_id, book_id)| (book_id, event_id))
+            .collect();
+
+        if !relationships.is_empty() {
+            let event_ids: Vec<i64> = relationship_book_ids
+                .iter()
+                .map(|book_id| {
+                    event_by_book.get(book_id).copied().ok_or_else(|| {
+                        DomainError::Unexpected(format!("missing event for book {book_id}"))
+                    })
+                })
+                .collect::<Result<_, _>>()?;
+            sqlx::query(
+                "INSERT INTO book_event_author (event_id, author_id)
+                 SELECT event_id, author_id
+                 FROM UNNEST($1::bigint[], $2::uuid[]) AS input(event_id, author_id)",
+            )
+            .bind(&event_ids)
+            .bind(&author_ids)
+            .execute(tx.as_mut())
+            .await?;
+        }
+
+        Ok(())
+    }
+
     async fn delete(
         &self,
         tx: &mut Self::Transaction,
@@ -1187,6 +1353,184 @@ mod tests {
 
         let actual = book_repository.find_by_id(&user_id, book.id()).await?;
         assert_eq!(actual, Some(book.clone()));
+
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn test_update_all_persists_books_relationships_and_events(
+        pool: PgPool,
+    ) -> anyhow::Result<()> {
+        let user_repository = PgUserRepository::new(pool.clone());
+        let author_repository = PgAuthorRepository::new(pool.clone());
+        let book_repository = PgBookRepository::new(pool.clone());
+        let user_id = prepare_user(&user_repository, "user1").await?;
+        let mut author_ids = prepare_authors1(&pool, &user_id, &author_repository).await?;
+        author_ids.extend(prepare_authors2(&pool, &user_id, &author_repository).await?);
+
+        let mut book1 = book_entity1(&author_ids[..2])?;
+        let mut book2 = book_entity2(&author_ids[2..])?;
+        create_book(&pool, &book_repository, &user_id, &book1).await?;
+        create_book(&pool, &book_repository, &user_id, &book2).await?;
+
+        let book1_created_at = *book1.created_at();
+        let updated_at = PrimitiveDateTime::new(date!(2026 - 08 - 23), time!(12:34)).assume_utc();
+        book1.update(
+            BookUpdate {
+                title: BookTitle::new("bulk title 1".to_owned())?,
+                author_ids: vec![author_ids[1].clone(), author_ids[2].clone()],
+                isbn: Isbn::new("3333333333333".to_owned())?,
+                read: ReadFlag::new(true),
+                owned: OwnedFlag::new(true),
+                priority: Priority::new(10)?,
+                format: BookFormat::Printed,
+                store: BookStore::Unknown,
+            },
+            updated_at,
+        );
+        book2.update(
+            BookUpdate {
+                title: BookTitle::new("bulk title 2".to_owned())?,
+                author_ids: vec![],
+                isbn: book2.isbn().clone(),
+                read: book2.read().clone(),
+                owned: book2.owned().clone(),
+                priority: book2.priority().clone(),
+                format: book2.format().clone(),
+                store: book2.store().clone(),
+            },
+            updated_at,
+        );
+
+        let tm = PgTransactionManager::new(pool.clone());
+        let mut tx = tm.begin(&user_id, EventSetOperation::MergeAuthor).await?;
+        let event_set_id = tx.event_set_id();
+        book_repository
+            .update_all(&mut tx, &[book1.clone(), book2.clone()])
+            .await?;
+        tm.commit(tx).await?;
+
+        assert_eq!(
+            book_repository.find_by_id(&user_id, book1.id()).await?,
+            Some(book1.clone())
+        );
+        assert_eq!(
+            book_repository.find_by_id(&user_id, book2.id()).await?,
+            Some(book2.clone())
+        );
+        let (created_at,): (OffsetDateTime,) =
+            sqlx::query_as("SELECT created_at FROM book WHERE user_id = $1 AND id = $2")
+                .bind(user_id.as_str())
+                .bind(book1.id().to_uuid())
+                .fetch_one(&pool)
+                .await?;
+        assert_eq!(created_at, book1_created_at);
+
+        let events: Vec<(i64, Uuid, String, OffsetDateTime)> = sqlx::query_as(
+            "SELECT event_id, book_id, title, book_updated_at
+             FROM book_event
+             WHERE event_set_id = $1 AND operation = 'update'
+             ORDER BY book_id",
+        )
+        .bind(event_set_id)
+        .fetch_all(&pool)
+        .await?;
+        assert_eq!(events.len(), 2);
+        for (event_id, book_id, title, event_updated_at) in events {
+            let expected = if book_id == book1.id().to_uuid() {
+                &book1
+            } else {
+                &book2
+            };
+            assert_eq!(title, expected.title().as_str());
+            assert_eq!(event_updated_at, *expected.updated_at());
+            let event_author_ids: Vec<Uuid> = sqlx::query_scalar(
+                "SELECT author_id FROM book_event_author WHERE event_id = $1 ORDER BY author_id",
+            )
+            .bind(event_id)
+            .fetch_all(&pool)
+            .await?;
+            let mut expected_author_ids: Vec<Uuid> = expected
+                .author_ids()
+                .iter()
+                .map(AuthorId::to_uuid)
+                .collect();
+            expected_author_ids.sort_unstable();
+            assert_eq!(event_author_ids, expected_author_ids);
+        }
+
+        let event_count_before: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM book_event")
+            .fetch_one(&pool)
+            .await?;
+        let mut tx = tm.begin(&user_id, EventSetOperation::MergeAuthor).await?;
+        book_repository.update_all(&mut tx, &[]).await?;
+        tm.commit(tx).await?;
+        let event_count_after: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM book_event")
+            .fetch_one(&pool)
+            .await?;
+        assert_eq!(event_count_after, event_count_before);
+
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn test_update_all_wrong_user_rolls_back_partial_update(
+        pool: PgPool,
+    ) -> anyhow::Result<()> {
+        let user_repository = PgUserRepository::new(pool.clone());
+        let author_repository = PgAuthorRepository::new(pool.clone());
+        let book_repository = PgBookRepository::new(pool.clone());
+        let user1_id = prepare_user(&user_repository, "user1").await?;
+        let user2_id = prepare_user(&user_repository, "user2").await?;
+        let user1_authors = prepare_authors1(&pool, &user1_id, &author_repository).await?;
+        let user2_authors = prepare_authors2(&pool, &user2_id, &author_repository).await?;
+        let mut user1_book = book_entity1(&user1_authors)?;
+        let user2_book = book_entity2(&user2_authors)?;
+        create_book(&pool, &book_repository, &user1_id, &user1_book).await?;
+        create_book(&pool, &book_repository, &user2_id, &user2_book).await?;
+
+        user1_book.update(
+            BookUpdate {
+                title: BookTitle::new("must roll back".to_owned())?,
+                author_ids: user1_book.author_ids().to_vec(),
+                isbn: user1_book.isbn().clone(),
+                read: user1_book.read().clone(),
+                owned: user1_book.owned().clone(),
+                priority: user1_book.priority().clone(),
+                format: user1_book.format().clone(),
+                store: user1_book.store().clone(),
+            },
+            OffsetDateTime::now_utc(),
+        );
+
+        {
+            let tm = PgTransactionManager::new(pool.clone());
+            let mut tx = tm.begin(&user1_id, EventSetOperation::MergeAuthor).await?;
+            let result = book_repository
+                .update_all(&mut tx, &[user1_book, user2_book.clone()])
+                .await;
+            assert!(matches!(result, Err(DomainError::NotFound { .. })));
+        }
+
+        let persisted = book_repository
+            .find_by_id(
+                &user1_id,
+                &BookId::try_from("675bc8d9-3155-42fb-87b0-0a82cb162848")?,
+            )
+            .await?
+            .unwrap();
+        assert_eq!(persisted.title().as_str(), "title1");
+        assert_eq!(
+            book_repository
+                .find_by_id(&user2_id, user2_book.id())
+                .await?,
+            Some(user2_book)
+        );
+        let update_event_count: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM book_event WHERE operation = 'update'")
+                .fetch_one(&pool)
+                .await?;
+        assert_eq!(update_event_count, 0);
 
         Ok(())
     }

--- a/src/use_case/interactor/author.rs
+++ b/src/use_case/interactor/author.rs
@@ -148,7 +148,7 @@ where
         // Book updates lock their Book row before book_author inserts acquire
         // foreign-key locks on Author rows. Merge uses the same Book -> Author
         // order to avoid a deadlock cycle with a concurrent updateBook.
-        let books = self
+        let mut books = self
             .book_repository
             .find_by_author_id_with_tx(&mut tx, &user_id, &source_id)
             .await?;
@@ -185,7 +185,7 @@ where
             )
         };
 
-        for mut book in books {
+        for book in &mut books {
             let mut author_ids: Vec<_> = book
                 .author_ids()
                 .iter()
@@ -208,8 +208,8 @@ where
                 },
                 OffsetDateTime::now_utc(),
             );
-            self.book_repository.update(&mut tx, &book).await?;
         }
+        self.book_repository.update_all(&mut tx, &books).await?;
 
         self.author_repository
             .delete(
@@ -1065,6 +1065,11 @@ mod tests {
             .times(2)
             .in_sequence(&mut sequence)
             .returning(move |_, _, _| Ok(Some(locked.next().unwrap())));
+        book_repository
+            .expect_update_all()
+            .withf(|_, books| books.is_empty())
+            .times(1)
+            .returning(|_, _| Ok(()));
         author_repository
             .expect_delete()
             .withf(move |_, author_id, extra| {
@@ -1193,19 +1198,28 @@ mod tests {
         let expected_destination = destination_author_id.clone();
         let expected_other = other_id.clone();
         book_repository
-            .expect_update()
-            .times(2)
-            .withf(move |_, book| {
-                !book.author_ids().contains(&expected_source)
-                    && book
-                        .author_ids()
+            .expect_update_all()
+            .times(1)
+            .withf(move |_, books| {
+                books.len() == 2
+                    && books.iter().all(|book| {
+                        !book.author_ids().contains(&expected_source)
+                            && book
+                                .author_ids()
+                                .iter()
+                                .filter(|id| *id == &expected_destination)
+                                .count()
+                                == 1
+                            && book.author_ids().contains(&expected_other)
+                    })
+                    && books
                         .iter()
-                        .filter(|id| *id == &expected_destination)
-                        .count()
-                        == 1
-                    && book.author_ids().contains(&expected_other)
+                        .any(|book| book.title().as_str() == "Needs destination")
+                    && books
+                        .iter()
+                        .any(|book| book.title().as_str() == "Already has destination")
             })
-            .returning(|_, _| Ok(1.into()));
+            .returning(|_, _| Ok(()));
         let mut event_repository = MockAuthorEventRepository::new();
         event_repository
             .expect_append()


### PR DESCRIPTION
## Background

`mergeAuthor` executed `BookRepository::update()` once for every Book linked to the source Author.

## Problem

Each Book update writes `book`, `book_author`, `book_event`, and `book_event_author`, so SQL round trips grew in proportion to the number of Books being merged.

## Changes

- Add the general-purpose `BookRepository::update_all()` API.
- Continue updating every entity through `Book::update()` in the use-case layer.
- Persist Book rows, Book-author relationships, Book events, and event-author snapshots with set-based bulk SQL in `PgBookRepository`.
- Call `update_all()` once from `mergeAuthor` while preserving the existing Book-to-Author lock order.
- Add OpenSpec artifacts and repository, use-case, integration, and E2E regression coverage.

## Design decisions

- Keep the repository API general instead of adding a merge-specific method, preserving the boundary between domain operations and persistence optimization.
- Continue relying on the existing `(user_id, book_id, author_id)` primary key for `book_author` uniqueness.
- Treat an already-linked destination Author as normal by using conflict-safe bulk inserts.
- Validate the user-scoped Book UPDATE count before writing relationships and events.
- Preserve the existing GraphQL contract, Author merge events, Book update event semantics, and `eventSetId` behavior.

## Tests

- `cargo fmt --check`
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo test --locked` (136 tests)
- `DATABASE_URL=postgres://bookshelf:password@localhost:5432/bookshelf cargo test --locked --features test-with-database --lib` (202 tests)
- `TEST_SERVER_URL=http://localhost:8080 cargo test -p bookshelf-e2e --locked -- --test-threads=1` (43 tests)
- `openspec validate bulk-update-books-in-merge-author --type change --strict`

## Performance

The update-related SQL round trips that previously scaled with Book count are reduced to a nearly fixed set of bulk statements: one Book UPDATE, relationship DELETE/INSERT, event INSERT, and event-author INSERT.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 著者のマージ時に、複数の書籍をまとめて移行できるようになりました。
  - 移行元と移行先で共有されている書籍も、重複なく移行されます。
  - 書籍・著者の変更イベントが、マージ結果に応じて正しく記録されます。

- **改善**
  - 書籍がない著者のマージも正常に完了します。
  - マージ処理中に問題が発生した場合、関連する変更がまとめて取り消されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->