### PR TITLE
Add book import preview

### DIFF
--- a/docs/architecture/event-recording.md
+++ b/docs/architecture/event-recording.md
@@ -27,6 +27,13 @@ the user from the transaction opened by `begin`; callers do not pass a second
 repositories (e.g. the bulk import composes `BookRepository` and
 `AuthorRepository`) inside one transaction.
 
+`previewBookImport` deliberately follows the same author, book, relationship,
+and event write path as `importBooks`, then consumes the transaction through
+`TransactionManager::rollback`. The shared path must therefore contain no
+transaction-external side effects. Validation remains before `begin`, and an
+execution error leaves the uncommitted sqlx transaction to roll back on drop;
+successful preview execution always uses explicit rollback.
+
 The use-case layer knows two event concepts: the `EventSetOperation` passed
 to `begin`, and the generated `event_set.id` exposed by the transaction so
 mutation results can return an `eventSetId` after a successful commit. Event

--- a/docs/architecture/event-recording.md
+++ b/docs/architecture/event-recording.md
@@ -27,13 +27,6 @@ the user from the transaction opened by `begin`; callers do not pass a second
 repositories (e.g. the bulk import composes `BookRepository` and
 `AuthorRepository`) inside one transaction.
 
-`previewBookImport` deliberately follows the same author, book, relationship,
-and event write path as `importBooks`, then consumes the transaction through
-`TransactionManager::rollback`. The shared path must therefore contain no
-transaction-external side effects. Validation remains before `begin`, and an
-execution error leaves the uncommitted sqlx transaction to roll back on drop;
-successful preview execution always uses explicit rollback.
-
 The use-case layer knows two event concepts: the `EventSetOperation` passed
 to `begin`, and the generated `event_set.id` exposed by the transaction so
 mutation results can return an `eventSetId` after a successful commit. Event

--- a/e2e/tests/graphql_import.rs
+++ b/e2e/tests/graphql_import.rs
@@ -743,14 +743,45 @@ async fn e2e_preview_book_import_rolls_back_and_can_then_import() -> Result<()> 
         "preview must leave DB unchanged"
     );
 
-    let import = preview
-        .replace("previewBookImport", "importBooks")
-        .replace("authors { name status }", "authors { name }")
-        .replace(
-            "                    title\n                    authors",
-            "                    id\n                    title\n                    authors",
-        );
-    let (_, imported) = graphql_request(&import, Some(&token)).await?;
+    let import = r#"
+        mutation {
+            importBooks(books: [
+                {
+                    title: "Preview One"
+                    authorNames: ["Preview Existing", "Preview New", "Preview New"]
+                    isbn: ""
+                    read: true
+                    owned: false
+                    priority: 42
+                    format: E_BOOK
+                    store: KINDLE
+                },
+                {
+                    title: "Preview Two"
+                    authorNames: ["Preview New"]
+                    isbn: ""
+                    read: false
+                    owned: true
+                    priority: 7
+                    format: PRINTED
+                    store: UNKNOWN
+                }
+            ]) {
+                books {
+                    id
+                    title
+                    authors { name }
+                    isbn
+                    read
+                    owned
+                    priority
+                    format
+                    store
+                }
+            }
+        }
+    "#;
+    let (_, imported) = graphql_request(import, Some(&token)).await?;
     assert_no_graphql_errors(&imported, "importBooks after preview");
     let imported_books = imported["data"]["importBooks"]["books"]
         .as_array()

--- a/e2e/tests/graphql_import.rs
+++ b/e2e/tests/graphql_import.rs
@@ -676,3 +676,122 @@ async fn e2e_import_books_empty_returns_error() -> Result<()> {
 
     Ok(())
 }
+
+#[tokio::test]
+#[serial]
+async fn e2e_preview_book_import_rolls_back_and_can_then_import() -> Result<()> {
+    let (_user_id, token) = create_test_user().await?;
+    let existing_author_id = create_test_author("Preview Existing", &token).await?;
+    let before_query = "{ books { id } authors { id } eventSets { id } }";
+    let (_, before) = graphql_request(before_query, Some(&token)).await?;
+
+    let preview = r#"
+        mutation {
+            previewBookImport(books: [
+                {
+                    title: "Preview One"
+                    authorNames: ["Preview Existing", "Preview New", "Preview New"]
+                    isbn: ""
+                    read: true
+                    owned: false
+                    priority: 42
+                    format: E_BOOK
+                    store: KINDLE
+                },
+                {
+                    title: "Preview Two"
+                    authorNames: ["Preview New"]
+                    isbn: ""
+                    read: false
+                    owned: true
+                    priority: 7
+                    format: PRINTED
+                    store: UNKNOWN
+                }
+            ]) {
+                books {
+                    title
+                    authors { name status }
+                    isbn
+                    read
+                    owned
+                    priority
+                    format
+                    store
+                }
+            }
+        }
+    "#;
+    let (_, response) = graphql_request(preview, Some(&token)).await?;
+    assert_no_graphql_errors(&response, "previewBookImport");
+    let books = response["data"]["previewBookImport"]["books"]
+        .as_array()
+        .context("preview books should be an array")?;
+    assert_eq!(books.len(), 2);
+    assert_eq!(books[0]["title"], "Preview One");
+    let authors = books[0]["authors"]
+        .as_array()
+        .context("preview authors should be an array")?;
+    assert_eq!(authors.len(), 2, "duplicate author names are normalized");
+    assert_eq!(authors[0]["status"], "EXISTING");
+    assert_eq!(authors[1]["status"], "NEW");
+    assert_eq!(books[1]["authors"][0]["status"], "NEW");
+
+    let (_, after) = graphql_request(before_query, Some(&token)).await?;
+    assert_eq!(
+        after["data"], before["data"],
+        "preview must leave DB unchanged"
+    );
+
+    let import = preview
+        .replace("previewBookImport", "importBooks")
+        .replace("authors { name status }", "authors { name }")
+        .replace(
+            "                    title\n                    authors",
+            "                    id\n                    title\n                    authors",
+        );
+    let (_, imported) = graphql_request(&import, Some(&token)).await?;
+    assert_no_graphql_errors(&imported, "importBooks after preview");
+    let imported_books = imported["data"]["importBooks"]["books"]
+        .as_array()
+        .context("imported books should be an array")?;
+    assert_eq!(imported_books.len(), 2);
+    for book in imported_books {
+        delete_test_book(
+            book["id"]
+                .as_str()
+                .context("imported book id should exist")?,
+            &token,
+        )
+        .await?;
+    }
+    let (_, authors_response) = graphql_request("{ authors { id name } }", Some(&token)).await?;
+    if let Some(new_author) = authors_response["data"]["authors"]
+        .as_array()
+        .and_then(|authors| {
+            authors
+                .iter()
+                .find(|author| author["name"] == "Preview New")
+        })
+    {
+        delete_test_author(
+            new_author["id"]
+                .as_str()
+                .context("new author id should exist")?,
+            &token,
+        )
+        .await?;
+    }
+    delete_test_author(&existing_author_id, &token).await?;
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
+async fn e2e_preview_book_import_empty_returns_error() -> Result<()> {
+    let (_user_id, token) = create_test_user().await?;
+    let query = "mutation { previewBookImport(books: []) { books { title } } }";
+    let (_, response) = graphql_request(query, Some(&token)).await?;
+    assert_graphql_errors(&response, "previewBookImport with empty list");
+    Ok(())
+}

--- a/openspec/changes/add-book-import-preview/.openspec.yaml
+++ b/openspec/changes/add-book-import-preview/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-23

--- a/openspec/changes/add-book-import-preview/design.md
+++ b/openspec/changes/add-book-import-preview/design.md
@@ -1,0 +1,131 @@
+## Context
+
+`importBooks` currently validates and maps the complete batch before opening a
+write transaction, then bulk-resolves authors, builds books, bulk-persists books
+and events, and commits one `ImportBooks` event set. PostgreSQL transactions
+roll back on drop, but `TransactionManager` exposes only `begin` and `commit`.
+The bulk author repository returns only name-to-ID mappings, so callers cannot
+tell which inserts won `ON CONFLICT DO NOTHING`.
+
+The preview must be as faithful as an import: it must execute repository writes,
+event recording, and database constraints. It must also preserve the existing
+rule that invalid input does not begin a transaction and must not expose IDs for
+rows that are deliberately rolled back.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Add a GraphQL `previewBookImport` mutation using `ImportBookInput`.
+- Share validation, author resolution, book construction, persistence, and
+  event recording between preview and import.
+- Explicitly roll back a successful preview and leave all import tables
+  unchanged.
+- Return only preview books and per-book author `EXISTING`/`NEW` status.
+- Preserve bounded bulk SQL, validation semantics, the import contract, and
+  event recording.
+
+**Non-Goals:**
+
+- Reserving preview results or guaranteeing a later import has identical author
+  statuses.
+- Adding `dryRun` to `importBooks`, a preview token, locks, or a preview-specific
+  event-set operation.
+- Returning book, author, event, event-set, or timestamp identifiers.
+- Adding transaction-external notifications, files, messages, or other side
+  effects.
+
+## Decisions
+
+### Expose preview as a dedicated Mutation
+
+The schema adds `previewBookImport(books: [ImportBookInput!]!)` to Mutation.
+Although successful execution leaves no final database state, it performs
+inserts and event recording before rollback. Mutation makes that write-capable
+execution explicit and keeps write dependencies in `BookCommandUseCase`.
+
+Alternatives considered were a `dryRun` flag, which would complicate the
+existing import contract, and Query, which would conceal a write transaction
+behind read semantics.
+
+### Use one prepared and transactional import execution path
+
+Both operations use the same preparation/validation routine before `begin`,
+preserving the existing no-transaction-on-validation-error behavior. Both then
+invoke one private transactional `execute_import` routine that bulk-resolves
+authors, removes duplicate author names per book, constructs books, and calls
+`create_all`, including all author/book/event writes. The execution result owns
+the generated domain books plus resolved author names and creation statuses;
+presentation DTOs are derived afterward.
+
+The only transaction-terminal difference is that import reads the event-set ID
+and commits, while preview builds its ID-free DTO and rolls back. Copying the
+repository path or using a preview-only lookup was rejected because either can
+drift from import behavior and the latter adds queries.
+
+### Return creation metadata from bulk author resolution
+
+`find_or_create_by_names` returns resolved name/ID values plus the set of IDs
+inserted by its existing bulk `INSERT ... RETURNING` statement. The subsequent
+bulk lookup remains unchanged, so statement count stays bounded. Duplicate
+input names are normalized before this repository method, as today.
+
+A preliminary `find_by_names` was rejected because it adds a query, can race
+with the insert, and does not describe what the actual find-or-create operation
+created.
+
+### Add explicit rollback at the transaction boundary
+
+`TransactionManager::rollback` consumes its transaction, and
+`PgTransactionManager` delegates to `sqlx::Transaction::rollback`. A successful
+preview always calls it. If transactional execution fails, the uncommitted
+transaction is dropped and sqlx performs rollback, preserving the original
+execution error. If explicit rollback after successful execution fails, that
+rollback/database error is returned because the preview cannot assert that its
+cleanup completed. There is no second meaningful rollback error to combine
+with an execution error under the consuming transaction API.
+
+Concrete sqlx transaction operations remain outside the use-case layer.
+
+### Treat preview output as advisory and ID-free
+
+The response contains book fields and ordered, de-duplicated authors with
+`EXISTING` or `NEW`. If one newly inserted author appears in several input
+books, every occurrence is `NEW` because all refer to the creation performed by
+that preview transaction. IDs and timestamps are omitted because their rows do
+not survive rollback and generated values are execution-time details.
+
+Preview and import are separate transactions. A concurrent write can change a
+later import's author resolution; the import always re-executes against current
+state. No reservation or locking is introduced.
+
+### Require transaction-contained side effects
+
+The shared execution path currently performs only writes through repositories
+using the supplied transaction. This is a required invariant for rollback-based
+preview: future external API calls, queue publishing, email, file writes,
+out-of-transaction persistence, or irreversible audit operations must not be
+added to it without redesigning preview semantics.
+
+## Risks / Trade-offs
+
+- **Preview performs real write work and can be expensive** → Keep the existing
+  1,000-book limit and bounded bulk statements; clearly expose it as Mutation.
+- **Preview can differ from a later import after concurrent changes** → Define
+  the response as advisory and always re-run import against current state.
+- **Rollback failure leaves outcome uncertain** → Return the database error and
+  never report a successful preview.
+- **Shared refactoring could alter existing import behavior** → Retain existing
+  regression tests and add unit/E2E parity checks around validation,
+  normalization, transaction boundaries, and event recording.
+
+## Migration Plan
+
+No schema migration is required. Deploy the additive GraphQL schema and server
+implementation together. Older clients remain compatible because
+`importBooks` is unchanged. Rollback is removing the new mutation and related
+code; no persisted preview data needs cleanup.
+
+## Open Questions
+
+None.

--- a/openspec/changes/add-book-import-preview/proposal.md
+++ b/openspec/changes/add-book-import-preview/proposal.md
@@ -1,0 +1,45 @@
+## Why
+
+Clients currently must execute `importBooks` to learn whether an import will
+succeed and which authors will be reused or created. A faithful preview is
+needed that exercises the same database-backed import path without leaving any
+persistent state.
+
+## What Changes
+
+- Add a `previewBookImport` GraphQL mutation accepting the existing
+  `ImportBookInput` list and returning preview books with per-author
+  `EXISTING` or `NEW` status.
+- Execute previews through the same validation, bulk author resolution, book
+  persistence, constraint, and event-recording path as `importBooks`, then
+  explicitly roll back the transaction.
+- Add explicit rollback support to the transaction abstraction and report
+  which authors a bulk find-or-create operation created without adding
+  per-author queries.
+- Preserve the existing `importBooks` input, output, event-recording, atomicity,
+  and batch-limit behavior.
+- Exclude generated book, author, and event identifiers and timestamps from the
+  preview contract because the corresponding rows do not survive rollback.
+- Document that preview results are advisory: a later import re-evaluates the
+  current database state and may observe concurrent changes.
+
+## Capabilities
+
+### New Capabilities
+- `book-import-preview`: Faithful rollback-based preview of bulk book imports,
+  including per-book author creation status and a no-persistent-state guarantee.
+
+### Modified Capabilities
+- `bulk-book-import`: Extend the bulk author-resolution contract to expose
+  created-versus-existing status while preserving bounded queries, and require
+  preview and import to share the same execution path.
+
+## Impact
+
+- GraphQL mutation schema and presentation objects for book import.
+- Book command use-case DTOs, transaction lifecycle, and shared import
+  execution logic.
+- `TransactionManager` and its PostgreSQL adapter gain explicit rollback.
+- Author repository bulk-resolution results include creation status.
+- Unit, repository/integration, schema, and GraphQL E2E coverage expand; no new
+  external dependency or transaction-external side effect is introduced.

--- a/openspec/changes/add-book-import-preview/specs/book-import-preview/spec.md
+++ b/openspec/changes/add-book-import-preview/specs/book-import-preview/spec.md
@@ -1,0 +1,75 @@
+## ADDED Requirements
+
+### Requirement: Clients can preview a book import
+The system SHALL expose a `previewBookImport` GraphQL mutation that accepts the
+same list of `ImportBookInput` values as `importBooks` and returns preview books
+without changing the `importBooks` contract.
+
+#### Scenario: Valid preview request
+- **WHEN** an authenticated client previews a valid non-empty book batch
+- **THEN** the response contains one preview book for each normalized imported book with its title, authors, ISBN, read flag, owned flag, priority, format, and store
+
+#### Scenario: Preview contract excludes transient identifiers
+- **WHEN** a preview succeeds
+- **THEN** its response contains no book ID, author ID, event ID, event-set ID, creation timestamp, or update timestamp
+
+### Requirement: Preview executes the real import path and rolls it back
+The system MUST run preview and import through the same validation, bulk author
+resolution, book construction, repository persistence, database constraints,
+and event-recording path, and MUST explicitly roll back a successfully executed
+preview transaction.
+
+#### Scenario: Preview reaches transactional persistence
+- **WHEN** valid input is previewed
+- **THEN** author, book, relationship, event-set, and entity-event writes execute inside one transaction using `ImportBooks` operation semantics before rollback
+
+#### Scenario: Database state is unchanged
+- **WHEN** a preview completes successfully
+- **THEN** no author, book, book-author relationship, event set, book event, author event, or related event relationship created by the preview remains in the database
+
+#### Scenario: Validation parity
+- **WHEN** preview and import receive the same empty, oversized, or invalid batch
+- **THEN** both reject it with the same validation semantics without beginning a transaction
+
+#### Scenario: Constraint parity
+- **WHEN** the shared persistence path violates a database constraint
+- **THEN** preview fails as import would and leaves no partial state
+
+#### Scenario: Rollback fails
+- **WHEN** successful preview execution is followed by a rollback failure
+- **THEN** the system returns the rollback database error and does not report a successful preview
+
+### Requirement: Preview reports author resolution status per book
+Each preview book SHALL contain its normalized authors in input order and SHALL
+label every author `EXISTING` when reused from pre-preview state or `NEW` when
+created by the preview transaction.
+
+#### Scenario: Existing and new authors are mixed
+- **WHEN** a book references one existing author and one previously unknown author
+- **THEN** that book reports the authors as `EXISTING` and `NEW` respectively
+
+#### Scenario: Duplicate author within one book
+- **WHEN** one book repeats the same author name
+- **THEN** the preview includes that author once, matching import relationship normalization
+
+#### Scenario: New author is shared across books
+- **WHEN** multiple preview books reference the same previously unknown author
+- **THEN** every one of those books reports that author as `NEW`
+
+### Requirement: Preview results are advisory
+The system SHALL evaluate every preview and import in its own transaction
+against the database state visible to that execution and SHALL NOT reserve or
+lock a preview result for a later import.
+
+#### Scenario: State changes between preview and import
+- **WHEN** an author reported as `NEW` by preview is created before the client runs import
+- **THEN** the later import reuses that now-existing author and succeeds according to its own transaction state
+
+### Requirement: Preview execution has no transaction-external side effects
+The shared import execution path used by preview MUST NOT perform external API
+calls, message publication, email, file writes, out-of-transaction database
+writes, external event publication, or irreversible audit writes.
+
+#### Scenario: Preview is rolled back
+- **WHEN** preview execution completes and its database transaction is rolled back
+- **THEN** no side effect from that execution survives outside the transaction

--- a/openspec/changes/add-book-import-preview/specs/bulk-book-import/spec.md
+++ b/openspec/changes/add-book-import-preview/specs/bulk-book-import/spec.md
@@ -1,0 +1,37 @@
+## MODIFIED Requirements
+
+### Requirement: Bulk author resolution preserves creation semantics
+The system MUST deduplicate requested author names, use the tenant-scoped
+author uniqueness constraint to insert missing authors, resolve all requested
+author IDs and created-versus-existing statuses in one lookup, and record an
+author event only for each author created by the import or preview execution.
+
+#### Scenario: Existing and new authors are mixed
+- **WHEN** an import or preview references both existing and previously unknown author names
+- **THEN** all names resolve to their tenant-scoped IDs and statuses and only newly inserted authors receive author events
+
+#### Scenario: Author names repeat
+- **WHEN** one author name occurs in multiple books or more than once in one book
+- **THEN** the name is resolved once and each book contains that author relationship at most once
+
+#### Scenario: Imports race to create an author
+- **WHEN** concurrent import executions request the same previously unknown tenant-scoped author name
+- **THEN** the database uniqueness constraint prevents duplicates and each execution resolves the surviving author ID with the status produced by its own find-or-create operation
+
+### Requirement: Bulk import remains atomic and compatible
+The system MUST preserve the existing `importBooks` GraphQL schema, validation,
+response semantics, 1,000-book limit, and single-transaction behavior while
+sharing its validation and transactional execution path with book import
+preview.
+
+#### Scenario: A bulk statement fails
+- **WHEN** any author, book, relationship, or event statement fails before commit
+- **THEN** the complete import is rolled back without partial rows
+
+#### Scenario: Validation fails
+- **WHEN** an import request violates an existing validation rule
+- **THEN** the system returns the existing validation error without beginning a transaction
+
+#### Scenario: Import succeeds after preview
+- **WHEN** a valid batch is previewed and then imported without intervening database changes
+- **THEN** `importBooks` commits the same normalized books and author relationships and returns its existing books and event-set payload

--- a/openspec/changes/add-book-import-preview/tasks.md
+++ b/openspec/changes/add-book-import-preview/tasks.md
@@ -1,28 +1,28 @@
 ## 1. Transaction and Author Resolution
 
-- [ ] 1.1 Add `TransactionManager::rollback`, implement PostgreSQL rollback, and cover commit, rollback, event-set cleanup, and error propagation
-- [ ] 1.2 Extend bulk author find-or-create results with created status while preserving bounded SQL and update repository tests for existing, new, mixed, duplicate, tenant, and rollback cases
+- [x] 1.1 Add `TransactionManager::rollback`, implement PostgreSQL rollback, and cover commit, rollback, event-set cleanup, and error propagation
+- [x] 1.2 Extend bulk author find-or-create results with created status while preserving bounded SQL and update repository tests for existing, new, mixed, duplicate, tenant, and rollback cases
 
 ## 2. Shared Import Execution
 
-- [ ] 2.1 Add internal import execution result and resolved-author status types without presentation dependencies
-- [ ] 2.2 Extract shared validation/preparation and transactional import execution from `importBooks`, preserving normalization, batch limits, event recording, and commit behavior
-- [ ] 2.3 Update and extend book interactor unit/integration tests for execution results, validations, repository calls, and import regressions
+- [x] 2.1 Add internal import execution result and resolved-author status types without presentation dependencies
+- [x] 2.2 Extract shared validation/preparation and transactional import execution from `importBooks`, preserving normalization, batch limits, event recording, and commit behavior
+- [x] 2.3 Update and extend book interactor unit/integration tests for execution results, validations, repository calls, and import regressions
 
 ## 3. Preview Use Case
 
-- [ ] 3.1 Add ID-free preview DTOs and `BookCommandUseCase::preview_import`
-- [ ] 3.2 Implement preview through the shared import path with explicit rollback and no commit
-- [ ] 3.3 Add preview unit tests for author statuses, DTO conversion, validation/execution failures, rollback success, and rollback failure
+- [x] 3.1 Add ID-free preview DTOs and `BookCommandUseCase::preview_import`
+- [x] 3.2 Implement preview through the shared import path with explicit rollback and no commit
+- [x] 3.3 Add preview unit tests for author statuses, DTO conversion, validation/execution failures, rollback success, and rollback failure
 
 ## 4. GraphQL API
 
-- [ ] 4.1 Add preview GraphQL objects and author-status enum using the existing `ImportBookInput`
-- [ ] 4.2 Add authenticated `previewBookImport` Mutation resolver and update generated schema artifacts if present
-- [ ] 4.3 Add GraphQL E2E coverage for successful fields, statuses, normalization, unchanged database state, later import, validation parity, and constraint parity where reproducible
+- [x] 4.1 Add preview GraphQL objects and author-status enum using the existing `ImportBookInput`
+- [x] 4.2 Add authenticated `previewBookImport` Mutation resolver and update generated schema artifacts if present
+- [x] 4.3 Add GraphQL E2E coverage for successful fields, statuses, normalization, unchanged database state, later import, validation parity, and constraint parity where reproducible
 
 ## 5. Verification and Delivery
 
-- [ ] 5.1 Verify the shared execution path has no transaction-external side effects and update architecture documentation or comments with the rollback-preview invariant
+- [x] 5.1 Verify the shared execution path has no transaction-external side effects and update architecture documentation or comments with the rollback-preview invariant
 - [ ] 5.2 Run formatting, clippy, locked unit/integration tests, and the complete E2E suite; inspect the final diff and confirm OpenSpec alignment
 - [ ] 5.3 Commit logical changes, push the feature branch, create the PR against `main`, inspect the PR diff, and confirm CI starts and passes

--- a/openspec/changes/add-book-import-preview/tasks.md
+++ b/openspec/changes/add-book-import-preview/tasks.md
@@ -24,5 +24,5 @@
 ## 5. Verification and Delivery
 
 - [x] 5.1 Verify the shared execution path has no transaction-external side effects and update architecture documentation or comments with the rollback-preview invariant
-- [ ] 5.2 Run formatting, clippy, locked unit/integration tests, and the complete E2E suite; inspect the final diff and confirm OpenSpec alignment
+- [x] 5.2 Run formatting, clippy, locked unit/integration tests, and the complete E2E suite; inspect the final diff and confirm OpenSpec alignment
 - [ ] 5.3 Commit logical changes, push the feature branch, create the PR against `main`, inspect the PR diff, and confirm CI starts and passes

--- a/openspec/changes/add-book-import-preview/tasks.md
+++ b/openspec/changes/add-book-import-preview/tasks.md
@@ -1,0 +1,28 @@
+## 1. Transaction and Author Resolution
+
+- [ ] 1.1 Add `TransactionManager::rollback`, implement PostgreSQL rollback, and cover commit, rollback, event-set cleanup, and error propagation
+- [ ] 1.2 Extend bulk author find-or-create results with created status while preserving bounded SQL and update repository tests for existing, new, mixed, duplicate, tenant, and rollback cases
+
+## 2. Shared Import Execution
+
+- [ ] 2.1 Add internal import execution result and resolved-author status types without presentation dependencies
+- [ ] 2.2 Extract shared validation/preparation and transactional import execution from `importBooks`, preserving normalization, batch limits, event recording, and commit behavior
+- [ ] 2.3 Update and extend book interactor unit/integration tests for execution results, validations, repository calls, and import regressions
+
+## 3. Preview Use Case
+
+- [ ] 3.1 Add ID-free preview DTOs and `BookCommandUseCase::preview_import`
+- [ ] 3.2 Implement preview through the shared import path with explicit rollback and no commit
+- [ ] 3.3 Add preview unit tests for author statuses, DTO conversion, validation/execution failures, rollback success, and rollback failure
+
+## 4. GraphQL API
+
+- [ ] 4.1 Add preview GraphQL objects and author-status enum using the existing `ImportBookInput`
+- [ ] 4.2 Add authenticated `previewBookImport` Mutation resolver and update generated schema artifacts if present
+- [ ] 4.3 Add GraphQL E2E coverage for successful fields, statuses, normalization, unchanged database state, later import, validation parity, and constraint parity where reproducible
+
+## 5. Verification and Delivery
+
+- [ ] 5.1 Verify the shared execution path has no transaction-external side effects and update architecture documentation or comments with the rollback-preview invariant
+- [ ] 5.2 Run formatting, clippy, locked unit/integration tests, and the complete E2E suite; inspect the final diff and confirm OpenSpec alignment
+- [ ] 5.3 Commit logical changes, push the feature branch, create the PR against `main`, inspect the PR diff, and confirm CI starts and passes

--- a/openspec/changes/add-book-import-preview/tasks.md
+++ b/openspec/changes/add-book-import-preview/tasks.md
@@ -25,4 +25,4 @@
 
 - [x] 5.1 Verify the shared execution path has no transaction-external side effects and update architecture documentation or comments with the rollback-preview invariant
 - [x] 5.2 Run formatting, clippy, locked unit/integration tests, and the complete E2E suite; inspect the final diff and confirm OpenSpec alignment
-- [ ] 5.3 Commit logical changes, push the feature branch, create the PR against `main`, inspect the PR diff, and confirm CI starts and passes
+- [x] 5.3 Commit logical changes, push the feature branch, create the PR against `main`, inspect the PR diff, and confirm CI starts and passes

--- a/schema.graphql
+++ b/schema.graphql
@@ -126,6 +126,16 @@ type EventSetEntry {
 	createdAt: Int!
 }
 
+type ImportAuthorPreview {
+	name: String!
+	status: ImportAuthorStatus!
+}
+
+enum ImportAuthorStatus {
+	EXISTING
+	NEW
+}
+
 input ImportBookInput {
 	"""
 	Title of the book.
@@ -161,9 +171,24 @@ input ImportBookInput {
 	store: BookStore!
 }
 
+type ImportBookPreview {
+	title: String!
+	authors: [ImportAuthorPreview!]!
+	isbn: String!
+	read: Boolean!
+	owned: Boolean!
+	priority: Int!
+	format: BookFormat!
+	store: BookStore!
+}
+
 type ImportBooksPayload {
 	books: [Book!]!
 	eventSetId: ID!
+}
+
+type ImportBooksPreview {
+	books: [ImportBookPreview!]!
 }
 
 """
@@ -191,6 +216,10 @@ type Mutation {
 	Imports multiple books. Creates authors if they do not exist.
 	"""
 	importBooks(books: [ImportBookInput!]!): ImportBooksPayload!
+	"""
+	Executes the book import path and rolls the complete transaction back.
+	"""
+	previewBookImport(books: [ImportBookInput!]!): ImportBooksPreview!
 }
 
 type Query {

--- a/src/domain/repository/author_repository.rs
+++ b/src/domain/repository/author_repository.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use async_trait::async_trait;
 use mockall::automock;
@@ -16,6 +16,27 @@ use crate::domain::{
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DeleteAuthorEventExtra {
     Merge { destination_author_id: AuthorId },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FindOrCreateAuthorsResult {
+    pub authors_by_name: HashMap<String, AuthorId>,
+    pub created_author_ids: HashSet<AuthorId>,
+}
+
+impl From<HashMap<String, AuthorId>> for FindOrCreateAuthorsResult {
+    fn from(authors_by_name: HashMap<String, AuthorId>) -> Self {
+        Self {
+            authors_by_name,
+            created_author_ids: HashSet::new(),
+        }
+    }
+}
+
+impl FromIterator<(String, AuthorId)> for FindOrCreateAuthorsResult {
+    fn from_iter<T: IntoIterator<Item = (String, AuthorId)>>(iter: T) -> Self {
+        HashMap::from_iter(iter).into()
+    }
 }
 
 #[automock(type Transaction = ();)]
@@ -58,7 +79,7 @@ pub trait AuthorRepository: Send + Sync + 'static {
         tx: &mut Self::Transaction,
         names: &[AuthorName],
         created_at: OffsetDateTime,
-    ) -> Result<HashMap<String, AuthorId>, DomainError>;
+    ) -> Result<FindOrCreateAuthorsResult, DomainError>;
     async fn update(
         &self,
         tx: &mut Self::Transaction,

--- a/src/domain/repository/author_repository.rs
+++ b/src/domain/repository/author_repository.rs
@@ -24,6 +24,8 @@ pub struct FindOrCreateAuthorsResult {
     pub created_author_ids: HashSet<AuthorId>,
 }
 
+/// Builds a resolved-author result in which no authors were newly created.
+/// `created_author_ids` is always empty.
 impl From<HashMap<String, AuthorId>> for FindOrCreateAuthorsResult {
     fn from(authors_by_name: HashMap<String, AuthorId>) -> Self {
         Self {
@@ -33,6 +35,8 @@ impl From<HashMap<String, AuthorId>> for FindOrCreateAuthorsResult {
     }
 }
 
+/// Collects resolved authors into a result in which no authors were newly
+/// created. `created_author_ids` is always empty.
 impl FromIterator<(String, AuthorId)> for FindOrCreateAuthorsResult {
     fn from_iter<T: IntoIterator<Item = (String, AuthorId)>>(iter: T) -> Self {
         HashMap::from_iter(iter).into()

--- a/src/domain/repository/transaction.rs
+++ b/src/domain/repository/transaction.rs
@@ -31,4 +31,6 @@ pub trait TransactionManager: Send + Sync + 'static {
     ) -> Result<Self::Transaction, DomainError>;
 
     async fn commit(&self, tx: Self::Transaction) -> Result<(), DomainError>;
+
+    async fn rollback(&self, tx: Self::Transaction) -> Result<(), DomainError>;
 }

--- a/src/infrastructure/author_repository.rs
+++ b/src/infrastructure/author_repository.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use async_trait::async_trait;
 use futures_util::{StreamExt, TryStreamExt};
@@ -14,7 +14,9 @@ use crate::domain::{
         user::UserId,
     },
     error::DomainError,
-    repository::author_repository::{AuthorRepository, DeleteAuthorEventExtra},
+    repository::author_repository::{
+        AuthorRepository, DeleteAuthorEventExtra, FindOrCreateAuthorsResult,
+    },
 };
 use crate::infrastructure::transaction::PgTransaction;
 
@@ -180,9 +182,12 @@ impl AuthorRepository for PgAuthorRepository {
         tx: &mut Self::Transaction,
         names: &[AuthorName],
         created_at: OffsetDateTime,
-    ) -> Result<HashMap<String, AuthorId>, DomainError> {
+    ) -> Result<FindOrCreateAuthorsResult, DomainError> {
         if names.is_empty() {
-            return Ok(HashMap::new());
+            return Ok(FindOrCreateAuthorsResult {
+                authors_by_name: HashMap::new(),
+                created_author_ids: HashSet::new(),
+            });
         }
 
         let user_id = tx.user_id().clone();
@@ -248,10 +253,19 @@ impl AuthorRepository for PgAuthorRepository {
             )));
         }
 
-        Ok(resolved
+        let created_author_ids = created
+            .into_iter()
+            .map(|author| AuthorId::new(author.id))
+            .collect();
+        let authors_by_name = resolved
             .into_iter()
             .map(|(id, name)| (name, AuthorId::new(id)))
-            .collect())
+            .collect();
+
+        Ok(FindOrCreateAuthorsResult {
+            authors_by_name,
+            created_author_ids,
+        })
     }
 
     async fn find_by_id(
@@ -1363,6 +1377,53 @@ mod tests {
         assert_eq!(found.created_at(), &OffsetDateTime::UNIX_EPOCH);
         assert_eq!(found.updated_at(), &OffsetDateTime::UNIX_EPOCH);
 
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn find_or_create_by_names_reports_created_ids_and_rolls_back(
+        pool: PgPool,
+    ) -> anyhow::Result<()> {
+        let user_repository = PgUserRepository::new(pool.clone());
+        let author_repository = PgAuthorRepository::new(pool.clone());
+        let user_id = prepare_user(&user_repository, "bulk-status-user").await?;
+        let existing_id = AuthorId::new(Uuid::new_v4());
+        let existing = new_author(
+            existing_id.clone(),
+            AuthorName::new("Existing".to_string())?,
+        )?;
+        create_author(&pool, &author_repository, &user_id, &existing).await?;
+
+        let manager = PgTransactionManager::new(pool.clone());
+        let mut tx = manager
+            .begin(&user_id, EventSetOperation::ImportBooks)
+            .await?;
+        let names = vec![
+            AuthorName::new("Existing".to_string())?,
+            AuthorName::new("New".to_string())?,
+        ];
+        let result = author_repository
+            .find_or_create_by_names(&mut tx, &names, OffsetDateTime::now_utc())
+            .await?;
+
+        assert_eq!(result.authors_by_name["Existing"], existing_id);
+        assert!(!result.created_author_ids.contains(&existing_id));
+        let new_id = result.authors_by_name["New"].clone();
+        assert!(result.created_author_ids.contains(&new_id));
+        manager.rollback(tx).await?;
+
+        assert!(
+            author_repository
+                .find_by_id(&user_id, &new_id)
+                .await?
+                .is_none()
+        );
+        assert!(
+            author_repository
+                .find_by_id(&user_id, &existing_id)
+                .await?
+                .is_some()
+        );
         Ok(())
     }
 }

--- a/src/infrastructure/transaction.rs
+++ b/src/infrastructure/transaction.rs
@@ -48,6 +48,11 @@ impl PgTransaction {
         self.tx.commit().await?;
         Ok(())
     }
+
+    pub async fn rollback(self) -> Result<(), DomainError> {
+        self.tx.rollback().await?;
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -89,5 +94,67 @@ impl TransactionManager for PgTransactionManager {
 
     async fn commit(&self, tx: Self::Transaction) -> Result<(), DomainError> {
         tx.commit().await
+    }
+
+    async fn rollback(&self, tx: Self::Transaction) -> Result<(), DomainError> {
+        tx.rollback().await
+    }
+}
+
+#[cfg(all(test, feature = "test-with-database"))]
+mod tests {
+    use sqlx::PgPool;
+
+    use crate::{
+        domain::{
+            entity::{
+                event::EventSetOperation,
+                user::{User, UserId},
+            },
+            repository::{transaction::TransactionManager, user_repository::UserRepository},
+        },
+        infrastructure::{transaction::PgTransactionManager, user_repository::PgUserRepository},
+    };
+
+    async fn user(pool: &PgPool) -> anyhow::Result<UserId> {
+        let id = UserId::new("transaction-user".to_string())?;
+        PgUserRepository::new(pool.clone())
+            .create(&User::new(id.clone()))
+            .await?;
+        Ok(id)
+    }
+
+    #[sqlx::test]
+    async fn rollback_removes_event_set(pool: PgPool) -> anyhow::Result<()> {
+        let user_id = user(&pool).await?;
+        let manager = PgTransactionManager::new(pool.clone());
+        let tx = manager
+            .begin(&user_id, EventSetOperation::ImportBooks)
+            .await?;
+        manager.rollback(tx).await?;
+
+        let (count,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM event_set WHERE user_id = $1")
+            .bind(user_id.as_str())
+            .fetch_one(&pool)
+            .await?;
+        assert_eq!(count, 0);
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn commit_keeps_event_set(pool: PgPool) -> anyhow::Result<()> {
+        let user_id = user(&pool).await?;
+        let manager = PgTransactionManager::new(pool.clone());
+        let tx = manager
+            .begin(&user_id, EventSetOperation::ImportBooks)
+            .await?;
+        manager.commit(tx).await?;
+
+        let (count,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM event_set WHERE user_id = $1")
+            .bind(user_id.as_str())
+            .fetch_one(&pool)
+            .await?;
+        assert_eq!(count, 1);
+        Ok(())
     }
 }

--- a/src/presentation/graphql/mutation.rs
+++ b/src/presentation/graphql/mutation.rs
@@ -12,8 +12,8 @@ use crate::{
 use super::object::{
     Author, AuthorMutationPayload, Book, BookMutationPayload, CreateAuthorInput, CreateBookInput,
     DeleteAuthorPayload, DeleteBookPayload, ImportBookInput, ImportBooksPayload,
-    MergeAuthorPayload, RestoreAuthorPayload, RestoreBookPayload, UpdateAuthorInput,
-    UpdateBookInput, User,
+    ImportBooksPreview, MergeAuthorPayload, RestoreAuthorPayload, RestoreBookPayload,
+    UpdateAuthorInput, UpdateBookInput, User,
 };
 
 pub struct Mutation<UC, BC, AC> {
@@ -222,6 +222,20 @@ where
             books: books.value.into_iter().map(Book::from).collect(),
             event_set_id: ID(books.event_set_id),
         })
+    }
+
+    /// Executes the book import path and rolls the complete transaction back.
+    async fn preview_book_import(
+        &self,
+        ctx: &Context<'_>,
+        books: Vec<ImportBookInput>,
+    ) -> Result<ImportBooksPreview, PresentationalError> {
+        let claims = get_claims(ctx)?;
+        Ok(self
+            .book_command
+            .preview_import(&claims.sub, books.into_iter().map(Into::into).collect())
+            .await?
+            .into())
     }
 }
 

--- a/src/presentation/graphql/object.rs
+++ b/src/presentation/graphql/object.rs
@@ -7,7 +7,10 @@ use time::OffsetDateTime;
 use crate::common::types::{BookFormat as CommonBookFormat, BookStore as CommonBookStore};
 use crate::dependency_injection::{AQ, BQ};
 use crate::use_case::dto::author::{AuthorDto, CreateAuthorDto, UpdateAuthorDto};
-use crate::use_case::dto::book::{BookDto, CreateBookDto, ImportBookEntryDto, UpdateBookDto};
+use crate::use_case::dto::book::{
+    BookDto, CreateBookDto, ImportAuthorPreviewDto, ImportAuthorStatus as ImportAuthorStatusDto,
+    ImportBookEntryDto, ImportBookPreviewDto, ImportBooksPreviewDto, UpdateBookDto,
+};
 use crate::use_case::dto::event::{AuthorEventDto, BookEventDto};
 use crate::use_case::dto::event_set::{EventSetDetailDto, EventSetDto};
 
@@ -535,6 +538,80 @@ pub struct DeleteAuthorPayload {
 pub struct ImportBooksPayload {
     pub books: Vec<Book>,
     pub event_set_id: ID,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Enum)]
+pub enum ImportAuthorStatus {
+    Existing,
+    New,
+}
+
+impl From<ImportAuthorStatusDto> for ImportAuthorStatus {
+    fn from(status: ImportAuthorStatusDto) -> Self {
+        match status {
+            ImportAuthorStatusDto::Existing => Self::Existing,
+            ImportAuthorStatusDto::New => Self::New,
+        }
+    }
+}
+
+#[derive(SimpleObject)]
+pub struct ImportAuthorPreview {
+    pub name: String,
+    pub status: ImportAuthorStatus,
+}
+
+impl From<ImportAuthorPreviewDto> for ImportAuthorPreview {
+    fn from(dto: ImportAuthorPreviewDto) -> Self {
+        Self {
+            name: dto.name,
+            status: dto.status.into(),
+        }
+    }
+}
+
+#[derive(SimpleObject)]
+pub struct ImportBookPreview {
+    pub title: String,
+    pub authors: Vec<ImportAuthorPreview>,
+    pub isbn: String,
+    pub read: bool,
+    pub owned: bool,
+    pub priority: i32,
+    pub format: BookFormat,
+    pub store: BookStore,
+}
+
+impl From<ImportBookPreviewDto> for ImportBookPreview {
+    fn from(dto: ImportBookPreviewDto) -> Self {
+        Self {
+            title: dto.title,
+            authors: dto
+                .authors
+                .into_iter()
+                .map(ImportAuthorPreview::from)
+                .collect(),
+            isbn: dto.isbn,
+            read: dto.read,
+            owned: dto.owned,
+            priority: dto.priority,
+            format: dto.format.into(),
+            store: dto.store.into(),
+        }
+    }
+}
+
+#[derive(SimpleObject)]
+pub struct ImportBooksPreview {
+    pub books: Vec<ImportBookPreview>,
+}
+
+impl From<ImportBooksPreviewDto> for ImportBooksPreview {
+    fn from(dto: ImportBooksPreviewDto) -> Self {
+        Self {
+            books: dto.books.into_iter().map(Into::into).collect(),
+        }
+    }
 }
 
 #[derive(SimpleObject)]

--- a/src/use_case/dto/book.rs
+++ b/src/use_case/dto/book.rs
@@ -170,6 +170,35 @@ pub struct ImportBookEntryDto {
     pub store: BookStore,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ImportAuthorStatus {
+    Existing,
+    New,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ImportAuthorPreviewDto {
+    pub name: String,
+    pub status: ImportAuthorStatus,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ImportBookPreviewDto {
+    pub title: String,
+    pub authors: Vec<ImportAuthorPreviewDto>,
+    pub isbn: String,
+    pub read: bool,
+    pub owned: bool,
+    pub priority: i32,
+    pub format: BookFormat,
+    pub store: BookStore,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ImportBooksPreviewDto {
+    pub books: Vec<ImportBookPreviewDto>,
+}
+
 impl UpdateBookDto {
     #[allow(clippy::too_many_arguments)]
     pub fn new(

--- a/src/use_case/interactor/book.rs
+++ b/src/use_case/interactor/book.rs
@@ -23,7 +23,11 @@ use crate::{
     },
     use_case::{
         dto::{
-            book::{BookDto, CreateBookDto, ImportBookEntryDto, TimeInfo, UpdateBookDto},
+            book::{
+                BookDto, CreateBookDto, ImportAuthorPreviewDto, ImportAuthorStatus,
+                ImportBookEntryDto, ImportBookPreviewDto, ImportBooksPreviewDto, TimeInfo,
+                UpdateBookDto,
+            },
             mutation::{
                 BookMutationResultDto, DeleteBookResultDto, ImportBooksResultDto,
                 MutationResultDto, SingleEventMutationResultDto,
@@ -118,6 +122,11 @@ struct ImportBookInput {
     updated_at: OffsetDateTime,
 }
 
+struct ImportExecutionResult {
+    books: Vec<Book>,
+    previews: Vec<ImportBookPreviewDto>,
+}
+
 pub struct BookCommandInteractor<BR, AR, BER, TM> {
     book_repository: BR,
     author_repository: AR,
@@ -138,6 +147,135 @@ impl<BR, AR, BER, TM> BookCommandInteractor<BR, AR, BER, TM> {
             book_event_repository,
             transaction_manager,
         }
+    }
+}
+
+impl<BR, AR, BER, TM> BookCommandInteractor<BR, AR, BER, TM>
+where
+    TM: TransactionManager,
+    BR: BookRepository<Transaction = TM::Transaction>,
+    AR: AuthorRepository<Transaction = TM::Transaction>,
+{
+    fn prepare_import(
+        books: Vec<ImportBookEntryDto>,
+    ) -> Result<Vec<ImportBookInput>, UseCaseError> {
+        if books.is_empty() {
+            return Err(UseCaseError::Validation(
+                "books cannot be empty".to_string(),
+            ));
+        }
+        if books.len() > MAX_BOOK_BATCH {
+            return Err(UseCaseError::Validation(format!(
+                "books cannot exceed {MAX_BOOK_BATCH}"
+            )));
+        }
+
+        let now = OffsetDateTime::now_utc();
+        books
+            .into_iter()
+            .map(|dto| {
+                Ok(ImportBookInput {
+                    book_id: BookId::new(Uuid::new_v4())?,
+                    title: BookTitle::new(dto.title)?,
+                    author_names: dto
+                        .author_names
+                        .into_iter()
+                        .map(AuthorName::new)
+                        .collect::<Result<_, DomainError>>()?,
+                    isbn: Isbn::new(dto.isbn)?,
+                    read: ReadFlag::new(dto.read),
+                    owned: OwnedFlag::new(dto.owned),
+                    priority: Priority::new(dto.priority)?,
+                    format: dto.format,
+                    store: dto.store,
+                    created_at: now,
+                    updated_at: now,
+                })
+            })
+            .collect()
+    }
+
+    async fn execute_import(
+        &self,
+        tx: &mut TM::Transaction,
+        inputs: Vec<ImportBookInput>,
+    ) -> Result<ImportExecutionResult, UseCaseError> {
+        // This shared path must contain only writes scoped to `tx`: preview
+        // relies on rollback to undo every author, book, relationship, and event.
+        let mut seen_author_names = HashSet::new();
+        let unique_author_names: Vec<AuthorName> = inputs
+            .iter()
+            .flat_map(|input| input.author_names.iter())
+            .filter(|name| seen_author_names.insert(name.as_str().to_owned()))
+            .cloned()
+            .collect();
+        let resolved = self
+            .author_repository
+            .find_or_create_by_names(tx, &unique_author_names, inputs[0].created_at)
+            .await?;
+
+        let mut books = Vec::with_capacity(inputs.len());
+        let mut previews = Vec::with_capacity(inputs.len());
+        for input in inputs {
+            let mut seen_names = HashSet::new();
+            let authors = input
+                .author_names
+                .iter()
+                .filter(|name| seen_names.insert(name.as_str()))
+                .map(|name| {
+                    let id = resolved
+                        .authors_by_name
+                        .get(name.as_str())
+                        .cloned()
+                        .ok_or_else(|| {
+                            DomainError::Unexpected(format!(
+                                "author name '{}' not found in name_to_id map",
+                                name.as_str()
+                            ))
+                        })?;
+                    let status = if resolved.created_author_ids.contains(&id) {
+                        ImportAuthorStatus::New
+                    } else {
+                        ImportAuthorStatus::Existing
+                    };
+                    Ok((
+                        id,
+                        ImportAuthorPreviewDto {
+                            name: name.as_str().to_owned(),
+                            status,
+                        },
+                    ))
+                })
+                .collect::<Result<Vec<_>, DomainError>>()?;
+            let (author_ids, preview_authors): (Vec<_>, Vec<_>) = authors.into_iter().unzip();
+
+            previews.push(ImportBookPreviewDto {
+                title: input.title.as_str().to_owned(),
+                authors: preview_authors,
+                isbn: input.isbn.as_str().to_owned(),
+                read: input.read.to_bool(),
+                owned: input.owned.to_bool(),
+                priority: input.priority.to_i32(),
+                format: input.format.clone(),
+                store: input.store.clone(),
+            });
+            books.push(Book::new(
+                input.book_id,
+                input.title,
+                author_ids,
+                input.isbn,
+                input.read,
+                input.owned,
+                input.priority,
+                input.format,
+                input.store,
+                input.created_at,
+                input.updated_at,
+            )?);
+        }
+
+        self.book_repository.create_all(tx, &books).await?;
+        Ok(ImportExecutionResult { books, previews })
     }
 }
 
@@ -269,116 +407,37 @@ where
         user_id: &str,
         books: Vec<ImportBookEntryDto>,
     ) -> Result<ImportBooksResultDto, UseCaseError> {
-        if books.is_empty() {
-            return Err(UseCaseError::Validation(
-                "books cannot be empty".to_string(),
-            ));
-        }
-
-        if books.len() > MAX_BOOK_BATCH {
-            return Err(UseCaseError::Validation(format!(
-                "books cannot exceed {MAX_BOOK_BATCH}"
-            )));
-        }
-
+        let inputs = Self::prepare_import(books)?;
         let user_id = UserId::new(user_id.to_string())?;
-        let now = OffsetDateTime::now_utc();
-
-        // Validation and DTO mapping happen BEFORE begin, so a validation
-        // failure never opens a transaction.
-        let inputs: Result<Vec<ImportBookInput>, UseCaseError> = books
-            .into_iter()
-            .map(|dto| {
-                let title = BookTitle::new(dto.title)?;
-                let author_names: Result<Vec<AuthorName>, DomainError> =
-                    dto.author_names.into_iter().map(AuthorName::new).collect();
-                let author_names = author_names?;
-                let isbn = Isbn::new(dto.isbn)?;
-                let priority = Priority::new(dto.priority)?;
-
-                Ok(ImportBookInput {
-                    book_id: BookId::new(Uuid::new_v4())?,
-                    title,
-                    author_names,
-                    isbn,
-                    read: ReadFlag::new(dto.read),
-                    owned: OwnedFlag::new(dto.owned),
-                    priority,
-                    format: dto.format,
-                    store: dto.store,
-                    created_at: now,
-                    updated_at: now,
-                })
-            })
-            .collect();
-        let inputs = inputs?;
-
-        let mut seen_author_names = HashSet::new();
-        let unique_author_names: Vec<AuthorName> = inputs
-            .iter()
-            .flat_map(|input| input.author_names.iter())
-            .filter(|name| seen_author_names.insert(name.as_str().to_owned()))
-            .cloned()
-            .collect();
-
         let mut tx = self
             .transaction_manager
             .begin(&user_id, EventSetOperation::ImportBooks)
             .await?;
-
-        let name_to_id = self
-            .author_repository
-            .find_or_create_by_names(&mut tx, &unique_author_names, now)
-            .await?;
-
-        let mut result_books = Vec::with_capacity(inputs.len());
-        for input in inputs {
-            // Drop duplicate author names within one book (keeping first-seen
-            // order) — book_author has a primary key on (user_id, book_id,
-            // author_id), so a duplicated id would abort the whole import.
-            let mut seen_names: HashSet<&str> = HashSet::new();
-            let author_ids: Vec<AuthorId> = input
-                .author_names
-                .iter()
-                .filter(|name| seen_names.insert(name.as_str()))
-                .map(|name| {
-                    name_to_id.get(name.as_str()).cloned().ok_or_else(|| {
-                        DomainError::Unexpected(format!(
-                            "author name '{}' not found in name_to_id map",
-                            name.as_str()
-                        ))
-                    })
-                })
-                .collect::<Result<Vec<_>, _>>()?;
-
-            let book = Book::new(
-                input.book_id,
-                input.title,
-                author_ids,
-                input.isbn,
-                input.read,
-                input.owned,
-                input.priority,
-                input.format,
-                input.store,
-                input.created_at,
-                input.updated_at,
-            )?;
-
-            result_books.push(book);
-        }
-
-        self.book_repository
-            .create_all(&mut tx, &result_books)
-            .await?;
-
+        let result = self.execute_import(&mut tx, inputs).await?;
         let event_set_id = tx.event_set_id().hyphenated().to_string();
         self.transaction_manager.commit(tx).await?;
-
         Ok(MutationResultDto::new(
-            result_books.into_iter().map(BookDto::from).collect(),
+            result.books.into_iter().map(BookDto::from).collect(),
             event_set_id,
         ))
+    }
+
+    async fn preview_import(
+        &self,
+        user_id: &str,
+        books: Vec<ImportBookEntryDto>,
+    ) -> Result<ImportBooksPreviewDto, UseCaseError> {
+        let inputs = Self::prepare_import(books)?;
+        let user_id = UserId::new(user_id.to_string())?;
+        let mut tx = self
+            .transaction_manager
+            .begin(&user_id, EventSetOperation::ImportBooks)
+            .await?;
+        let result = self.execute_import(&mut tx, inputs).await?;
+        self.transaction_manager.rollback(tx).await?;
+        Ok(ImportBooksPreviewDto {
+            books: result.previews,
+        })
     }
 
     async fn restore(
@@ -483,13 +542,14 @@ mod tests {
             },
             error::DomainError,
             repository::{
-                author_repository::MockAuthorRepository,
+                author_repository::{FindOrCreateAuthorsResult, MockAuthorRepository},
                 book_event_repository::MockBookEventRepository,
-                book_repository::MockBookRepository, transaction::MockTransactionManager,
+                book_repository::MockBookRepository,
+                transaction::MockTransactionManager,
             },
         },
         use_case::{
-            dto::book::{CreateBookDto, ImportBookEntryDto, UpdateBookDto},
+            dto::book::{CreateBookDto, ImportAuthorStatus, ImportBookEntryDto, UpdateBookDto},
             error::UseCaseError,
             interactor::book::{BookCommandInteractor, BookQueryInteractor},
             traits::book::{BookCommandUseCase, BookQueryUseCase},
@@ -1047,7 +1107,7 @@ mod tests {
             .expect_find_or_create_by_names()
             .withf(|_, names, _| names.is_empty())
             .times(1)
-            .returning(|_, _, _| Ok(HashMap::new()));
+            .returning(|_, _, _| Ok(HashMap::new().into()));
         let mut book_repository = MockBookRepository::new();
         book_repository
             .expect_create_all()
@@ -1155,10 +1215,10 @@ mod tests {
             .withf(|_, names, _| names.len() == 1)
             .times(1)
             .returning(move |_, names, _| {
-                Ok(HashMap::from([(
-                    names[0].as_str().to_owned(),
-                    AuthorId::new(author_uuid),
-                )]))
+                Ok(
+                    HashMap::from([(names[0].as_str().to_owned(), AuthorId::new(author_uuid))])
+                        .into(),
+                )
             });
 
         let mut book_repository = MockBookRepository::new();
@@ -1193,10 +1253,10 @@ mod tests {
             .expect_find_or_create_by_names()
             .times(1)
             .returning(move |_, names, _| {
-                Ok(HashMap::from([(
-                    names[0].as_str().to_owned(),
-                    AuthorId::new(author_uuid),
-                )]))
+                Ok(
+                    HashMap::from([(names[0].as_str().to_owned(), AuthorId::new(author_uuid))])
+                        .into(),
+                )
             });
 
         let mut book_repository = MockBookRepository::new();
@@ -1229,7 +1289,7 @@ mod tests {
         let mut author_repository = MockAuthorRepository::new();
         author_repository
             .expect_find_or_create_by_names()
-            .returning(|_, _, _| Ok(HashMap::new()));
+            .returning(|_, _, _| Ok(HashMap::new().into()));
 
         let interactor = ImportBooksTestCommand::build(
             book_repository,
@@ -1242,6 +1302,98 @@ mod tests {
         let result = interactor.import("user1", books).await;
 
         // Then
+        assert!(matches!(result, Err(UseCaseError::Unexpected(_))));
+    }
+
+    #[tokio::test]
+    async fn preview_import_rolls_back_and_reports_author_statuses() {
+        let existing_id = AuthorId::new(Uuid::new_v4());
+        let new_id = AuthorId::new(Uuid::new_v4());
+        let mut author_repository = MockAuthorRepository::new();
+        author_repository
+            .expect_find_or_create_by_names()
+            .times(1)
+            .returning(move |_, _, _| {
+                Ok(FindOrCreateAuthorsResult {
+                    authors_by_name: HashMap::from([
+                        ("Existing".to_string(), existing_id.clone()),
+                        ("New".to_string(), new_id.clone()),
+                    ]),
+                    created_author_ids: [new_id.clone()].into_iter().collect(),
+                })
+            });
+        let mut book_repository = MockBookRepository::new();
+        book_repository
+            .expect_create_all()
+            .withf(|_, books| books.len() == 1 && books[0].author_ids().len() == 2)
+            .times(1)
+            .returning(|_, _| Ok(()));
+        let mut tm = MockTransactionManager::new();
+        tm.expect_begin().times(1).returning(|_, _| Ok(()));
+        tm.expect_commit().times(0);
+        tm.expect_rollback().times(1).returning(|_| Ok(()));
+        let interactor = ImportBooksTestCommand::build(book_repository, author_repository, tm);
+
+        let result = interactor
+            .preview_import(
+                "user1",
+                vec![import_entry("Preview", vec!["Existing", "New", "New"])],
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.books.len(), 1);
+        assert_eq!(result.books[0].authors.len(), 2);
+        assert_eq!(
+            result.books[0].authors[0].status,
+            ImportAuthorStatus::Existing
+        );
+        assert_eq!(result.books[0].authors[1].status, ImportAuthorStatus::New);
+    }
+
+    #[tokio::test]
+    async fn preview_import_propagates_rollback_failure() {
+        let mut author_repository = MockAuthorRepository::new();
+        author_repository
+            .expect_find_or_create_by_names()
+            .returning(|_, _, _| Ok(HashMap::new().into()));
+        let mut book_repository = MockBookRepository::new();
+        book_repository.expect_create_all().returning(|_, _| Ok(()));
+        let mut tm = MockTransactionManager::new();
+        tm.expect_begin().returning(|_, _| Ok(()));
+        tm.expect_commit().times(0);
+        tm.expect_rollback()
+            .times(1)
+            .returning(|_| Err(DomainError::Unexpected("rollback failed".to_string())));
+        let interactor = ImportBooksTestCommand::build(book_repository, author_repository, tm);
+
+        let result = interactor
+            .preview_import("user1", vec![import_entry("Preview", vec![])])
+            .await;
+
+        assert!(matches!(result, Err(UseCaseError::Unexpected(_))));
+    }
+
+    #[tokio::test]
+    async fn preview_import_does_not_rollback_explicitly_when_execution_fails() {
+        let mut author_repository = MockAuthorRepository::new();
+        author_repository
+            .expect_find_or_create_by_names()
+            .returning(|_, _, _| Ok(HashMap::new().into()));
+        let mut book_repository = MockBookRepository::new();
+        book_repository
+            .expect_create_all()
+            .returning(|_, _| Err(DomainError::Unexpected("db error".to_string())));
+        let mut tm = MockTransactionManager::new();
+        tm.expect_begin().returning(|_, _| Ok(()));
+        tm.expect_commit().times(0);
+        tm.expect_rollback().times(0);
+        let interactor = ImportBooksTestCommand::build(book_repository, author_repository, tm);
+
+        let result = interactor
+            .preview_import("user1", vec![import_entry("Preview", vec![])])
+            .await;
+
         assert!(matches!(result, Err(UseCaseError::Unexpected(_))));
     }
 

--- a/src/use_case/traits/book.rs
+++ b/src/use_case/traits/book.rs
@@ -5,7 +5,7 @@ use mockall::automock;
 
 use crate::use_case::{
     dto::{
-        book::{BookDto, CreateBookDto, ImportBookEntryDto, UpdateBookDto},
+        book::{BookDto, CreateBookDto, ImportBookEntryDto, ImportBooksPreviewDto, UpdateBookDto},
         mutation::{
             BookMutationResultDto, DeleteBookResultDto, ImportBooksResultDto, RestoreBookResultDto,
         },
@@ -52,6 +52,11 @@ pub trait BookCommandUseCase: Send + Sync + 'static {
         user_id: &str,
         books: Vec<ImportBookEntryDto>,
     ) -> Result<ImportBooksResultDto, UseCaseError>;
+    async fn preview_import(
+        &self,
+        user_id: &str,
+        books: Vec<ImportBookEntryDto>,
+    ) -> Result<ImportBooksPreviewDto, UseCaseError>;
     async fn restore(
         &self,
         user_id: &str,


### PR DESCRIPTION
## Summary

- add the `previewBookImport` GraphQL mutation
- execute preview and import through the same validation, bulk author resolution, book persistence, database constraint, and event-recording path
- explicitly roll back the complete preview transaction
- return only preview books with per-book author `EXISTING` / `NEW` status
- omit Book IDs, Author IDs, event set/event IDs, and timestamps from preview
- preserve the existing `importBooks` contract and event behavior

## Design notes

- preview is a Mutation because it performs transactional writes before rollback
- `TransactionManager` now exposes explicit rollback
- bulk author resolution reports which IDs were created without adding queries or N+1 behavior
- preview and import remain separate transactions, so races between them are intentionally allowed
- the shared execution path has no transaction-external side effects

## Verification

- `cargo fmt --check`
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo test --locked` (139 passed)
- DB-feature test targets compile with `cargo test --locked --features test-with-database --no-run`
- complete `bookshelf-e2e` suite passed, including preview DB-unchanged and preview-then-import coverage
- `openspec validate add-book-import-preview`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 書籍インポート前に、登録内容を確認できるプレビュー機能を追加しました。
  - 書籍情報と著者情報に加え、著者が既存か新規かを表示します。
  - プレビュー実行ではデータベースを変更せず、通常のインポートと同じ検証結果を確認できます。

- **改善**
  - 著者名の重複や表記ゆれを整理し、正確な登録状況を表示します。
  - プレビュー後も、確認した同じ内容を通常どおりインポートできます。

- **テスト**
  - 正常系、入力エラー、既存・新規著者、データ未変更の動作を検証しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->