### PR TITLE
Unify GraphQL event set model

### DIFF
--- a/openspec/changes/unify-event-set/.openspec.yaml
+++ b/openspec/changes/unify-event-set/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-24

--- a/openspec/changes/unify-event-set/design.md
+++ b/openspec/changes/unify-event-set/design.md
@@ -1,0 +1,63 @@
+## Context
+
+The event history API uses separate use-case and GraphQL models for list and detail access to the same domain `EventSet`. The detail use case eagerly loads book and author events, while the list model omits them. The schema should represent the domain concept consistently without turning a list query into an unconditional nested-event load. This change spans use cases, repositories, GraphQL request context, generated schema, tests, and the separately maintained `bookshelf` client schema.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Represent event sets with one GraphQL `EventSet` type and one scalar-only use-case DTO.
+- Resolve nested event fields lazily and batch loads across all event sets in a request.
+- Preserve user scoping, response fields, field nullability, query field names, and UI behavior.
+- Coordinate the schema-breaking type rename with regenerated frontend types.
+
+**Non-Goals:**
+
+- Changing the domain `EventSet` or event-recording model.
+- Adding a new GraphQL query or user-facing event-history workflow.
+- Renaming the `EventSetDetail` UI component, whose name describes screen responsibility.
+- Embedding nested events in `EventSetDto`.
+
+## Decisions
+
+### Keep `EventSetDto` scalar-only
+
+Both list and single-item use cases return `EventSetDto` containing `id`, `operation`, and `created_at`. `find_event_set` stops coordinating nested repositories. This prevents the query resolver from eagerly loading data that the GraphQL selection does not require. Keeping a detail DTO with optional or deferred fields was rejected because it retains two representations or leaks presentation loading concerns into the use-case model.
+
+### Add user-scoped batch repository and use-case operations
+
+Book and author event repositories accept multiple event-set IDs and execute one set-based query constrained by `user_id`. Use cases convert the resulting domain events to event DTOs and return flat vectors. Presentation code groups them by event-set ID. Returning a map from repositories or naming APIs around maps was rejected because grouping is a DataLoader concern.
+
+The existing single-ID repository operations remain where other callers need them. Empty ID inputs return an empty vector without issuing an invalid query.
+
+### Resolve nested fields through two DataLoaders
+
+`BookEventsByEventSetLoader` and `AuthorEventsByEventSetLoader` use the existing async-graphql DataLoader pattern and request-scoped user context. Each loader calls its corresponding batch use case once per collected key set and returns a value for every requested event-set ID, including empty vectors. A single loader returning both event kinds was rejected because GraphQL selections must independently avoid loading unrequested fields.
+
+### Expose one complex GraphQL object
+
+One `EventSet` simple object contains scalar fields and uses complex-object resolvers for `bookEvents` and `authorEvents`. Both `eventSets` and `eventSet` return this type and neither query resolver loads nested events. The removed GraphQL names make this a schema-level breaking change even though field response shapes remain unchanged.
+
+### Update the frontend by schema regeneration
+
+The API SDL is copied to the frontend's local schema and `pnpm run generate` regenerates operation types. Existing operations already select the required list and detail fields, so component behavior and component names remain unchanged unless generated-type compilation exposes a necessary minimal adjustment.
+
+## Risks / Trade-offs
+
+- [Direct clients depend on removed type names] → Treat the rename as breaking, document it in the API PR, and update the paired frontend in a coordinated PR.
+- [DataLoader grouping omits keys with no rows] → Initialize requested keys with empty vectors and test zero-event event sets.
+- [Batch SQL leaks cross-user events] → Retain an explicit `user_id` predicate and add repository coverage for mixed ownership.
+- [A resolver bypasses DataLoader and reintroduces N+1] → Keep nested fields only on complex resolvers and verify batch use-case call counts where the test seam permits.
+- [Separate repositories cannot deploy atomically] → Merge/deploy the API schema and frontend regeneration in coordination; rollback each repository to its prior schema/generated code if needed.
+
+## Migration Plan
+
+1. Add and test batch repository/use-case operations and DataLoaders.
+2. Replace the API DTO and GraphQL type split, then regenerate and validate SDL.
+3. Run API unit, repository, GraphQL, and existing event-history regression suites.
+4. Update the frontend local SDL, regenerate types, and run unit, type, and relevant E2E checks.
+5. Publish linked API and frontend PRs that call out the breaking type rename.
+
+## Open Questions
+
+None. The existing repository and DataLoader conventions determine concrete SQL and dependency-injection details during implementation.

--- a/openspec/changes/unify-event-set/design.md
+++ b/openspec/changes/unify-event-set/design.md
@@ -42,6 +42,8 @@ One `EventSet` simple object contains scalar fields and uses complex-object reso
 
 The API SDL is copied to the frontend's local schema and `pnpm run generate` regenerates operation types. Existing operations already select the required list and detail fields, so component behavior and component names remain unchanged unless generated-type compilation exposes a necessary minimal adjustment.
 
+The frontend repository intentionally ignores both its fetched local SDL and generated GraphQL files. Therefore, when generation and verification produce no tracked source change, no frontend commit or PR is created; the normal generation step consumes the published API SDL after deployment.
+
 ## Risks / Trade-offs
 
 - [Direct clients depend on removed type names] → Treat the rename as breaking, document it in the API PR, and update the paired frontend in a coordinated PR.
@@ -55,8 +57,8 @@ The API SDL is copied to the frontend's local schema and `pnpm run generate` reg
 1. Add and test batch repository/use-case operations and DataLoaders.
 2. Replace the API DTO and GraphQL type split, then regenerate and validate SDL.
 3. Run API unit, repository, GraphQL, and existing event-history regression suites.
-4. Update the frontend local SDL, regenerate types, and run unit, type, and relevant E2E checks.
-5. Publish linked API and frontend PRs that call out the breaking type rename.
+4. Update the frontend local SDL locally, regenerate types, and run unit, type, and relevant E2E checks.
+5. Publish the API PR. Publish a linked frontend PR only if schema regeneration requires a tracked source change.
 
 ## Open Questions
 

--- a/openspec/changes/unify-event-set/proposal.md
+++ b/openspec/changes/unify-event-set/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+The API currently represents an event set with separate list and detail types even though both types describe the same domain concept. Unifying the public model makes the schema consistent while preserving efficient, selection-driven loading of nested events.
+
+## What Changes
+
+- **BREAKING** Replace the GraphQL `EventSetEntry` and `EventSetDetail` types with one `EventSet` type used by both existing query fields.
+- Preserve the existing query field names, response fields, and nullability while resolving `bookEvents` and `authorEvents` lazily.
+- Batch nested event loading across event-set IDs with DataLoader to avoid N+1 repository queries.
+- Remove `EventSetDetailDto`; use the scalar-only `EventSetDto` for both list and single-item use cases.
+- Add user-scoped repository and use-case batch queries for book and author events.
+- Keep the domain `EventSet` unchanged.
+- Update the `bookshelf` local schema and generated GraphQL types without changing the event-history UI behavior.
+
+## Capabilities
+
+### New Capabilities
+
+- `event-set-query-model`: Defines the unified GraphQL event-set model and selection-driven, batched loading behavior for nested events.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Affects event query DTOs and use cases, book/author event repositories, database queries, GraphQL loaders, objects, query resolvers, schema tests, and generated SDL in `bookshelf-api`.
+- Requires a coordinated schema and generated-type update in `hiterm/bookshelf`.
+- Clients that refer directly to the removed GraphQL type names must regenerate or update types; the existing query field response shapes remain compatible.

--- a/openspec/changes/unify-event-set/specs/event-set-query-model/spec.md
+++ b/openspec/changes/unify-event-set/specs/event-set-query-model/spec.md
@@ -1,0 +1,54 @@
+## ADDED Requirements
+
+### Requirement: Unified event-set GraphQL type
+The GraphQL schema SHALL expose one `EventSet` type for both the event-set list and single-event-set query and SHALL NOT expose `EventSetEntry` or `EventSetDetail` types.
+
+#### Scenario: Query field types are unified
+- **WHEN** a client inspects the GraphQL schema
+- **THEN** `eventSets` returns non-null `EventSet` elements and `eventSet` returns a nullable `EventSet`
+
+#### Scenario: Event-set fields remain available
+- **WHEN** a client selects scalar, book-event, or author-event fields from either event-set query
+- **THEN** the unified type exposes the existing fields with their existing nullability
+
+### Requirement: Selection-driven nested event loading
+The system SHALL load book and author events only when their corresponding GraphQL fields are selected.
+
+#### Scenario: Scalar-only list query
+- **WHEN** a client requests only scalar fields from `eventSets`
+- **THEN** the system does not query book events or author events
+
+#### Scenario: Single event set with nested events
+- **WHEN** a client requests `bookEvents` or `authorEvents` from `eventSet`
+- **THEN** the system returns the requested events for that event set
+
+#### Scenario: Event set with no nested events
+- **WHEN** a selected nested event field has no events for an event set
+- **THEN** the system returns an empty list for that field
+
+### Requirement: Batched nested event loading
+The system MUST batch each selected nested event kind across all event sets resolved within a GraphQL request and MUST preserve user ownership filtering.
+
+#### Scenario: Multiple event sets request book events
+- **WHEN** a client selects `bookEvents` for multiple event sets in one query
+- **THEN** the system retrieves book events with one user-scoped batch query rather than one query per event set
+
+#### Scenario: Multiple event sets request author events
+- **WHEN** a client selects `authorEvents` for multiple event sets in one query
+- **THEN** the system retrieves author events with one user-scoped batch query rather than one query per event set
+
+#### Scenario: Events belong to another user
+- **WHEN** a batch query includes event-set IDs associated with another user
+- **THEN** the system does not return that user's events
+
+### Requirement: Scalar-only use-case event-set model
+The event query use case SHALL return the same scalar-only event-set DTO for list and single-item lookups, while nested events SHALL be obtained through dedicated batch operations.
+
+#### Scenario: Single event-set lookup
+- **WHEN** the use case finds an event set by a valid ID
+- **THEN** it returns the event-set ID, operation, and creation time without eagerly loading nested events
+
+#### Scenario: Batch operation receives no IDs
+- **WHEN** a nested event batch operation receives an empty event-set ID list
+- **THEN** it returns an empty result without failing
+

--- a/openspec/changes/unify-event-set/tasks.md
+++ b/openspec/changes/unify-event-set/tasks.md
@@ -20,7 +20,7 @@
 ## 4. API Validation
 
 - [x] 4.1 Run OpenSpec validation and confirm the implementation matches the event-set query-model scenarios
-- [x] 4.2 Run formatting, clippy, locked unit/integration tests, and the existing event-history E2E regression suite
+- [x] 4.2 Confirm existing event-history E2E regression coverage is sufficient for this GraphQL contract change, add no dedicated E2E scenario, and run formatting, clippy, locked unit/integration tests, and the regression suite
 
 ## 5. Frontend Schema Follow-Up
 

--- a/openspec/changes/unify-event-set/tasks.md
+++ b/openspec/changes/unify-event-set/tasks.md
@@ -32,4 +32,4 @@
 
 - [x] 6.1 Commit logical API changes after mandatory checks, push, and open a PR documenting the breaking rename, lazy loading, batching, and test results
 - [x] 6.2 Confirm frontend schema generation produces no tracked changes, so no empty frontend commit or PR is required
-- [ ] 6.3 Monitor all required CI checks on both PRs and fix failures until both are green
+- [x] 6.3 Monitor all required CI checks on the implementation PR and fix failures until it is green

--- a/openspec/changes/unify-event-set/tasks.md
+++ b/openspec/changes/unify-event-set/tasks.md
@@ -1,0 +1,35 @@
+## 1. Batch Event Queries
+
+- [x] 1.1 Add user-scoped multi-event-set queries to book and author event repositories and database implementations
+- [x] 1.2 Add repository tests for multiple IDs, mixed ownership, missing events, and empty ID lists
+- [x] 1.3 Add event-query use-case batch operations and unit tests for conversion, empty input, and empty results
+
+## 2. Use-Case Event Set Model
+
+- [x] 2.1 Remove `EventSetDetailDto` and make single-event-set lookup return the scalar-only `EventSetDto`
+- [x] 2.2 Replace eager-loading detail tests with lookup validation, found, and not-found unit tests
+
+## 3. GraphQL Loading and Model
+
+- [x] 3.1 Add request-scoped book-events-by-event-set and author-events-by-event-set DataLoaders with empty-list grouping
+- [x] 3.2 Replace `EventSetEntry` and `EventSetDetail` with one complex `EventSet` object whose nested fields use the DataLoaders
+- [x] 3.3 Update query resolvers and dependency injection so list and single-item queries return `EventSet` without eager loading
+- [x] 3.4 Add GraphQL schema/resolver tests for the unified type, nested detail/list results, empty lists, and batched calls
+- [x] 3.5 Regenerate `schema.graphql` and verify removed type names, field types, and nullability
+
+## 4. API Validation
+
+- [x] 4.1 Run OpenSpec validation and confirm the implementation matches the event-set query-model scenarios
+- [x] 4.2 Run formatting, clippy, locked unit/integration tests, and the existing event-history E2E regression suite
+
+## 5. Frontend Schema Follow-Up
+
+- [x] 5.1 Update the `bookshelf` local GraphQL schema and regenerate GraphQL client types
+- [x] 5.2 Verify EventSet list/detail components and operations require no behavior changes, making only necessary type follow-ups
+- [x] 5.3 Run frontend generate, lint, unit, typecheck, and relevant event-history E2E regression suites
+
+## 6. Delivery
+
+- [ ] 6.1 Commit logical API changes after mandatory checks, push, and open a PR documenting the breaking rename, lazy loading, batching, and test results
+- [ ] 6.2 Commit the frontend schema/generated-type follow-up after mandatory checks, push, and open a linked PR documenting unchanged UI behavior and test results
+- [ ] 6.3 Monitor all required CI checks on both PRs and fix failures until both are green

--- a/openspec/changes/unify-event-set/tasks.md
+++ b/openspec/changes/unify-event-set/tasks.md
@@ -30,6 +30,6 @@
 
 ## 6. Delivery
 
-- [ ] 6.1 Commit logical API changes after mandatory checks, push, and open a PR documenting the breaking rename, lazy loading, batching, and test results
-- [ ] 6.2 Commit the frontend schema/generated-type follow-up after mandatory checks, push, and open a linked PR documenting unchanged UI behavior and test results
+- [x] 6.1 Commit logical API changes after mandatory checks, push, and open a PR documenting the breaking rename, lazy loading, batching, and test results
+- [x] 6.2 Confirm frontend schema generation produces no tracked changes, so no empty frontend commit or PR is required
 - [ ] 6.3 Monitor all required CI checks on both PRs and fix failures until both are green

--- a/schema.graphql
+++ b/schema.graphql
@@ -112,18 +112,12 @@ type DeleteBookPayload {
 	eventSetId: ID!
 }
 
-type EventSetDetail {
+type EventSet {
 	id: ID!
 	operation: String!
 	createdAt: Int!
 	bookEvents: [BookEventEntry!]!
 	authorEvents: [AuthorEventEntry!]!
-}
-
-type EventSetEntry {
-	id: ID!
-	operation: String!
-	createdAt: Int!
 }
 
 type ImportAuthorPreview {
@@ -241,11 +235,11 @@ type Query {
 	"""
 	Returns the logged-in user's event sets, newest first.
 	"""
-	eventSets: [EventSetEntry!]!
+	eventSets: [EventSet!]!
 	"""
 	Returns a single event set with nested events, or null if not found.
 	"""
-	eventSet(id: ID!): EventSetDetail
+	eventSet(id: ID!): EventSet
 }
 
 type RestoreAuthorPayload {

--- a/src/dependency_injection.rs
+++ b/src/dependency_injection.rs
@@ -40,7 +40,7 @@ pub type AppQuery = Query<UQ, BQ, AQ, EQ>;
 pub type AppMutation = Mutation<UC, BC, AC>;
 pub type AppSchema = Schema<AppQuery, AppMutation, EmptySubscription>;
 
-pub fn dependency_injection(pool: Pool<Postgres>) -> (AQ, BQ, AppSchema) {
+pub fn dependency_injection(pool: Pool<Postgres>) -> (AQ, BQ, EQ, AppSchema) {
     let user_repository = PgUserRepository::new(pool.clone());
     let book_repository = PgBookRepository::new(pool.clone());
     let author_repository = PgAuthorRepository::new(pool.clone());
@@ -75,10 +75,10 @@ pub fn dependency_injection(pool: Pool<Postgres>) -> (AQ, BQ, AppSchema) {
         user_query,
         book_query.clone(),
         author_query.clone(),
-        event_query,
+        event_query.clone(),
     );
     let mutation = Mutation::new(user_command, book_command, author_command);
     let schema = build_schema(query, mutation);
 
-    (author_query, book_query, schema)
+    (author_query, book_query, event_query, schema)
 }

--- a/src/domain/repository/author_event_repository.rs
+++ b/src/domain/repository/author_event_repository.rs
@@ -38,4 +38,10 @@ pub trait AuthorEventRepository: Send + Sync + 'static {
         user_id: &UserId,
         event_set_id: &EventSetId,
     ) -> Result<Vec<AuthorEvent>, DomainError>;
+
+    async fn find_by_event_set_ids(
+        &self,
+        user_id: &UserId,
+        event_set_ids: &[EventSetId],
+    ) -> Result<Vec<AuthorEvent>, DomainError>;
 }

--- a/src/domain/repository/book_event_repository.rs
+++ b/src/domain/repository/book_event_repository.rs
@@ -26,4 +26,10 @@ pub trait BookEventRepository: Send + Sync + 'static {
         user_id: &UserId,
         event_set_id: &EventSetId,
     ) -> Result<Vec<BookEvent>, DomainError>;
+
+    async fn find_by_event_set_ids(
+        &self,
+        user_id: &UserId,
+        event_set_ids: &[EventSetId],
+    ) -> Result<Vec<BookEvent>, DomainError>;
 }

--- a/src/infrastructure/author_event_repository.rs
+++ b/src/infrastructure/author_event_repository.rs
@@ -149,6 +149,30 @@ impl AuthorEventRepository for PgAuthorEventRepository {
 
         rows.into_iter().map(row_to_author_event).collect()
     }
+
+    async fn find_by_event_set_ids(
+        &self,
+        user_id: &UserId,
+        event_set_ids: &[EventSetId],
+    ) -> Result<Vec<AuthorEvent>, DomainError> {
+        if event_set_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+        let event_set_ids: Vec<Uuid> = event_set_ids.iter().map(EventSetId::to_uuid).collect();
+        let rows: Vec<AuthorEventRow> = sqlx::query_as(
+            "SELECT event_id, event_set_id, operation, author_id, name, yomi,
+                    author_created_at, author_updated_at, changed_at, extra
+             FROM author_event
+             WHERE user_id = $1 AND event_set_id = ANY($2)
+             ORDER BY changed_at DESC",
+        )
+        .bind(user_id.as_str())
+        .bind(&event_set_ids)
+        .fetch_all(&self.pool)
+        .await?;
+
+        rows.into_iter().map(row_to_author_event).collect()
+    }
 }
 
 #[cfg(feature = "test-with-database")]
@@ -276,6 +300,66 @@ mod tests {
             .await?;
         assert!(entries.is_empty());
 
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn find_by_event_set_ids_batches_and_remains_user_scoped(
+        pool: PgPool,
+    ) -> anyhow::Result<()> {
+        let user_repo = PgUserRepository::new(pool.clone());
+        let author_repo = PgAuthorRepository::new(pool.clone());
+        let event_repo = PgAuthorEventRepository::new(pool.clone());
+        let user1 = prepare_user(&user_repo, "user1").await?;
+        let user2 = prepare_user(&user_repo, "user2").await?;
+        for (user, id, name) in [
+            (&user1, "278935cf-ed83-4346-9b35-b84bbdb630c0", "Author 1"),
+            (&user1, "006099b4-6c42-4ec4-8645-f6bd5b63eddc", "Author 2"),
+            (&user2, "93090e87-b7a1-403c-974c-d74d881e83b9", "Other User"),
+        ] {
+            create_author(
+                &pool,
+                &author_repo,
+                user,
+                &Author::new(
+                    AuthorId::try_from(id)?,
+                    AuthorName::new(name.to_string())?,
+                    OffsetDateTime::UNIX_EPOCH,
+                )?,
+            )
+            .await?;
+        }
+        let ids: Vec<(Uuid,)> = sqlx::query_as("SELECT event_set_id FROM author_event")
+            .fetch_all(&pool)
+            .await?;
+        let ids: Vec<EventSetId> = ids
+            .into_iter()
+            .map(|(id,)| EventSetId::from(id))
+            .chain(std::iter::once(EventSetId::new()))
+            .collect();
+
+        let events = event_repo.find_by_event_set_ids(&user1, &ids).await?;
+
+        assert_eq!(events.len(), 2);
+        assert!(
+            events
+                .iter()
+                .all(|event| event.name.as_deref() != Some("Other User"))
+        );
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn find_by_event_set_ids_accepts_empty_ids(pool: PgPool) -> anyhow::Result<()> {
+        let event_repo = PgAuthorEventRepository::new(pool);
+        let user_id = UserId::new("user1".to_string())?;
+
+        assert!(
+            event_repo
+                .find_by_event_set_ids(&user_id, &[])
+                .await?
+                .is_empty()
+        );
         Ok(())
     }
 }

--- a/src/infrastructure/book_event_repository.rs
+++ b/src/infrastructure/book_event_repository.rs
@@ -204,6 +204,47 @@ impl BookEventRepository for PgBookEventRepository {
 
         rows.into_iter().map(row_to_book_event).collect()
     }
+
+    async fn find_by_event_set_ids(
+        &self,
+        user_id: &UserId,
+        event_set_ids: &[EventSetId],
+    ) -> Result<Vec<BookEvent>, DomainError> {
+        if event_set_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+        let event_set_ids: Vec<Uuid> = event_set_ids.iter().map(EventSetId::to_uuid).collect();
+        let rows: Vec<BookEventRow> = sqlx::query_as(
+            "SELECT
+                be.event_id,
+                be.event_set_id,
+                be.operation,
+                be.book_id,
+                be.title,
+                be.isbn,
+                be.read,
+                be.owned,
+                be.priority,
+                be.format,
+                be.store,
+                be.book_created_at,
+                be.book_updated_at,
+                be.changed_at,
+                array_agg(bea.author_id) FILTER (WHERE bea.author_id IS NOT NULL) AS author_ids,
+                be.extra
+            FROM book_event be
+            LEFT JOIN book_event_author bea ON be.event_id = bea.event_id
+            WHERE be.user_id = $1 AND be.event_set_id = ANY($2)
+            GROUP BY be.event_id
+            ORDER BY be.changed_at DESC",
+        )
+        .bind(user_id.as_str())
+        .bind(&event_set_ids)
+        .fetch_all(&self.pool)
+        .await?;
+
+        rows.into_iter().map(row_to_book_event).collect()
+    }
 }
 
 #[cfg(feature = "test-with-database")]
@@ -555,6 +596,63 @@ mod tests {
         let entries = event_repo.find_by_event_set(&user_id, &unknown).await?;
         assert!(entries.is_empty());
 
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn find_by_event_set_ids_returns_multiple_sets(pool: PgPool) -> anyhow::Result<()> {
+        let user_repo = PgUserRepository::new(pool.clone());
+        let author_repo = PgAuthorRepository::new(pool.clone());
+        let book_repo = PgBookRepository::new(pool.clone());
+        let event_repo = PgBookEventRepository::new(pool.clone());
+        let user_id = prepare_user(&user_repo, "user1").await?;
+        let author_id = AuthorId::try_from("278935cf-ed83-4346-9b35-b84bbdb630c0")?;
+        create_author(
+            &pool,
+            &author_repo,
+            &user_id,
+            &Author::new(
+                author_id.clone(),
+                AuthorName::new("author1".to_owned())?,
+                OffsetDateTime::UNIX_EPOCH,
+            )?,
+        )
+        .await?;
+        for (id, title) in [
+            ("675bc8d9-3155-42fb-87b0-0a82cb162848", "title1"),
+            ("a1b2c3d4-e5f6-4890-abcd-ef1234567890", "title2"),
+        ] {
+            let book = make_book(id, title, std::slice::from_ref(&author_id))?;
+            create_book(&pool, &book_repo, &user_id, &book).await?;
+        }
+        let ids: Vec<(Uuid,)> =
+            sqlx::query_as("SELECT event_set_id FROM book_event WHERE user_id = $1")
+                .bind(user_id.as_str())
+                .fetch_all(&pool)
+                .await?;
+        let ids: Vec<EventSetId> = ids
+            .into_iter()
+            .map(|(id,)| EventSetId::from(id))
+            .chain(std::iter::once(EventSetId::new()))
+            .collect();
+
+        let events = event_repo.find_by_event_set_ids(&user_id, &ids).await?;
+
+        assert_eq!(events.len(), 2);
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn find_by_event_set_ids_accepts_empty_ids(pool: PgPool) -> anyhow::Result<()> {
+        let event_repo = PgBookEventRepository::new(pool);
+        let user_id = UserId::new("user1".to_string())?;
+
+        assert!(
+            event_repo
+                .find_by_event_set_ids(&user_id, &[])
+                .await?
+                .is_empty()
+        );
         Ok(())
     }
 }

--- a/src/infrastructure/book_event_repository.rs
+++ b/src/infrastructure/book_event_repository.rs
@@ -606,6 +606,7 @@ mod tests {
         let book_repo = PgBookRepository::new(pool.clone());
         let event_repo = PgBookEventRepository::new(pool.clone());
         let user_id = prepare_user(&user_repo, "user1").await?;
+        let other_user_id = prepare_user(&user_repo, "user2").await?;
         let author_id = AuthorId::try_from("278935cf-ed83-4346-9b35-b84bbdb630c0")?;
         create_author(
             &pool,
@@ -625,11 +626,27 @@ mod tests {
             let book = make_book(id, title, std::slice::from_ref(&author_id))?;
             create_book(&pool, &book_repo, &user_id, &book).await?;
         }
-        let ids: Vec<(Uuid,)> =
-            sqlx::query_as("SELECT event_set_id FROM book_event WHERE user_id = $1")
-                .bind(user_id.as_str())
-                .fetch_all(&pool)
-                .await?;
+        let other_author_id = AuthorId::try_from("45fb525f-8dc4-4c0d-a27a-96bff8fdde28")?;
+        create_author(
+            &pool,
+            &author_repo,
+            &other_user_id,
+            &Author::new(
+                other_author_id.clone(),
+                AuthorName::new("other author".to_owned())?,
+                OffsetDateTime::UNIX_EPOCH,
+            )?,
+        )
+        .await?;
+        let other_book = make_book(
+            "4a7b4494-887c-44ef-a656-8b664b2585f4",
+            "other user's book",
+            std::slice::from_ref(&other_author_id),
+        )?;
+        create_book(&pool, &book_repo, &other_user_id, &other_book).await?;
+        let ids: Vec<(Uuid,)> = sqlx::query_as("SELECT event_set_id FROM book_event")
+            .fetch_all(&pool)
+            .await?;
         let ids: Vec<EventSetId> = ids
             .into_iter()
             .map(|(id,)| EventSetId::from(id))
@@ -639,6 +656,7 @@ mod tests {
         let events = event_repo.find_by_event_set_ids(&user_id, &ids).await?;
 
         assert_eq!(events.len(), 2);
+        assert!(events.iter().all(|event| &event.book_id != other_book.id()));
         Ok(())
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,7 @@ async fn main() -> Result<(), anyhow::Error> {
 
     sqlx::migrate!().run(&pool).await?;
 
-    let (author_query, book_query, schema) = dependency_injection(pool);
+    let (author_query, book_query, event_query, schema) = dependency_injection(pool);
 
     let jwt_config = JwtConfig::from_env()?;
     let jwks_cache = moka::future::Cache::builder()
@@ -74,6 +74,7 @@ async fn main() -> Result<(), anyhow::Error> {
             ServiceBuilder::new()
                 .layer(Extension(author_query))
                 .layer(Extension(book_query))
+                .layer(Extension(event_query))
                 .layer(Extension(schema))
                 .layer(
                     TraceLayer::new_for_http()

--- a/src/presentation/graphql/loader.rs
+++ b/src/presentation/graphql/loader.rs
@@ -4,10 +4,12 @@ use async_graphql::dataloader::Loader;
 
 use crate::{
     presentation::{error::PresentationalError, extractor::claims::Claims},
-    use_case::traits::{author::AuthorQueryUseCase, book::BookQueryUseCase},
+    use_case::traits::{
+        author::AuthorQueryUseCase, book::BookQueryUseCase, event::EventQueryUseCase,
+    },
 };
 
-use super::object::{Author, Book};
+use super::object::{Author, AuthorEventEntry, Book, BookEventEntry};
 
 pub struct AuthorLoader<AQ> {
     claims: Claims,
@@ -17,6 +19,88 @@ pub struct AuthorLoader<AQ> {
 pub struct BooksByAuthorLoader<BQ> {
     claims: Claims,
     book_query: BQ,
+}
+
+pub struct BookEventsByEventSetLoader<EQ> {
+    claims: Claims,
+    event_query: EQ,
+}
+
+pub struct AuthorEventsByEventSetLoader<EQ> {
+    claims: Claims,
+    event_query: EQ,
+}
+
+impl<EQ> BookEventsByEventSetLoader<EQ> {
+    pub fn new(claims: Claims, event_query: EQ) -> Self {
+        Self {
+            claims,
+            event_query,
+        }
+    }
+}
+
+impl<EQ> AuthorEventsByEventSetLoader<EQ> {
+    pub fn new(claims: Claims, event_query: EQ) -> Self {
+        Self {
+            claims,
+            event_query,
+        }
+    }
+}
+
+impl<EQ> Loader<String> for BookEventsByEventSetLoader<EQ>
+where
+    EQ: EventQueryUseCase,
+{
+    type Value = Vec<BookEventEntry>;
+    type Error = PresentationalError;
+
+    async fn load(&self, keys: &[String]) -> Result<HashMap<String, Self::Value>, Self::Error> {
+        let events = self
+            .event_query
+            .list_book_events_by_event_set_ids(&self.claims.sub, keys)
+            .await?;
+        let mut grouped = keys
+            .iter()
+            .cloned()
+            .map(|key| (key, Vec::new()))
+            .collect::<HashMap<_, _>>();
+        for event in events {
+            grouped
+                .entry(event.event_set_id.clone())
+                .or_default()
+                .push(BookEventEntry::from(event));
+        }
+        Ok(grouped)
+    }
+}
+
+impl<EQ> Loader<String> for AuthorEventsByEventSetLoader<EQ>
+where
+    EQ: EventQueryUseCase,
+{
+    type Value = Vec<AuthorEventEntry>;
+    type Error = PresentationalError;
+
+    async fn load(&self, keys: &[String]) -> Result<HashMap<String, Self::Value>, Self::Error> {
+        let events = self
+            .event_query
+            .list_author_events_by_event_set_ids(&self.claims.sub, keys)
+            .await?;
+        let mut grouped = keys
+            .iter()
+            .cloned()
+            .map(|key| (key, Vec::new()))
+            .collect::<HashMap<_, _>>();
+        for event in events {
+            grouped
+                .entry(event.event_set_id.clone())
+                .or_default()
+                .push(AuthorEventEntry::from(event));
+        }
+        Ok(grouped)
+    }
 }
 
 impl<BQ> BooksByAuthorLoader<BQ> {
@@ -93,11 +177,65 @@ mod tests {
         presentation::extractor::claims::Claims,
         use_case::{
             dto::{author::AuthorDto, book::BookDto},
-            traits::{author::MockAuthorQueryUseCase, book::MockBookQueryUseCase},
+            traits::{
+                author::MockAuthorQueryUseCase, book::MockBookQueryUseCase,
+                event::MockEventQueryUseCase,
+            },
         },
     };
 
-    use super::{AuthorLoader, BooksByAuthorLoader};
+    use super::{
+        AuthorEventsByEventSetLoader, AuthorLoader, BookEventsByEventSetLoader, BooksByAuthorLoader,
+    };
+
+    fn claims() -> Claims {
+        Claims {
+            sub: "user1".to_string(),
+            _permissions: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn book_events_loader_batches_keys_and_includes_empty_values() {
+        let keys = vec![
+            "006099b4-6c42-4ec4-8645-f6bd5b63eddc".to_string(),
+            "93090e87-b7a1-403c-974c-d74d881e83b9".to_string(),
+        ];
+        let expected_keys = keys.clone();
+        let mut event_query = MockEventQueryUseCase::new();
+        event_query
+            .expect_list_book_events_by_event_set_ids()
+            .with(predicate::eq("user1"), predicate::eq(expected_keys))
+            .times(1)
+            .return_once(|_, _| Ok(Vec::new()));
+        let loader = BookEventsByEventSetLoader::new(claims(), event_query);
+
+        let result = loader.load(&keys).await.unwrap();
+
+        assert_eq!(result.len(), 2);
+        assert!(result.values().all(Vec::is_empty));
+    }
+
+    #[tokio::test]
+    async fn author_events_loader_batches_keys_and_includes_empty_values() {
+        let keys = vec![
+            "006099b4-6c42-4ec4-8645-f6bd5b63eddc".to_string(),
+            "93090e87-b7a1-403c-974c-d74d881e83b9".to_string(),
+        ];
+        let expected_keys = keys.clone();
+        let mut event_query = MockEventQueryUseCase::new();
+        event_query
+            .expect_list_author_events_by_event_set_ids()
+            .with(predicate::eq("user1"), predicate::eq(expected_keys))
+            .times(1)
+            .return_once(|_, _| Ok(Vec::new()));
+        let loader = AuthorEventsByEventSetLoader::new(claims(), event_query);
+
+        let result = loader.load(&keys).await.unwrap();
+
+        assert_eq!(result.len(), 2);
+        assert!(result.values().all(Vec::is_empty));
+    }
 
     #[tokio::test]
     async fn author_loader_batches_keys_and_maps_authors() {

--- a/src/presentation/graphql/loader.rs
+++ b/src/presentation/graphql/loader.rs
@@ -176,7 +176,11 @@ mod tests {
         common::types::{BookFormat, BookStore},
         presentation::extractor::claims::Claims,
         use_case::{
-            dto::{author::AuthorDto, book::BookDto},
+            dto::{
+                author::AuthorDto,
+                book::BookDto,
+                event::{AuthorEventDto, BookEventDto},
+            },
             traits::{
                 author::MockAuthorQueryUseCase, book::MockBookQueryUseCase,
                 event::MockEventQueryUseCase,
@@ -195,25 +199,70 @@ mod tests {
         }
     }
 
+    fn book_event(event_id: i64, event_set_id: String) -> BookEventDto {
+        BookEventDto {
+            event_id,
+            event_set_id,
+            operation: "create".to_string(),
+            book_id: format!("book-{event_id}"),
+            title: Some(format!("Book {event_id}")),
+            author_ids: Vec::new(),
+            isbn: None,
+            read: None,
+            owned: None,
+            priority: None,
+            format: None,
+            store: None,
+            book_created_at: None,
+            book_updated_at: None,
+            changed_at: OffsetDateTime::UNIX_EPOCH,
+            extra: None,
+        }
+    }
+
+    fn author_event(event_id: i64, event_set_id: String) -> AuthorEventDto {
+        AuthorEventDto {
+            event_id,
+            event_set_id,
+            operation: "create".to_string(),
+            author_id: format!("author-{event_id}"),
+            name: Some(format!("Author {event_id}")),
+            yomi: None,
+            author_created_at: None,
+            author_updated_at: None,
+            changed_at: OffsetDateTime::UNIX_EPOCH,
+            extra: None,
+        }
+    }
+
     #[tokio::test]
     async fn book_events_loader_batches_keys_and_includes_empty_values() {
         let keys = vec![
             "006099b4-6c42-4ec4-8645-f6bd5b63eddc".to_string(),
             "93090e87-b7a1-403c-974c-d74d881e83b9".to_string(),
+            "278935cf-ed83-4346-9b35-b84bbdb630c0".to_string(),
         ];
         let expected_keys = keys.clone();
+        let returned_keys = keys.clone();
         let mut event_query = MockEventQueryUseCase::new();
         event_query
             .expect_list_book_events_by_event_set_ids()
             .with(predicate::eq("user1"), predicate::eq(expected_keys))
             .times(1)
-            .return_once(|_, _| Ok(Vec::new()));
+            .return_once(move |_, _| {
+                Ok(vec![
+                    book_event(1, returned_keys[0].clone()),
+                    book_event(2, returned_keys[1].clone()),
+                ])
+            });
         let loader = BookEventsByEventSetLoader::new(claims(), event_query);
 
         let result = loader.load(&keys).await.unwrap();
 
-        assert_eq!(result.len(), 2);
-        assert!(result.values().all(Vec::is_empty));
+        assert_eq!(result.len(), 3);
+        assert_eq!(result[&keys[0]][0].event_id.as_str(), "1");
+        assert_eq!(result[&keys[1]][0].event_id.as_str(), "2");
+        assert!(result[&keys[2]].is_empty());
     }
 
     #[tokio::test]
@@ -221,20 +270,29 @@ mod tests {
         let keys = vec![
             "006099b4-6c42-4ec4-8645-f6bd5b63eddc".to_string(),
             "93090e87-b7a1-403c-974c-d74d881e83b9".to_string(),
+            "278935cf-ed83-4346-9b35-b84bbdb630c0".to_string(),
         ];
         let expected_keys = keys.clone();
+        let returned_keys = keys.clone();
         let mut event_query = MockEventQueryUseCase::new();
         event_query
             .expect_list_author_events_by_event_set_ids()
             .with(predicate::eq("user1"), predicate::eq(expected_keys))
             .times(1)
-            .return_once(|_, _| Ok(Vec::new()));
+            .return_once(move |_, _| {
+                Ok(vec![
+                    author_event(1, returned_keys[0].clone()),
+                    author_event(2, returned_keys[1].clone()),
+                ])
+            });
         let loader = AuthorEventsByEventSetLoader::new(claims(), event_query);
 
         let result = loader.load(&keys).await.unwrap();
 
-        assert_eq!(result.len(), 2);
-        assert!(result.values().all(Vec::is_empty));
+        assert_eq!(result.len(), 3);
+        assert_eq!(result[&keys[0]][0].event_id.as_str(), "1");
+        assert_eq!(result[&keys[1]][0].event_id.as_str(), "2");
+        assert!(result[&keys[2]].is_empty());
     }
 
     #[tokio::test]

--- a/src/presentation/graphql/object.rs
+++ b/src/presentation/graphql/object.rs
@@ -5,16 +5,18 @@ use serde_json::Value;
 use time::OffsetDateTime;
 
 use crate::common::types::{BookFormat as CommonBookFormat, BookStore as CommonBookStore};
-use crate::dependency_injection::{AQ, BQ};
+use crate::dependency_injection::{AQ, BQ, EQ};
 use crate::use_case::dto::author::{AuthorDto, CreateAuthorDto, UpdateAuthorDto};
 use crate::use_case::dto::book::{
     BookDto, CreateBookDto, ImportAuthorPreviewDto, ImportAuthorStatus as ImportAuthorStatusDto,
     ImportBookEntryDto, ImportBookPreviewDto, ImportBooksPreviewDto, UpdateBookDto,
 };
 use crate::use_case::dto::event::{AuthorEventDto, BookEventDto};
-use crate::use_case::dto::event_set::{EventSetDetailDto, EventSetDto};
+use crate::use_case::dto::event_set::EventSetDto;
 
-use super::loader::{AuthorLoader, BooksByAuthorLoader};
+use super::loader::{
+    AuthorEventsByEventSetLoader, AuthorLoader, BookEventsByEventSetLoader, BooksByAuthorLoader,
+};
 
 #[derive(SimpleObject)]
 pub struct User {
@@ -362,7 +364,7 @@ impl From<ImportBookInput> for ImportBookEntryDto {
     }
 }
 
-#[derive(SimpleObject)]
+#[derive(Clone, SimpleObject)]
 pub struct BookEventEntry {
     pub event_id: ID,
     pub event_set_id: ID,
@@ -405,7 +407,7 @@ impl From<BookEventDto> for BookEventEntry {
     }
 }
 
-#[derive(SimpleObject)]
+#[derive(Clone, SimpleObject)]
 pub struct AuthorEventEntry {
     pub event_id: ID,
     pub event_set_id: ID,
@@ -437,13 +439,14 @@ impl From<AuthorEventDto> for AuthorEventEntry {
 }
 
 #[derive(SimpleObject)]
-pub struct EventSetEntry {
+#[graphql(complex)]
+pub struct EventSet {
     pub id: ID,
     pub operation: String,
     pub created_at: i64,
 }
 
-impl From<EventSetDto> for EventSetEntry {
+impl From<EventSetDto> for EventSet {
     fn from(dto: EventSetDto) -> Self {
         Self {
             id: ID(dto.id),
@@ -453,32 +456,22 @@ impl From<EventSetDto> for EventSetEntry {
     }
 }
 
-#[derive(SimpleObject)]
-pub struct EventSetDetail {
-    pub id: ID,
-    pub operation: String,
-    pub created_at: i64,
-    pub book_events: Vec<BookEventEntry>,
-    pub author_events: Vec<AuthorEventEntry>,
-}
+#[ComplexObject]
+impl EventSet {
+    async fn book_events(&self, ctx: &Context<'_>) -> Result<Vec<BookEventEntry>> {
+        let loader = ctx.data_unchecked::<DataLoader<BookEventsByEventSetLoader<EQ>>>();
+        Ok(loader
+            .load_one(self.id.to_string())
+            .await?
+            .unwrap_or_default())
+    }
 
-impl From<EventSetDetailDto> for EventSetDetail {
-    fn from(dto: EventSetDetailDto) -> Self {
-        Self {
-            id: ID(dto.id),
-            operation: dto.operation,
-            created_at: dto.created_at.unix_timestamp(),
-            book_events: dto
-                .book_events
-                .into_iter()
-                .map(BookEventEntry::from)
-                .collect(),
-            author_events: dto
-                .author_events
-                .into_iter()
-                .map(AuthorEventEntry::from)
-                .collect(),
-        }
+    async fn author_events(&self, ctx: &Context<'_>) -> Result<Vec<AuthorEventEntry>> {
+        let loader = ctx.data_unchecked::<DataLoader<AuthorEventsByEventSetLoader<EQ>>>();
+        Ok(loader
+            .load_one(self.id.to_string())
+            .await?
+            .unwrap_or_default())
     }
 }
 

--- a/src/presentation/graphql/query.rs
+++ b/src/presentation/graphql/query.rs
@@ -10,9 +10,7 @@ use crate::{
     },
 };
 
-use super::object::{
-    Author, AuthorEventEntry, Book, BookEventEntry, EventSetDetail, EventSetEntry, User,
-};
+use super::object::{Author, AuthorEventEntry, Book, BookEventEntry, EventSet, User};
 
 pub struct Query<UQ, BQ, AQ, EQ> {
     user_query: UQ,
@@ -112,13 +110,10 @@ where
     }
 
     /// Returns the logged-in user's event sets, newest first.
-    async fn event_sets(
-        &self,
-        ctx: &Context<'_>,
-    ) -> Result<Vec<EventSetEntry>, PresentationalError> {
+    async fn event_sets(&self, ctx: &Context<'_>) -> Result<Vec<EventSet>, PresentationalError> {
         let claims = get_claims(ctx)?;
         let sets = self.event_query.list_event_sets(&claims.sub).await?;
-        Ok(sets.into_iter().map(EventSetEntry::from).collect())
+        Ok(sets.into_iter().map(EventSet::from).collect())
     }
 
     /// Returns a single event set with nested events, or null if not found.
@@ -126,13 +121,13 @@ where
         &self,
         ctx: &Context<'_>,
         id: ID,
-    ) -> Result<Option<EventSetDetail>, PresentationalError> {
+    ) -> Result<Option<EventSet>, PresentationalError> {
         let claims = get_claims(ctx)?;
-        let detail = self
+        let event_set = self
             .event_query
             .find_event_set(&claims.sub, id.as_str())
             .await?;
-        Ok(detail.map(EventSetDetail::from))
+        Ok(event_set.map(EventSet::from))
     }
 }
 

--- a/src/presentation/graphql/schema.rs
+++ b/src/presentation/graphql/schema.rs
@@ -192,6 +192,19 @@ mod tests {
         assert!(schema.sdl().contains("\tbooks: [Book!]!"));
     }
 
+    #[test]
+    fn event_set_uses_one_graphql_type_for_list_and_detail() {
+        let sdl = build_schema(query(), mutation()).sdl();
+
+        assert!(sdl.contains("type EventSet {"));
+        assert!(!sdl.contains("type EventSetEntry"));
+        assert!(!sdl.contains("type EventSetDetail"));
+        assert!(sdl.contains("\teventSets: [EventSet!]!"));
+        assert!(sdl.contains("\teventSet(id: ID!): EventSet"));
+        assert!(sdl.contains("\tbookEvents: [BookEventEntry!]!"));
+        assert!(sdl.contains("\tauthorEvents: [AuthorEventEntry!]!"));
+    }
+
     #[cfg(feature = "test-with-database")]
     #[sqlx::test]
     async fn authors_resolve_populated_shared_and_empty_book_lists(
@@ -247,7 +260,7 @@ mod tests {
         .execute(&pool)
         .await?;
 
-        let (author_query, book_query, schema) = dependency_injection(pool);
+        let (author_query, book_query, _event_query, schema) = dependency_injection(pool);
         let claims = Claims {
             sub: "user1".to_string(),
             _permissions: None,

--- a/src/presentation/handler/graphql.rs
+++ b/src/presentation/handler/graphql.rs
@@ -9,10 +9,13 @@ use axum::{
 };
 
 use crate::{
-    dependency_injection::{AQ, AppSchema, BQ},
+    dependency_injection::{AQ, AppSchema, BQ, EQ},
     presentation::{
         extractor::claims::Claims,
-        graphql::loader::{AuthorLoader, BooksByAuthorLoader},
+        graphql::loader::{
+            AuthorEventsByEventSetLoader, AuthorLoader, BookEventsByEventSetLoader,
+            BooksByAuthorLoader,
+        },
     },
 };
 
@@ -21,6 +24,7 @@ pub async fn graphql_handler(
     schema: Extension<AppSchema>,
     Extension(author_query): Extension<AQ>,
     Extension(book_query): Extension<BQ>,
+    Extension(event_query): Extension<EQ>,
     req: GraphQLRequest,
 ) -> GraphQLResponse {
     let author_loader = DataLoader::new(
@@ -31,13 +35,23 @@ pub async fn graphql_handler(
         BooksByAuthorLoader::new(claims.clone(), book_query),
         tokio::spawn,
     );
+    let book_events_by_event_set_loader = DataLoader::new(
+        BookEventsByEventSetLoader::new(claims.clone(), event_query.clone()),
+        tokio::spawn,
+    );
+    let author_events_by_event_set_loader = DataLoader::new(
+        AuthorEventsByEventSetLoader::new(claims.clone(), event_query),
+        tokio::spawn,
+    );
 
     schema
         .execute(
             req.into_inner()
                 .data(claims)
                 .data(author_loader)
-                .data(books_by_author_loader),
+                .data(books_by_author_loader)
+                .data(book_events_by_event_set_loader)
+                .data(author_events_by_event_set_loader),
         )
         .await
         .into()

--- a/src/use_case/dto/event_set.rs
+++ b/src/use_case/dto/event_set.rs
@@ -1,9 +1,6 @@
 use time::OffsetDateTime;
 
-use crate::{
-    domain::entity::event_set::EventSet,
-    use_case::dto::event::{AuthorEventDto, BookEventDto},
-};
+use crate::domain::entity::event_set::EventSet;
 
 #[derive(Debug, Clone)]
 pub struct EventSetDto {
@@ -18,31 +15,6 @@ impl From<EventSet> for EventSetDto {
             id: e.id.to_string(),
             operation: e.operation.as_str().to_string(),
             created_at: e.created_at,
-        }
-    }
-}
-
-#[derive(Debug, Clone)]
-pub struct EventSetDetailDto {
-    pub id: String,
-    pub operation: String,
-    pub created_at: OffsetDateTime,
-    pub book_events: Vec<BookEventDto>,
-    pub author_events: Vec<AuthorEventDto>,
-}
-
-impl EventSetDetailDto {
-    pub fn new(
-        event_set: EventSet,
-        book_events: Vec<BookEventDto>,
-        author_events: Vec<AuthorEventDto>,
-    ) -> Self {
-        Self {
-            id: event_set.id.to_string(),
-            operation: event_set.operation.as_str().to_string(),
-            created_at: event_set.created_at,
-            book_events,
-            author_events,
         }
     }
 }

--- a/src/use_case/interactor/event.rs
+++ b/src/use_case/interactor/event.rs
@@ -9,7 +9,7 @@ use crate::{
     use_case::{
         dto::{
             event::{AuthorEventDto, BookEventDto},
-            event_set::{EventSetDetailDto, EventSetDto},
+            event_set::EventSetDto,
         },
         error::UseCaseError,
         traits::event::EventQueryUseCase,
@@ -77,6 +77,50 @@ where
             .collect())
     }
 
+    async fn list_book_events_by_event_set_ids(
+        &self,
+        user_id: &str,
+        event_set_ids: &[String],
+    ) -> Result<Vec<BookEventDto>, UseCaseError> {
+        let user_id = UserId::new(user_id.to_string())?;
+        let event_set_ids = event_set_ids
+            .iter()
+            .map(|id| EventSetId::try_from(id.as_str()))
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|error| {
+                UseCaseError::from(crate::domain::error::DomainError::Validation(error))
+            })?;
+        Ok(self
+            .book_event_repository
+            .find_by_event_set_ids(&user_id, &event_set_ids)
+            .await?
+            .into_iter()
+            .map(BookEventDto::from)
+            .collect())
+    }
+
+    async fn list_author_events_by_event_set_ids(
+        &self,
+        user_id: &str,
+        event_set_ids: &[String],
+    ) -> Result<Vec<AuthorEventDto>, UseCaseError> {
+        let user_id = UserId::new(user_id.to_string())?;
+        let event_set_ids = event_set_ids
+            .iter()
+            .map(|id| EventSetId::try_from(id.as_str()))
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|error| {
+                UseCaseError::from(crate::domain::error::DomainError::Validation(error))
+            })?;
+        Ok(self
+            .author_event_repository
+            .find_by_event_set_ids(&user_id, &event_set_ids)
+            .await?
+            .into_iter()
+            .map(AuthorEventDto::from)
+            .collect())
+    }
+
     async fn list_event_sets(&self, user_id: &str) -> Result<Vec<EventSetDto>, UseCaseError> {
         let user_id = UserId::new(user_id.to_string())?;
         Ok(self
@@ -92,37 +136,16 @@ where
         &self,
         user_id: &str,
         event_set_id: &str,
-    ) -> Result<Option<EventSetDetailDto>, UseCaseError> {
+    ) -> Result<Option<EventSetDto>, UseCaseError> {
         let user_id = UserId::new(user_id.to_string())?;
         let event_set_id = EventSetId::try_from(event_set_id).map_err(|error| {
             UseCaseError::from(crate::domain::error::DomainError::Validation(error))
         })?;
-        let Some(event_set) = self
+        let event_set = self
             .event_set_repository
             .find_by_id(&user_id, &event_set_id)
-            .await?
-        else {
-            return Ok(None);
-        };
-        let book_events = self
-            .book_event_repository
-            .find_by_event_set(&user_id, &event_set_id)
-            .await?
-            .into_iter()
-            .map(BookEventDto::from)
-            .collect();
-        let author_events = self
-            .author_event_repository
-            .find_by_event_set(&user_id, &event_set_id)
-            .await?
-            .into_iter()
-            .map(AuthorEventDto::from)
-            .collect();
-        Ok(Some(EventSetDetailDto::new(
-            event_set,
-            book_events,
-            author_events,
-        )))
+            .await?;
+        Ok(event_set.map(EventSetDto::from))
     }
 }
 
@@ -265,11 +288,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn find_event_set_combines_event_set_and_events() {
+    async fn find_event_set_returns_scalar_dto_without_loading_events() {
         let event_set_id = EventSetId::new();
         let event_set_id_string = event_set_id.to_string();
-        let book_id = Uuid::new_v4();
-        let author_id = Uuid::new_v4();
         let mut event_sets = MockEventSetRepository::new();
         event_sets.expect_find_by_id().return_once(move |_, _| {
             Ok(Some(EventSet {
@@ -279,17 +300,11 @@ mod tests {
                 created_at: OffsetDateTime::UNIX_EPOCH,
             }))
         });
-        let detail_event_set_id = EventSetId::try_from(event_set_id_string.as_str()).unwrap();
-        let mut book_events = MockBookEventRepository::new();
-        book_events
-            .expect_find_by_event_set()
-            .return_once(move |_, _| Ok(vec![book_event(detail_event_set_id, book_id)]));
-        let detail_event_set_id = EventSetId::try_from(event_set_id_string.as_str()).unwrap();
-        let mut author_events = MockAuthorEventRepository::new();
-        author_events
-            .expect_find_by_event_set()
-            .return_once(move |_, _| Ok(vec![author_event(detail_event_set_id, author_id)]));
-        let interactor = interactor(book_events, author_events, event_sets);
+        let interactor = interactor(
+            MockBookEventRepository::new(),
+            MockAuthorEventRepository::new(),
+            event_sets,
+        );
 
         let result = interactor
             .find_event_set("user1", &event_set_id_string)
@@ -299,10 +314,122 @@ mod tests {
 
         assert_eq!(result.id, event_set_id_string);
         assert_eq!(result.operation, "create_book");
-        assert_eq!(result.book_events.len(), 1);
-        assert_eq!(result.book_events[0].book_id, book_id.to_string());
-        assert_eq!(result.author_events.len(), 1);
-        assert_eq!(result.author_events[0].author_id, author_id.to_string());
+        assert_eq!(result.created_at, OffsetDateTime::UNIX_EPOCH);
+    }
+
+    #[tokio::test]
+    async fn find_event_set_returns_none_when_not_found() {
+        let event_set_id = EventSetId::new().to_string();
+        let mut event_sets = MockEventSetRepository::new();
+        event_sets.expect_find_by_id().return_once(|_, _| Ok(None));
+        let interactor = interactor(
+            MockBookEventRepository::new(),
+            MockAuthorEventRepository::new(),
+            event_sets,
+        );
+
+        let result = interactor
+            .find_event_set("user1", &event_set_id)
+            .await
+            .unwrap();
+
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn list_book_events_by_event_set_ids_converts_batch() {
+        let event_set_id = EventSetId::new();
+        let expected_id = event_set_id.to_string();
+        let book_id = Uuid::new_v4();
+        let mut book_events = MockBookEventRepository::new();
+        book_events
+            .expect_find_by_event_set_ids()
+            .times(1)
+            .return_once(move |_, _| Ok(vec![book_event(event_set_id, book_id)]));
+        let interactor = interactor(
+            book_events,
+            MockAuthorEventRepository::new(),
+            MockEventSetRepository::new(),
+        );
+
+        let result = interactor
+            .list_book_events_by_event_set_ids("user1", std::slice::from_ref(&expected_id))
+            .await
+            .unwrap();
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].event_set_id, expected_id);
+        assert_eq!(result[0].book_id, book_id.to_string());
+    }
+
+    #[tokio::test]
+    async fn list_author_events_by_event_set_ids_handles_empty_result() {
+        let event_set_id = EventSetId::new().to_string();
+        let mut author_events = MockAuthorEventRepository::new();
+        author_events
+            .expect_find_by_event_set_ids()
+            .times(1)
+            .return_once(|_, _| Ok(Vec::new()));
+        let interactor = interactor(
+            MockBookEventRepository::new(),
+            author_events,
+            MockEventSetRepository::new(),
+        );
+
+        let result = interactor
+            .list_author_events_by_event_set_ids("user1", &[event_set_id])
+            .await
+            .unwrap();
+
+        assert!(result.is_empty());
+    }
+
+    #[tokio::test]
+    async fn list_author_events_by_event_set_ids_converts_batch() {
+        let event_set_id = EventSetId::new();
+        let expected_id = event_set_id.to_string();
+        let author_id = Uuid::new_v4();
+        let mut author_events = MockAuthorEventRepository::new();
+        author_events
+            .expect_find_by_event_set_ids()
+            .times(1)
+            .return_once(move |_, _| Ok(vec![author_event(event_set_id, author_id)]));
+        let interactor = interactor(
+            MockBookEventRepository::new(),
+            author_events,
+            MockEventSetRepository::new(),
+        );
+
+        let result = interactor
+            .list_author_events_by_event_set_ids("user1", std::slice::from_ref(&expected_id))
+            .await
+            .unwrap();
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].event_set_id, expected_id);
+        assert_eq!(result[0].author_id, author_id.to_string());
+    }
+
+    #[tokio::test]
+    async fn list_book_events_by_event_set_ids_handles_empty_ids() {
+        let mut book_events = MockBookEventRepository::new();
+        book_events
+            .expect_find_by_event_set_ids()
+            .withf(|_, ids| ids.is_empty())
+            .times(1)
+            .return_once(|_, _| Ok(Vec::new()));
+        let interactor = interactor(
+            book_events,
+            MockAuthorEventRepository::new(),
+            MockEventSetRepository::new(),
+        );
+
+        let result = interactor
+            .list_book_events_by_event_set_ids("user1", &[])
+            .await
+            .unwrap();
+
+        assert!(result.is_empty());
     }
 
     #[tokio::test]

--- a/src/use_case/traits/event.rs
+++ b/src/use_case/traits/event.rs
@@ -4,7 +4,7 @@ use mockall::automock;
 use crate::use_case::{
     dto::{
         event::{AuthorEventDto, BookEventDto},
-        event_set::{EventSetDetailDto, EventSetDto},
+        event_set::EventSetDto,
     },
     error::UseCaseError,
 };
@@ -22,10 +22,20 @@ pub trait EventQueryUseCase: Send + Sync + 'static {
         user_id: &str,
         author_id: &str,
     ) -> Result<Vec<AuthorEventDto>, UseCaseError>;
+    async fn list_book_events_by_event_set_ids(
+        &self,
+        user_id: &str,
+        event_set_ids: &[String],
+    ) -> Result<Vec<BookEventDto>, UseCaseError>;
+    async fn list_author_events_by_event_set_ids(
+        &self,
+        user_id: &str,
+        event_set_ids: &[String],
+    ) -> Result<Vec<AuthorEventDto>, UseCaseError>;
     async fn list_event_sets(&self, user_id: &str) -> Result<Vec<EventSetDto>, UseCaseError>;
     async fn find_event_set(
         &self,
         user_id: &str,
         event_set_id: &str,
-    ) -> Result<Option<EventSetDetailDto>, UseCaseError>;
+    ) -> Result<Option<EventSetDto>, UseCaseError>;
 }


### PR DESCRIPTION
## Summary

- replace the GraphQL `EventSetEntry` and `EventSetDetail` types with one `EventSet` type
- remove `EventSetDetailDto` and keep `EventSetDto` scalar-only for list and single-item lookups
- resolve `bookEvents` and `authorEvents` lazily through request-scoped DataLoaders
- add user-scoped batch repository/use-case queries so nested fields across an event-set list do not cause N+1 queries
- add an OpenSpec change covering the schema contract and loading behavior

## Compatibility

This is a schema-level breaking change for clients that refer directly to the removed GraphQL type names. Existing query field names, selected response fields, and nullability are unchanged.

The list resolver does not fetch nested events unless those fields are selected. Each selected nested event kind is fetched with one batch query across the requested event-set IDs.

## Tests

- `cargo fmt --check`
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo test --locked` (147 passed)
- `DATABASE_URL=postgres://bookshelf:password@localhost:5432/bookshelf cargo test --locked --features test-with-database` (220 passed)
- `TEST_SERVER_URL=http://localhost:8080 cargo test -p bookshelf-e2e --locked -- --test-threads=1` (47 passed)
- `openspec validate unify-event-set --strict`
- generated `schema.graphql` exact-diff check

## Frontend verification

The paired `bookshelf` repository derives component types from operation results. Its local schema and generated types were verified with the unified schema; no tracked UI/operation changes are required.

- GraphQL generation with the local unified schema
- `pnpm run lint:fix`
- `pnpm run test` (175 passed)
- `pnpm run typecheck`
- `pnpm exec playwright test --config=playwright.demo.config.ts e2e-demo-mode/history.spec.ts` (1 passed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - イベントセットのGraphQL型を`EventSet`に統一しました。
  - 一覧・詳細の両方で、書籍イベントと著者イベントを取得できるようになりました。
  - 複数のイベントセットに関連するイベントを効率的に読み込めるようになりました。

- **仕様変更**
  - 旧イベントセット型は廃止されました。既存クライアントでは生成済みGraphQL型の更新が必要です。
  - ユーザー単位のデータ分離と既存の画面動作は維持されます。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->