### PR TITLE
Add atomic operation undo

### DIFF
--- a/e2e/tests/graphql_undo.rs
+++ b/e2e/tests/graphql_undo.rs
@@ -1,0 +1,192 @@
+#![cfg(test)]
+
+use anyhow::{Context, Result};
+use bookshelf_e2e::*;
+use serial_test::serial;
+
+async fn undo(operation_id: &str, token: &str) -> Result<serde_json::Value> {
+    let mutation =
+        format!(r#"mutation {{ undoOperation(operationId: "{operation_id}") {{ operationId }} }}"#);
+    let (_, response) = graphql_request(&mutation, Some(token)).await?;
+    Ok(response)
+}
+
+#[tokio::test]
+#[serial]
+async fn undo_create_and_undo_of_undo_round_trip_book_state() -> Result<()> {
+    let (_user_id, token) = create_test_user().await?;
+    let author_id = create_test_author("Undo Author", &token).await?;
+    let (book_id, _, create_operation_id) =
+        create_test_book_with_event("Undo Book", &author_id, &token).await?;
+
+    let response = undo(&create_operation_id, &token).await?;
+    assert_no_graphql_errors(&response, "undo create Book");
+    let undo_operation_id = response["data"]["undoOperation"]["operationId"]
+        .as_str()
+        .context("undo operation ID")?;
+
+    let (_, response) = graphql_request(
+        &format!(r#"{{ book(id: "{book_id}") {{ id }} }}"#),
+        Some(&token),
+    )
+    .await?;
+    assert_no_graphql_errors(&response, "query undone Book");
+    assert!(response["data"]["book"].is_null());
+
+    let response = undo(undo_operation_id, &token).await?;
+    assert_no_graphql_errors(&response, "undo the undo");
+
+    let (_, response) = graphql_request(
+        &format!(
+            r#"{{ book(id: "{book_id}") {{ id title }} bookRevisions(bookId: "{book_id}") {{ revisionNumber }} }}"#
+        ),
+        Some(&token),
+    )
+    .await?;
+    assert_no_graphql_errors(&response, "query restored Book");
+    assert_eq!(response["data"]["book"]["title"], "Undo Book");
+    assert_eq!(response["data"]["bookRevisions"][0]["revisionNumber"], 2);
+
+    delete_test_book(&book_id, &token).await?;
+    delete_test_author(&author_id, &token).await?;
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
+async fn undo_update_ignores_unrelated_changes_but_rejects_target_conflicts() -> Result<()> {
+    let (_user_id, token) = create_test_user().await?;
+    let author_id = create_test_author("Undo Update Author", &token).await?;
+    let (book_id, _, _) = create_test_book_with_event("Before", &author_id, &token).await?;
+    let update = |title: &str| {
+        format!(
+            r#"mutation {{ updateBook(bookData: {{
+              id: "{book_id}" title: "{title}" authorIds: ["{author_id}"]
+              isbn: "" read: false owned: true priority: 1
+              format: PRINTED store: UNKNOWN
+            }}) {{ operationId }} }}"#
+        )
+    };
+    let (_, response) = graphql_request(&update("First"), Some(&token)).await?;
+    assert_no_graphql_errors(&response, "first update");
+    let first_operation = response["data"]["updateBook"]["operationId"]
+        .as_str()
+        .context("first update operation")?
+        .to_owned();
+
+    let unrelated_author = create_test_author("Unrelated Undo Author", &token).await?;
+    let response = undo(&first_operation, &token).await?;
+    assert_no_graphql_errors(&response, "undo with unrelated later Operation");
+
+    let (_, response) = graphql_request(&update("Second"), Some(&token)).await?;
+    assert_no_graphql_errors(&response, "second update");
+    let second_operation = response["data"]["updateBook"]["operationId"]
+        .as_str()
+        .context("second update operation")?
+        .to_owned();
+    let (_, response) = graphql_request(&update("Conflicting"), Some(&token)).await?;
+    assert_no_graphql_errors(&response, "conflicting update");
+    let response = undo(&second_operation, &token).await?;
+    assert!(response.get("errors").is_some());
+
+    delete_test_book(&book_id, &token).await?;
+    delete_test_author(&author_id, &token).await?;
+    delete_test_author(&unrelated_author, &token).await?;
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
+async fn undo_delete_restores_the_entity_with_a_fresh_revision() -> Result<()> {
+    let (_user_id, token) = create_test_user().await?;
+    let author_id = create_test_author("Undo Delete Author", &token).await?;
+    let (book_id, _, _) = create_test_book_with_event("Deleted Book", &author_id, &token).await?;
+    let mutation = format!(r#"mutation {{ deleteBook(bookId: "{book_id}") {{ operationId }} }}"#);
+    let (_, response) = graphql_request(&mutation, Some(&token)).await?;
+    assert_no_graphql_errors(&response, "delete before undo");
+    let delete_operation = response["data"]["deleteBook"]["operationId"]
+        .as_str()
+        .context("delete operation")?;
+
+    let response = undo(delete_operation, &token).await?;
+    assert_no_graphql_errors(&response, "undo delete");
+    let (_, response) = graphql_request(
+        &format!(r#"{{ book(id: "{book_id}") {{ title }} bookRevisions(bookId: "{book_id}") {{ revisionNumber }} }}"#),
+        Some(&token),
+    ).await?;
+    assert_eq!(response["data"]["book"]["title"], "Deleted Book");
+    assert_eq!(response["data"]["bookRevisions"][0]["revisionNumber"], 2);
+
+    delete_test_book(&book_id, &token).await?;
+    delete_test_author(&author_id, &token).await?;
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
+async fn undo_import_removes_created_books_and_authors_atomically() -> Result<()> {
+    let (_user_id, token) = create_test_user().await?;
+    let author_name = format!("Imported Undo Author {}", uuid::Uuid::new_v4());
+    let mutation = format!(
+        r#"mutation {{ importBooks(books: [{{
+          title: "Imported Undo Book" authorNames: ["{author_name}"] isbn: ""
+          read: false owned: true priority: 1 format: PRINTED store: UNKNOWN
+        }}]) {{ operationId books {{ id }} }} }}"#
+    );
+    let (_, response) = graphql_request(&mutation, Some(&token)).await?;
+    assert_no_graphql_errors(&response, "import before undo");
+    let operation_id = response["data"]["importBooks"]["operationId"]
+        .as_str()
+        .context("import operation")?;
+    let book_id = response["data"]["importBooks"]["books"][0]["id"]
+        .as_str()
+        .context("imported Book")?;
+
+    let response = undo(operation_id, &token).await?;
+    assert_no_graphql_errors(&response, "undo import");
+    let (_, response) = graphql_request(
+        &format!(r#"{{ book(id: "{book_id}") {{ id }} authors {{ name }} }}"#),
+        Some(&token),
+    )
+    .await?;
+    assert!(response["data"]["book"].is_null());
+    assert!(
+        response["data"]["authors"]
+            .as_array()
+            .context("authors")?
+            .iter()
+            .all(|author| author["name"] != author_name)
+    );
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
+async fn undo_merge_restores_source_and_book_relationships() -> Result<()> {
+    let (_user_id, token) = create_test_user().await?;
+    let source_id = create_test_author("Undo Merge Source", &token).await?;
+    let destination_id = create_test_author("Undo Merge Destination", &token).await?;
+    let book_id = create_test_book("Undo Merge Book", &source_id, &token).await?;
+    let mutation = format!(
+        r#"mutation {{ mergeAuthor(sourceAuthorId: "{source_id}", destinationAuthorId: "{destination_id}") {{ operationId }} }}"#
+    );
+    let (_, response) = graphql_request(&mutation, Some(&token)).await?;
+    assert_no_graphql_errors(&response, "merge before undo");
+    let operation_id = response["data"]["mergeAuthor"]["operationId"]
+        .as_str()
+        .context("merge operation")?;
+
+    let response = undo(operation_id, &token).await?;
+    assert_no_graphql_errors(&response, "undo merge");
+    let (_, response) = graphql_request(
+        &format!(r#"{{ author(id: "{source_id}") {{ id }} book(id: "{book_id}") {{ authors {{ id }} }} }}"#),
+        Some(&token),
+    ).await?;
+    assert_eq!(response["data"]["author"]["id"], source_id);
+    assert_eq!(response["data"]["book"]["authors"][0]["id"], source_id);
+
+    delete_test_book(&book_id, &token).await?;
+    delete_test_author(&source_id, &token).await?;
+    delete_test_author(&destination_id, &token).await?;
+    Ok(())
+}

--- a/openspec/changes/redesign-history-model/design.md
+++ b/openspec/changes/redesign-history-model/design.md
@@ -75,6 +75,11 @@ An Operation is undoable only when it is owned, is not baseline, and every chang
 
 `undoOperation` begins a new `undo` Operation linked through `undo_of_operation_id`, locks every affected entity/history key in deterministic order, and repeats eligibility and reference validation. It then applies each target before-state. For related multi-entity Operations, restorations run Author before Book so restored Books can resolve their Authors, while deletions run Book before Author so no live Book retains a deleted Author reference. Restoring content appends a fresh revision; undoing a create deletes the entity and records `current -> none`. PR 2 import and merge E2E tests will verify this ordering and that all changes commit or roll back together. Undoing an undo is not specially exposed but the model does not prohibit it.
 
+PR 2 does not expose a computed GraphQL `undoable` field. Clients attempt
+`undoOperation` and handle a conflict when the target after-state is stale. This
+keeps the transaction-time server revalidation authoritative and avoids a
+time-of-check/time-of-use promise in the query contract.
+
 ### Replace the GraphQL history contract directly
 
 Queries expose `operations`, `operation(id)`, `bookRevisions(bookId)`, `bookRevision(bookId, revisionNumber)`, and Author equivalents. Operation nested Book/Author changes batch by Operation IDs and load only when selected. Changes expose before/after Revision objects. All paths are tenant-scoped.
@@ -109,4 +114,3 @@ Rollback before PR 3 can return application traffic to the legacy release while 
 
 - Whether normal `operations` queries expose an explicit `includeBaseline` argument or always hide baseline while direct lookup remains available; choose the smallest API consistent with frontend needs during PR 1.
 - Exact pagination shape for Operation and Revision lists; reuse the repository's prevailing list conventions unless scale testing requires cursors.
-- Whether `undoable` is exposed as a computed GraphQL field in PR 2 or clients attempt undo and handle a conflict; server-side execution validation is mandatory either way.

--- a/openspec/changes/redesign-history-model/tasks.md
+++ b/openspec/changes/redesign-history-model/tasks.md
@@ -16,19 +16,19 @@
 - [x] 1.14 Add `operations`, `operation`, Book Revision, and Author Revision GraphQL queries plus selection-driven batched nested changes and before/after Revision resolution
 - [x] 1.15 Remove Event/EventSet GraphQL queries, types, loaders, mutation metadata, and restore arguments; update the generated schema, API E2E contracts, fixtures, and architecture/database docs for the breaking Operation/Revision-only contract; migrate the frontend separately
 - [x] 1.16 Run PR 1 unit, database integration, migration, rollback, import, merge, restore, E2E, formatting, lint, full test, and OpenSpec validation suites
-- [ ] 1.17 Commit granular PR 1 changes, push, create the PR, fix CI to green, request `@coderabbitai review`, address and reply to findings, re-request after fixes or rate-limit expiry, obtain approval, and merge
+- [x] 1.17 Commit granular PR 1 changes, push, create the PR, fix CI to green, request `@coderabbitai review`, address and reply to findings, re-request after fixes or rate-limit expiry, obtain approval, and merge
 
 ## 2. PR 2 — Operation undo
 
-- [ ] 2.1 Update local `main` after PR 1 merge, record its SHA, and create a fresh `codex/` PR 2 branch
-- [ ] 2.2 Implement owned undo eligibility for create, update, delete, restore, import, and merge changes using only each affected entity's current after-state
-- [ ] 2.3 Add deterministic multi-entity locking and in-transaction revalidation for undo execution
-- [ ] 2.4 Implement inverse application that restores Authors before Books, deletes Books before Authors, appends new Revisions for restored content, deletes creations without deleted Revisions, and records a linked Undo Operation with all changes
-- [ ] 2.5 Validate current Book Author references during undo and roll back the complete multi-entity Operation on any failure
-- [ ] 2.6 Add `undoOperation(operationId)` and decide/document whether Operation exposes computed `undoable`, while always revalidating server-side
-- [ ] 2.7 Add unit and database tests for update, create, delete, restore, import, merge, related-entity restore/delete ordering, unrelated later Operations, conflicting later revisions, deleted-state matching, missing references, atomic rollback, and undo history
-- [ ] 2.8 Add/update GraphQL E2E coverage and schema assets for undo, including import/merge ordering and atomicity plus future undo-of-undo representability
-- [ ] 2.9 Run PR 2 formatting, lint, full tests, database integration, E2E, and OpenSpec validation
+- [x] 2.1 Update local `main` after PR 1 merge, record its SHA (`1e6ec8b`), and create a fresh `codex/` PR 2 branch (`codex/operation-undo`)
+- [x] 2.2 Implement owned undo eligibility for create, update, delete, restore, import, and merge changes using only each affected entity's current after-state
+- [x] 2.3 Add deterministic multi-entity locking and in-transaction revalidation for undo execution
+- [x] 2.4 Implement inverse application that restores Authors before Books, deletes Books before Authors, appends new Revisions for restored content, deletes creations without deleted Revisions, and records a linked Undo Operation with all changes
+- [x] 2.5 Validate current Book Author references during undo and roll back the complete multi-entity Operation on any failure
+- [x] 2.6 Add `undoOperation(operationId)` and decide/document whether Operation exposes computed `undoable`, while always revalidating server-side
+- [x] 2.7 Add unit and database tests for update, create, delete, restore, import, merge, related-entity restore/delete ordering, unrelated later Operations, conflicting later revisions, deleted-state matching, missing references, atomic rollback, and undo history
+- [x] 2.8 Add/update GraphQL E2E coverage and schema assets for undo, including import/merge ordering and atomicity plus future undo-of-undo representability
+- [x] 2.9 Run PR 2 formatting, lint, full tests, database integration, E2E, and OpenSpec validation
 - [ ] 2.10 Commit granular PR 2 changes, push, create the PR, fix CI to green, complete CodeRabbit review/replies/re-review to approval, and merge
 
 ## 3. PR 3 — Legacy Event/EventSet cleanup

--- a/schema.graphql
+++ b/schema.graphql
@@ -212,6 +212,7 @@ type Mutation {
 	Executes the book import path and rolls the complete transaction back.
 	"""
 	previewBookImport(books: [ImportBookInput!]!): ImportBooksPreview!
+	undoOperation(operationId: ID!): UndoOperationPayload!
 }
 
 type Operation {
@@ -248,6 +249,10 @@ type RestoreBookPayload {
 	book: Book
 	operationId: ID!
 	revisionNumber: Int!
+}
+
+type UndoOperationPayload {
+	operationId: ID!
 }
 
 input UpdateAuthorInput {

--- a/src/bin/gen_schema.rs
+++ b/src/bin/gen_schema.rs
@@ -3,7 +3,7 @@ use bookshelf_api::{
     use_case::traits::{
         author::{MockAuthorCommandUseCase, MockAuthorQueryUseCase},
         book::{MockBookCommandUseCase, MockBookQueryUseCase},
-        history::MockHistoryQueryUseCase,
+        history::{MockHistoryCommandUseCase, MockHistoryQueryUseCase},
         user::{MockUserCommandUseCase, MockUserQueryUseCase},
     },
 };
@@ -22,6 +22,7 @@ async fn main() {
         MockUserCommandUseCase::new(),
         MockBookCommandUseCase::new(),
         MockAuthorCommandUseCase::new(),
+        MockHistoryCommandUseCase::new(),
     );
     let schema = build_schema(query, mutation);
     let sdl = format!("{}\n", schema.sdl());

--- a/src/dependency_injection.rs
+++ b/src/dependency_injection.rs
@@ -36,7 +36,7 @@ pub type AC = AuthorCommandInteractor<
 pub type HQ = HistoryQueryInteractor<PgHistoryRepository>;
 
 pub type AppQuery = Query<UQ, BQ, AQ, HQ>;
-pub type AppMutation = Mutation<UC, BC, AC>;
+pub type AppMutation = Mutation<UC, BC, AC, HQ>;
 pub type AppSchema = Schema<AppQuery, AppMutation, EmptySubscription>;
 
 pub fn dependency_injection(pool: Pool<Postgres>) -> (AQ, BQ, HQ, AppSchema) {
@@ -70,7 +70,12 @@ pub fn dependency_injection(pool: Pool<Postgres>) -> (AQ, BQ, HQ, AppSchema) {
         author_query.clone(),
         history_query.clone(),
     );
-    let mutation = Mutation::new(user_command, book_command, author_command);
+    let mutation = Mutation::new(
+        user_command,
+        book_command,
+        author_command,
+        history_query.clone(),
+    );
     let schema = build_schema(query, mutation);
 
     (author_query, book_query, history_query, schema)

--- a/src/domain/error.rs
+++ b/src/domain/error.rs
@@ -15,6 +15,8 @@ pub enum DomainError {
     },
     #[error(r#"author "{author_id}" has associated books and cannot be deleted."#)]
     HasAssociatedBooks { author_id: String, user_id: String },
+    #[error("{0}")]
+    Conflict(String),
     #[error(transparent)]
     InfrastructureError(anyhow::Error),
     #[error("{0}")]

--- a/src/domain/repository/history_repository.rs
+++ b/src/domain/repository/history_repository.rs
@@ -26,6 +26,16 @@ pub trait HistoryRepository: Send + Sync + 'static {
         user_id: &UserId,
         operation_id: &OperationId,
     ) -> Result<Option<Operation>, DomainError>;
+    async fn is_operation_undoable(
+        &self,
+        user_id: &UserId,
+        operation_id: &OperationId,
+    ) -> Result<bool, DomainError>;
+    async fn undo_operation(
+        &self,
+        user_id: &UserId,
+        operation_id: &OperationId,
+    ) -> Result<OperationId, DomainError>;
     async fn find_book_revisions(
         &self,
         user_id: &UserId,

--- a/src/infrastructure.rs
+++ b/src/infrastructure.rs
@@ -7,4 +7,5 @@ pub mod event_set_repository;
 mod history_recording;
 pub mod history_repository;
 pub mod transaction;
+mod undo;
 pub mod user_repository;

--- a/src/infrastructure/book_repository.rs
+++ b/src/infrastructure/book_repository.rs
@@ -1470,7 +1470,7 @@ mod tests {
             "SELECT COUNT(*) FROM book_revision WHERE user_id = $1 AND book_id = ANY($2)",
         )
         .bind(user_id.as_str())
-        .bind(&[book1.id().to_uuid(), book2.id().to_uuid()])
+        .bind([book1.id().to_uuid(), book2.id().to_uuid()])
         .fetch_one(&pool)
         .await?;
         assert_eq!(revision_count, 4);

--- a/src/infrastructure/history_repository.rs
+++ b/src/infrastructure/history_repository.rs
@@ -189,6 +189,96 @@ impl HistoryRepository for PgHistoryRepository {
         .transpose()
     }
 
+    async fn is_operation_undoable(
+        &self,
+        user_id: &UserId,
+        operation_id: &OperationId,
+    ) -> Result<bool, DomainError> {
+        let undoable = sqlx::query_scalar::<_, bool>(
+            "SELECT EXISTS (
+                 SELECT 1
+                 FROM operation target
+                 WHERE target.user_id = $1
+                   AND target.id = $2
+                   AND target.type <> 'baseline'
+                   AND EXISTS (
+                       SELECT 1 FROM book_operation_change
+                       WHERE user_id = target.user_id AND operation_id = target.id
+                       UNION ALL
+                       SELECT 1 FROM author_operation_change
+                       WHERE user_id = target.user_id AND operation_id = target.id
+                   )
+                   AND NOT EXISTS (
+                       SELECT 1
+                       FROM book_operation_change change
+                       WHERE change.user_id = target.user_id
+                         AND change.operation_id = target.id
+                         AND (
+                           (change.after_revision_number IS NULL AND EXISTS (
+                               SELECT 1 FROM book current
+                               WHERE current.user_id = change.user_id
+                                 AND current.id = change.book_id
+                           ))
+                           OR
+                           (change.after_revision_number IS NOT NULL AND (
+                               NOT EXISTS (
+                                   SELECT 1 FROM book current
+                                   WHERE current.user_id = change.user_id
+                                     AND current.id = change.book_id
+                               )
+                               OR change.after_revision_number <> (
+                                   SELECT MAX(revision.revision_number)
+                                   FROM book_revision revision
+                                   WHERE revision.user_id = change.user_id
+                                     AND revision.book_id = change.book_id
+                               )
+                           ))
+                         )
+                   )
+                   AND NOT EXISTS (
+                       SELECT 1
+                       FROM author_operation_change change
+                       WHERE change.user_id = target.user_id
+                         AND change.operation_id = target.id
+                         AND (
+                           (change.after_revision_number IS NULL AND EXISTS (
+                               SELECT 1 FROM author current
+                               WHERE current.user_id = change.user_id
+                                 AND current.id = change.author_id
+                           ))
+                           OR
+                           (change.after_revision_number IS NOT NULL AND (
+                               NOT EXISTS (
+                                   SELECT 1 FROM author current
+                                   WHERE current.user_id = change.user_id
+                                     AND current.id = change.author_id
+                               )
+                               OR change.after_revision_number <> (
+                                   SELECT MAX(revision.revision_number)
+                                   FROM author_revision revision
+                                   WHERE revision.user_id = change.user_id
+                                     AND revision.author_id = change.author_id
+                               )
+                           ))
+                         )
+                   )
+             )",
+        )
+        .bind(user_id.as_str())
+        .bind(operation_id.to_uuid())
+        .fetch_one(&self.pool)
+        .await?;
+        Ok(undoable)
+    }
+
+    async fn undo_operation(
+        &self,
+        user_id: &UserId,
+        operation_id: &OperationId,
+    ) -> Result<OperationId, DomainError> {
+        super::undo::undo_operation(&self.pool, user_id, operation_id).await
+    }
+
     async fn find_book_revisions(
         &self,
         user_id: &UserId,
@@ -591,6 +681,86 @@ mod tests {
             .find_author_changes_by_operation_ids(&owner, std::slice::from_ref(&operation_id))
             .await?;
         assert_eq!(author_changes[&operation_id].len(), 1);
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn undo_eligibility_matches_only_the_current_after_state(
+        pool: PgPool,
+    ) -> anyhow::Result<()> {
+        let owner = user(&pool, "undo-owner").await?;
+        let other = user(&pool, "undo-other").await?;
+        let operation_id = Uuid::new_v4();
+        let book_id = Uuid::new_v4();
+        sqlx::query(
+            "INSERT INTO operation (id, user_id, type)
+             VALUES ($1, $2, 'create_book')",
+        )
+        .bind(operation_id)
+        .bind(owner.as_str())
+        .execute(&pool)
+        .await?;
+        sqlx::query(
+            "INSERT INTO book (
+               id, user_id, title, isbn, read, owned, priority, format, store
+             ) VALUES ($1, $2, 'Book', '', false, true, 4, 'Printed', 'Unknown')",
+        )
+        .bind(book_id)
+        .bind(owner.as_str())
+        .execute(&pool)
+        .await?;
+        sqlx::query(
+            "INSERT INTO book_revision (
+               book_id, revision_number, user_id, title, isbn, read, owned,
+               priority, format, store, book_created_at, book_updated_at
+             ) VALUES ($1, 1, $2, 'Book', '', false, true, 4, 'Printed',
+                       'Unknown', current_timestamp, current_timestamp)",
+        )
+        .bind(book_id)
+        .bind(owner.as_str())
+        .execute(&pool)
+        .await?;
+        sqlx::query(
+            "INSERT INTO book_operation_change
+               (operation_id, user_id, book_id, after_revision_number)
+             VALUES ($1, $2, $3, 1)",
+        )
+        .bind(operation_id)
+        .bind(owner.as_str())
+        .bind(book_id)
+        .execute(&pool)
+        .await?;
+
+        let repository = PgHistoryRepository::new(pool.clone());
+        let operation_id = OperationId::from(operation_id);
+        assert!(
+            repository
+                .is_operation_undoable(&owner, &operation_id)
+                .await?
+        );
+        assert!(
+            !repository
+                .is_operation_undoable(&other, &operation_id)
+                .await?
+        );
+
+        sqlx::query(
+            "INSERT INTO book_revision (
+               book_id, revision_number, user_id, title, isbn, read, owned,
+               priority, format, store, book_created_at, book_updated_at
+             ) VALUES ($1, 2, $2, 'Changed', '', false, true, 4, 'Printed',
+                       'Unknown', current_timestamp, current_timestamp)",
+        )
+        .bind(book_id)
+        .bind(owner.as_str())
+        .execute(&pool)
+        .await?;
+
+        assert!(
+            !repository
+                .is_operation_undoable(&owner, &operation_id)
+                .await?
+        );
         Ok(())
     }
 }

--- a/src/infrastructure/undo.rs
+++ b/src/infrastructure/undo.rs
@@ -1,0 +1,697 @@
+use sqlx::{FromRow, PgPool, Postgres, Transaction};
+use uuid::Uuid;
+
+use crate::domain::{
+    entity::{operation::OperationId, user::UserId},
+    error::DomainError,
+};
+
+#[derive(Debug, FromRow)]
+struct BookChange {
+    book_id: Uuid,
+    before_revision_number: Option<i32>,
+    after_revision_number: Option<i32>,
+}
+
+#[derive(Debug, FromRow)]
+struct AuthorChange {
+    author_id: Uuid,
+    before_revision_number: Option<i32>,
+    after_revision_number: Option<i32>,
+}
+
+pub async fn undo_operation(
+    pool: &PgPool,
+    user_id: &UserId,
+    target_id: &OperationId,
+) -> Result<OperationId, DomainError> {
+    let mut tx = pool.begin().await?;
+    sqlx::query("SET TRANSACTION ISOLATION LEVEL SERIALIZABLE")
+        .execute(&mut *tx)
+        .await?;
+    let operation_type = sqlx::query_scalar::<_, String>(
+        "SELECT type FROM operation
+         WHERE user_id = $1 AND id = $2
+         FOR UPDATE",
+    )
+    .bind(user_id.as_str())
+    .bind(target_id.to_uuid())
+    .fetch_optional(&mut *tx)
+    .await?
+    .ok_or_else(|| DomainError::NotFound {
+        entity_type: "operation",
+        entity_id: target_id.to_string(),
+        user_id: user_id.as_str().to_owned(),
+    })?;
+    if operation_type == "baseline" {
+        return Err(DomainError::Conflict(
+            "baseline operations cannot be undone".to_owned(),
+        ));
+    }
+
+    let book_changes: Vec<BookChange> = sqlx::query_as(
+        "SELECT book_id, before_revision_number, after_revision_number
+         FROM book_operation_change
+         WHERE user_id = $1 AND operation_id = $2
+         ORDER BY book_id",
+    )
+    .bind(user_id.as_str())
+    .bind(target_id.to_uuid())
+    .fetch_all(&mut *tx)
+    .await?;
+    let author_changes: Vec<AuthorChange> = sqlx::query_as(
+        "SELECT author_id, before_revision_number, after_revision_number
+         FROM author_operation_change
+         WHERE user_id = $1 AND operation_id = $2
+         ORDER BY author_id",
+    )
+    .bind(user_id.as_str())
+    .bind(target_id.to_uuid())
+    .fetch_all(&mut *tx)
+    .await?;
+    if book_changes.is_empty() && author_changes.is_empty() {
+        return Err(DomainError::Conflict(
+            "operation has no entity changes to undo".to_owned(),
+        ));
+    }
+
+    let mut lock_keys = book_changes
+        .iter()
+        .map(|change| format!("book:{}:{}", user_id.as_str(), change.book_id))
+        .chain(
+            author_changes
+                .iter()
+                .map(|change| format!("author:{}:{}", user_id.as_str(), change.author_id)),
+        )
+        .collect::<Vec<_>>();
+    lock_keys.sort_unstable();
+    for key in lock_keys {
+        sqlx::query("SELECT pg_advisory_xact_lock(hashtextextended($1, 0))")
+            .bind(key)
+            .execute(&mut *tx)
+            .await?;
+    }
+
+    let book_ids = book_changes
+        .iter()
+        .map(|change| change.book_id)
+        .collect::<Vec<_>>();
+    sqlx::query(
+        "SELECT id FROM book
+         WHERE user_id = $1 AND id = ANY($2::uuid[])
+         ORDER BY id FOR UPDATE",
+    )
+    .bind(user_id.as_str())
+    .bind(&book_ids)
+    .fetch_all(&mut *tx)
+    .await?;
+    let author_ids = author_changes
+        .iter()
+        .map(|change| change.author_id)
+        .collect::<Vec<_>>();
+    sqlx::query(
+        "SELECT id FROM author
+         WHERE user_id = $1 AND id = ANY($2::uuid[])
+         ORDER BY id FOR UPDATE",
+    )
+    .bind(user_id.as_str())
+    .bind(&author_ids)
+    .fetch_all(&mut *tx)
+    .await?;
+
+    if !matches_after_state(&mut tx, user_id, &book_changes, &author_changes).await? {
+        return Err(DomainError::Conflict(
+            "operation is no longer undoable because an affected entity changed".to_owned(),
+        ));
+    }
+
+    let undo_id = OperationId::new();
+    sqlx::query(
+        "INSERT INTO operation (id, user_id, type, undo_of_operation_id)
+         VALUES ($1, $2, 'undo', $3)",
+    )
+    .bind(undo_id.to_uuid())
+    .bind(user_id.as_str())
+    .bind(target_id.to_uuid())
+    .execute(&mut *tx)
+    .await?;
+
+    for change in author_changes
+        .iter()
+        .filter(|change| change.before_revision_number.is_some())
+    {
+        restore_author(&mut tx, user_id, &undo_id, change).await?;
+    }
+    for change in book_changes
+        .iter()
+        .filter(|change| change.before_revision_number.is_some())
+    {
+        restore_book(&mut tx, user_id, &undo_id, change).await?;
+    }
+    for change in book_changes
+        .iter()
+        .filter(|change| change.before_revision_number.is_none())
+    {
+        delete_book(&mut tx, user_id, &undo_id, change).await?;
+    }
+    for change in author_changes
+        .iter()
+        .filter(|change| change.before_revision_number.is_none())
+    {
+        delete_author(&mut tx, user_id, &undo_id, change).await?;
+    }
+
+    tx.commit().await?;
+    Ok(undo_id)
+}
+
+async fn matches_after_state(
+    tx: &mut Transaction<'_, Postgres>,
+    user_id: &UserId,
+    books: &[BookChange],
+    authors: &[AuthorChange],
+) -> Result<bool, DomainError> {
+    for change in books {
+        let current = sqlx::query_scalar::<_, i32>(
+            "SELECT (SELECT MAX(revision_number) FROM book_revision
+                     WHERE user_id = $1 AND book_id = $2)
+             WHERE EXISTS (SELECT 1 FROM book WHERE user_id = $1 AND id = $2)",
+        )
+        .bind(user_id.as_str())
+        .bind(change.book_id)
+        .fetch_optional(&mut **tx)
+        .await?;
+        if current != change.after_revision_number {
+            return Ok(false);
+        }
+    }
+    for change in authors {
+        let current = sqlx::query_scalar::<_, i32>(
+            "SELECT (SELECT MAX(revision_number) FROM author_revision
+                     WHERE user_id = $1 AND author_id = $2)
+             WHERE EXISTS (SELECT 1 FROM author WHERE user_id = $1 AND id = $2)",
+        )
+        .bind(user_id.as_str())
+        .bind(change.author_id)
+        .fetch_optional(&mut **tx)
+        .await?;
+        if current != change.after_revision_number {
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
+async fn restore_author(
+    tx: &mut Transaction<'_, Postgres>,
+    user_id: &UserId,
+    undo_id: &OperationId,
+    change: &AuthorChange,
+) -> Result<(), DomainError> {
+    let source = change.before_revision_number.expect("filtered revision");
+    let next = next_author_revision(tx, user_id, change.author_id).await?;
+    sqlx::query(
+        "INSERT INTO author (id, user_id, name, yomi, created_at, updated_at)
+         SELECT author_id, user_id, name, yomi, author_created_at, current_timestamp
+         FROM author_revision
+         WHERE user_id = $1 AND author_id = $2 AND revision_number = $3
+         ON CONFLICT (id, user_id) DO UPDATE
+         SET name = EXCLUDED.name, yomi = EXCLUDED.yomi,
+             created_at = EXCLUDED.created_at, updated_at = EXCLUDED.updated_at",
+    )
+    .bind(user_id.as_str())
+    .bind(change.author_id)
+    .bind(source)
+    .execute(&mut **tx)
+    .await?;
+    sqlx::query(
+        "INSERT INTO author_revision (
+           author_id, revision_number, user_id, name, yomi,
+           author_created_at, author_updated_at
+         ) SELECT author_id, $4, user_id, name, yomi,
+                  author_created_at, current_timestamp
+           FROM author_revision
+           WHERE user_id = $1 AND author_id = $2 AND revision_number = $3",
+    )
+    .bind(user_id.as_str())
+    .bind(change.author_id)
+    .bind(source)
+    .bind(next)
+    .execute(&mut **tx)
+    .await?;
+    insert_author_change(
+        tx,
+        user_id,
+        undo_id,
+        change.author_id,
+        change.after_revision_number,
+        Some(next),
+    )
+    .await
+}
+
+async fn restore_book(
+    tx: &mut Transaction<'_, Postgres>,
+    user_id: &UserId,
+    undo_id: &OperationId,
+    change: &BookChange,
+) -> Result<(), DomainError> {
+    let source = change.before_revision_number.expect("filtered revision");
+    let missing_author = sqlx::query_scalar::<_, Uuid>(
+        "SELECT link.author_id
+         FROM book_revision_author link
+         LEFT JOIN author current
+           ON current.user_id = link.user_id AND current.id = link.author_id
+         WHERE link.user_id = $1 AND link.book_id = $2
+           AND link.revision_number = $3 AND current.id IS NULL
+         LIMIT 1",
+    )
+    .bind(user_id.as_str())
+    .bind(change.book_id)
+    .bind(source)
+    .fetch_optional(&mut **tx)
+    .await?;
+    if let Some(author_id) = missing_author {
+        return Err(DomainError::Conflict(format!(
+            "book revision references missing author {author_id}"
+        )));
+    }
+    let next = next_book_revision(tx, user_id, change.book_id).await?;
+    sqlx::query(
+        "INSERT INTO book (
+           id, user_id, title, isbn, read, owned, priority, format, store,
+           created_at, updated_at
+         ) SELECT book_id, user_id, title, isbn, read, owned, priority, format,
+                  store, book_created_at, current_timestamp
+           FROM book_revision
+           WHERE user_id = $1 AND book_id = $2 AND revision_number = $3
+         ON CONFLICT (id, user_id) DO UPDATE
+         SET title = EXCLUDED.title, isbn = EXCLUDED.isbn, read = EXCLUDED.read,
+             owned = EXCLUDED.owned, priority = EXCLUDED.priority,
+             format = EXCLUDED.format, store = EXCLUDED.store,
+             created_at = EXCLUDED.created_at, updated_at = EXCLUDED.updated_at",
+    )
+    .bind(user_id.as_str())
+    .bind(change.book_id)
+    .bind(source)
+    .execute(&mut **tx)
+    .await?;
+    sqlx::query("DELETE FROM book_author WHERE user_id = $1 AND book_id = $2")
+        .bind(user_id.as_str())
+        .bind(change.book_id)
+        .execute(&mut **tx)
+        .await?;
+    sqlx::query(
+        "INSERT INTO book_author (user_id, book_id, author_id)
+         SELECT user_id, book_id, author_id FROM book_revision_author
+         WHERE user_id = $1 AND book_id = $2 AND revision_number = $3",
+    )
+    .bind(user_id.as_str())
+    .bind(change.book_id)
+    .bind(source)
+    .execute(&mut **tx)
+    .await?;
+    sqlx::query(
+        "INSERT INTO book_revision (
+           book_id, revision_number, user_id, title, isbn, read, owned,
+           priority, format, store, book_created_at, book_updated_at
+         ) SELECT book_id, $4, user_id, title, isbn, read, owned, priority,
+                  format, store, book_created_at, current_timestamp
+           FROM book_revision
+           WHERE user_id = $1 AND book_id = $2 AND revision_number = $3",
+    )
+    .bind(user_id.as_str())
+    .bind(change.book_id)
+    .bind(source)
+    .bind(next)
+    .execute(&mut **tx)
+    .await?;
+    sqlx::query(
+        "INSERT INTO book_revision_author (user_id, book_id, revision_number, author_id)
+         SELECT user_id, book_id, $4, author_id FROM book_revision_author
+         WHERE user_id = $1 AND book_id = $2 AND revision_number = $3",
+    )
+    .bind(user_id.as_str())
+    .bind(change.book_id)
+    .bind(source)
+    .bind(next)
+    .execute(&mut **tx)
+    .await?;
+    insert_book_change(
+        tx,
+        user_id,
+        undo_id,
+        change.book_id,
+        change.after_revision_number,
+        Some(next),
+    )
+    .await
+}
+
+async fn delete_book(
+    tx: &mut Transaction<'_, Postgres>,
+    user_id: &UserId,
+    undo_id: &OperationId,
+    change: &BookChange,
+) -> Result<(), DomainError> {
+    sqlx::query("DELETE FROM book_author WHERE user_id = $1 AND book_id = $2")
+        .bind(user_id.as_str())
+        .bind(change.book_id)
+        .execute(&mut **tx)
+        .await?;
+    sqlx::query("DELETE FROM book WHERE user_id = $1 AND id = $2")
+        .bind(user_id.as_str())
+        .bind(change.book_id)
+        .execute(&mut **tx)
+        .await?;
+    insert_book_change(
+        tx,
+        user_id,
+        undo_id,
+        change.book_id,
+        change.after_revision_number,
+        None,
+    )
+    .await
+}
+
+async fn delete_author(
+    tx: &mut Transaction<'_, Postgres>,
+    user_id: &UserId,
+    undo_id: &OperationId,
+    change: &AuthorChange,
+) -> Result<(), DomainError> {
+    sqlx::query("DELETE FROM author WHERE user_id = $1 AND id = $2")
+        .bind(user_id.as_str())
+        .bind(change.author_id)
+        .execute(&mut **tx)
+        .await?;
+    insert_author_change(
+        tx,
+        user_id,
+        undo_id,
+        change.author_id,
+        change.after_revision_number,
+        None,
+    )
+    .await
+}
+
+async fn next_book_revision(
+    tx: &mut Transaction<'_, Postgres>,
+    user_id: &UserId,
+    id: Uuid,
+) -> Result<i32, DomainError> {
+    Ok(sqlx::query_scalar(
+        "SELECT COALESCE(MAX(revision_number), 0) + 1
+         FROM book_revision WHERE user_id = $1 AND book_id = $2",
+    )
+    .bind(user_id.as_str())
+    .bind(id)
+    .fetch_one(&mut **tx)
+    .await?)
+}
+
+async fn next_author_revision(
+    tx: &mut Transaction<'_, Postgres>,
+    user_id: &UserId,
+    id: Uuid,
+) -> Result<i32, DomainError> {
+    Ok(sqlx::query_scalar(
+        "SELECT COALESCE(MAX(revision_number), 0) + 1
+         FROM author_revision WHERE user_id = $1 AND author_id = $2",
+    )
+    .bind(user_id.as_str())
+    .bind(id)
+    .fetch_one(&mut **tx)
+    .await?)
+}
+
+async fn insert_book_change(
+    tx: &mut Transaction<'_, Postgres>,
+    user_id: &UserId,
+    undo_id: &OperationId,
+    id: Uuid,
+    before: Option<i32>,
+    after: Option<i32>,
+) -> Result<(), DomainError> {
+    sqlx::query("INSERT INTO book_operation_change (operation_id, user_id, book_id, before_revision_number, after_revision_number) VALUES ($1, $2, $3, $4, $5)")
+        .bind(undo_id.to_uuid()).bind(user_id.as_str()).bind(id).bind(before).bind(after).execute(&mut **tx).await?;
+    Ok(())
+}
+
+async fn insert_author_change(
+    tx: &mut Transaction<'_, Postgres>,
+    user_id: &UserId,
+    undo_id: &OperationId,
+    id: Uuid,
+    before: Option<i32>,
+    after: Option<i32>,
+) -> Result<(), DomainError> {
+    sqlx::query("INSERT INTO author_operation_change (operation_id, user_id, author_id, before_revision_number, after_revision_number) VALUES ($1, $2, $3, $4, $5)")
+        .bind(undo_id.to_uuid()).bind(user_id.as_str()).bind(id).bind(before).bind(after).execute(&mut **tx).await?;
+    Ok(())
+}
+
+#[cfg(all(test, feature = "test-with-database"))]
+mod tests {
+    use sqlx::PgPool;
+    use uuid::Uuid;
+
+    use crate::{
+        domain::{
+            entity::{
+                operation::{OperationId, OperationType},
+                user::{User, UserId},
+            },
+            repository::{history_repository::HistoryRepository, user_repository::UserRepository},
+        },
+        infrastructure::{
+            history_repository::PgHistoryRepository, user_repository::PgUserRepository,
+        },
+    };
+
+    async fn owner(pool: &PgPool) -> anyhow::Result<UserId> {
+        let user_id = UserId::new("undo-owner".to_owned())?;
+        PgUserRepository::new(pool.clone())
+            .create(&User::new(user_id.clone()))
+            .await?;
+        Ok(user_id)
+    }
+
+    async fn insert_book_revision(
+        pool: &PgPool,
+        user_id: &UserId,
+        book_id: Uuid,
+        revision: i32,
+        title: &str,
+    ) -> anyhow::Result<()> {
+        sqlx::query(
+            "INSERT INTO book_revision (
+               book_id, revision_number, user_id, title, isbn, read, owned,
+               priority, format, store, book_created_at, book_updated_at
+             ) VALUES ($1, $2, $3, $4, '', false, true, 4, 'Printed',
+                       'Unknown', current_timestamp, current_timestamp)",
+        )
+        .bind(book_id)
+        .bind(revision)
+        .bind(user_id.as_str())
+        .bind(title)
+        .execute(pool)
+        .await?;
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn undo_create_deletes_current_book_and_records_inverse(
+        pool: PgPool,
+    ) -> anyhow::Result<()> {
+        let user_id = owner(&pool).await?;
+        let target_id = Uuid::new_v4();
+        let book_id = Uuid::new_v4();
+        sqlx::query("INSERT INTO operation (id, user_id, type) VALUES ($1, $2, 'create_book')")
+            .bind(target_id)
+            .bind(user_id.as_str())
+            .execute(&pool)
+            .await?;
+        sqlx::query("INSERT INTO book (id, user_id, title, isbn, read, owned, priority, format, store) VALUES ($1, $2, 'Book', '', false, true, 4, 'Printed', 'Unknown')")
+            .bind(book_id).bind(user_id.as_str()).execute(&pool).await?;
+        insert_book_revision(&pool, &user_id, book_id, 1, "Book").await?;
+        sqlx::query("INSERT INTO book_operation_change (operation_id, user_id, book_id, after_revision_number) VALUES ($1, $2, $3, 1)")
+            .bind(target_id).bind(user_id.as_str()).bind(book_id).execute(&pool).await?;
+
+        let repository = PgHistoryRepository::new(pool.clone());
+        let undo_id = repository
+            .undo_operation(&user_id, &OperationId::from(target_id))
+            .await?;
+
+        let current: bool =
+            sqlx::query_scalar("SELECT EXISTS (SELECT 1 FROM book WHERE user_id = $1 AND id = $2)")
+                .bind(user_id.as_str())
+                .bind(book_id)
+                .fetch_one(&pool)
+                .await?;
+        assert!(!current);
+        let undo = repository
+            .find_operation(&user_id, &undo_id)
+            .await?
+            .expect("recorded undo");
+        assert_eq!(undo.operation_type, OperationType::Undo);
+        assert_eq!(
+            undo.undo_of_operation_id,
+            Some(OperationId::from(target_id))
+        );
+        let inverse: (Option<i32>, Option<i32>) = sqlx::query_as(
+            "SELECT before_revision_number, after_revision_number
+             FROM book_operation_change WHERE operation_id = $1 AND book_id = $2",
+        )
+        .bind(undo_id.to_uuid())
+        .bind(book_id)
+        .fetch_one(&pool)
+        .await?;
+        assert_eq!(inverse, (Some(1), None));
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn undo_update_restores_snapshot_as_fresh_revision(pool: PgPool) -> anyhow::Result<()> {
+        let user_id = owner(&pool).await?;
+        let target_id = Uuid::new_v4();
+        let book_id = Uuid::new_v4();
+        sqlx::query("INSERT INTO operation (id, user_id, type) VALUES ($1, $2, 'update_book')")
+            .bind(target_id)
+            .bind(user_id.as_str())
+            .execute(&pool)
+            .await?;
+        sqlx::query("INSERT INTO book (id, user_id, title, isbn, read, owned, priority, format, store) VALUES ($1, $2, 'New', '', false, true, 4, 'Printed', 'Unknown')")
+            .bind(book_id).bind(user_id.as_str()).execute(&pool).await?;
+        insert_book_revision(&pool, &user_id, book_id, 1, "Old").await?;
+        insert_book_revision(&pool, &user_id, book_id, 2, "New").await?;
+        sqlx::query("INSERT INTO book_operation_change (operation_id, user_id, book_id, before_revision_number, after_revision_number) VALUES ($1, $2, $3, 1, 2)")
+            .bind(target_id).bind(user_id.as_str()).bind(book_id).execute(&pool).await?;
+
+        let repository = PgHistoryRepository::new(pool.clone());
+        let undo_id = repository
+            .undo_operation(&user_id, &OperationId::from(target_id))
+            .await?;
+
+        let title: String =
+            sqlx::query_scalar("SELECT title FROM book WHERE user_id = $1 AND id = $2")
+                .bind(user_id.as_str())
+                .bind(book_id)
+                .fetch_one(&pool)
+                .await?;
+        assert_eq!(title, "Old");
+        let revision: (String, i32) = sqlx::query_as(
+            "SELECT title, revision_number FROM book_revision
+             WHERE user_id = $1 AND book_id = $2 ORDER BY revision_number DESC LIMIT 1",
+        )
+        .bind(user_id.as_str())
+        .bind(book_id)
+        .fetch_one(&pool)
+        .await?;
+        assert_eq!(revision, ("Old".to_owned(), 3));
+        let inverse: (Option<i32>, Option<i32>) = sqlx::query_as(
+            "SELECT before_revision_number, after_revision_number
+             FROM book_operation_change WHERE operation_id = $1 AND book_id = $2",
+        )
+        .bind(undo_id.to_uuid())
+        .bind(book_id)
+        .fetch_one(&pool)
+        .await?;
+        assert_eq!(inverse, (Some(2), Some(3)));
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn undo_multi_entity_create_deletes_book_before_author(
+        pool: PgPool,
+    ) -> anyhow::Result<()> {
+        let user_id = owner(&pool).await?;
+        let target_id = Uuid::new_v4();
+        let book_id = Uuid::new_v4();
+        let author_id = Uuid::new_v4();
+        sqlx::query("INSERT INTO operation (id, user_id, type) VALUES ($1, $2, 'import_books')")
+            .bind(target_id)
+            .bind(user_id.as_str())
+            .execute(&pool)
+            .await?;
+        sqlx::query("INSERT INTO author (id, user_id, name) VALUES ($1, $2, 'Author')")
+            .bind(author_id)
+            .bind(user_id.as_str())
+            .execute(&pool)
+            .await?;
+        sqlx::query("INSERT INTO author_revision (author_id, revision_number, user_id, name, yomi, author_created_at, author_updated_at) VALUES ($1, 1, $2, 'Author', '', current_timestamp, current_timestamp)")
+            .bind(author_id).bind(user_id.as_str()).execute(&pool).await?;
+        sqlx::query("INSERT INTO book (id, user_id, title, isbn, read, owned, priority, format, store) VALUES ($1, $2, 'Book', '', false, true, 4, 'Printed', 'Unknown')")
+            .bind(book_id).bind(user_id.as_str()).execute(&pool).await?;
+        insert_book_revision(&pool, &user_id, book_id, 1, "Book").await?;
+        sqlx::query("INSERT INTO book_author (user_id, book_id, author_id) VALUES ($1, $2, $3)")
+            .bind(user_id.as_str())
+            .bind(book_id)
+            .bind(author_id)
+            .execute(&pool)
+            .await?;
+        sqlx::query("INSERT INTO book_revision_author (user_id, book_id, revision_number, author_id) VALUES ($1, $2, 1, $3)")
+            .bind(user_id.as_str()).bind(book_id).bind(author_id).execute(&pool).await?;
+        sqlx::query("INSERT INTO book_operation_change (operation_id, user_id, book_id, after_revision_number) VALUES ($1, $2, $3, 1)")
+            .bind(target_id).bind(user_id.as_str()).bind(book_id).execute(&pool).await?;
+        sqlx::query("INSERT INTO author_operation_change (operation_id, user_id, author_id, after_revision_number) VALUES ($1, $2, $3, 1)")
+            .bind(target_id).bind(user_id.as_str()).bind(author_id).execute(&pool).await?;
+
+        PgHistoryRepository::new(pool.clone())
+            .undo_operation(&user_id, &OperationId::from(target_id))
+            .await?;
+
+        let current_count: i64 = sqlx::query_scalar(
+            "SELECT (SELECT COUNT(*) FROM book WHERE user_id = $1) +
+                    (SELECT COUNT(*) FROM author WHERE user_id = $1)",
+        )
+        .bind(user_id.as_str())
+        .fetch_one(&pool)
+        .await?;
+        assert_eq!(current_count, 0);
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn missing_book_author_rolls_back_the_complete_undo(pool: PgPool) -> anyhow::Result<()> {
+        let user_id = owner(&pool).await?;
+        let target_id = Uuid::new_v4();
+        let book_id = Uuid::new_v4();
+        let missing_author_id = Uuid::new_v4();
+        sqlx::query("INSERT INTO operation (id, user_id, type) VALUES ($1, $2, 'update_book')")
+            .bind(target_id)
+            .bind(user_id.as_str())
+            .execute(&pool)
+            .await?;
+        sqlx::query("INSERT INTO book (id, user_id, title, isbn, read, owned, priority, format, store) VALUES ($1, $2, 'Current', '', false, true, 4, 'Printed', 'Unknown')")
+            .bind(book_id).bind(user_id.as_str()).execute(&pool).await?;
+        insert_book_revision(&pool, &user_id, book_id, 1, "Historical").await?;
+        insert_book_revision(&pool, &user_id, book_id, 2, "Current").await?;
+        sqlx::query("INSERT INTO book_revision_author (user_id, book_id, revision_number, author_id) VALUES ($1, $2, 1, $3)")
+            .bind(user_id.as_str()).bind(book_id).bind(missing_author_id).execute(&pool).await?;
+        sqlx::query("INSERT INTO book_operation_change (operation_id, user_id, book_id, before_revision_number, after_revision_number) VALUES ($1, $2, $3, 1, 2)")
+            .bind(target_id).bind(user_id.as_str()).bind(book_id).execute(&pool).await?;
+
+        let result = PgHistoryRepository::new(pool.clone())
+            .undo_operation(&user_id, &OperationId::from(target_id))
+            .await;
+        assert!(result.is_err());
+        let title: String =
+            sqlx::query_scalar("SELECT title FROM book WHERE user_id = $1 AND id = $2")
+                .bind(user_id.as_str())
+                .bind(book_id)
+                .fetch_one(&pool)
+                .await?;
+        assert_eq!(title, "Current");
+        let undo_count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM operation WHERE user_id = $1 AND type = 'undo'",
+        )
+        .bind(user_id.as_str())
+        .fetch_one(&pool)
+        .await?;
+        assert_eq!(undo_count, 0);
+        Ok(())
+    }
+}

--- a/src/presentation/graphql/mutation.rs
+++ b/src/presentation/graphql/mutation.rs
@@ -5,7 +5,8 @@ use async_graphql::{Context, ID, Object};
 use crate::{
     presentation::{error::PresentationalError, extractor::claims::Claims},
     use_case::traits::{
-        author::AuthorCommandUseCase, book::BookCommandUseCase, user::UserCommandUseCase,
+        author::AuthorCommandUseCase, book::BookCommandUseCase, history::HistoryCommandUseCase,
+        user::UserCommandUseCase,
     },
 };
 
@@ -13,31 +14,39 @@ use super::object::{
     Author, AuthorMutationPayload, Book, BookMutationPayload, CreateAuthorInput, CreateBookInput,
     DeleteAuthorPayload, DeleteBookPayload, ImportBookInput, ImportBooksPayload,
     ImportBooksPreview, MergeAuthorPayload, RestoreAuthorPayload, RestoreBookPayload,
-    UpdateAuthorInput, UpdateBookInput, User,
+    UndoOperationPayload, UpdateAuthorInput, UpdateBookInput, User,
 };
 
-pub struct Mutation<UC, BC, AC> {
+pub struct Mutation<UC, BC, AC, HC> {
     user_command: UC,
     book_command: BC,
     author_command: AC,
+    history_command: HC,
 }
 
-impl<UC, BC, AC> Mutation<UC, BC, AC> {
-    pub fn new(user_command: UC, book_command: BC, author_command: AC) -> Self {
+impl<UC, BC, AC, HC> Mutation<UC, BC, AC, HC> {
+    pub fn new(
+        user_command: UC,
+        book_command: BC,
+        author_command: AC,
+        history_command: HC,
+    ) -> Self {
         Self {
             user_command,
             book_command,
             author_command,
+            history_command,
         }
     }
 }
 
 #[Object]
-impl<UC, BC, AC> Mutation<UC, BC, AC>
+impl<UC, BC, AC, HC> Mutation<UC, BC, AC, HC>
 where
     UC: UserCommandUseCase,
     BC: BookCommandUseCase,
     AC: AuthorCommandUseCase,
+    HC: HistoryCommandUseCase,
 {
     async fn register_user(&self, ctx: &Context<'_>) -> Result<User, PresentationalError> {
         let claims = get_claims(ctx)?;
@@ -236,6 +245,21 @@ where
             .preview_import(&claims.sub, books.into_iter().map(Into::into).collect())
             .await?
             .into())
+    }
+
+    async fn undo_operation(
+        &self,
+        ctx: &Context<'_>,
+        operation_id: ID,
+    ) -> Result<UndoOperationPayload, PresentationalError> {
+        let claims = get_claims(ctx)?;
+        let undo_operation_id = self
+            .history_command
+            .undo_operation(&claims.sub, operation_id.as_str())
+            .await?;
+        Ok(UndoOperationPayload {
+            operation_id: ID(undo_operation_id),
+        })
     }
 }
 

--- a/src/presentation/graphql/object.rs
+++ b/src/presentation/graphql/object.rs
@@ -630,6 +630,11 @@ pub struct ImportBooksPayload {
     pub operation_id: ID,
 }
 
+#[derive(Clone, SimpleObject)]
+pub struct UndoOperationPayload {
+    pub operation_id: ID,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Enum)]
 pub enum ImportAuthorStatus {
     Existing,

--- a/src/presentation/graphql/schema.rs
+++ b/src/presentation/graphql/schema.rs
@@ -1,20 +1,20 @@
 use crate::use_case::traits::{
     author::{AuthorCommandUseCase, AuthorQueryUseCase},
     book::{BookCommandUseCase, BookQueryUseCase},
-    history::HistoryQueryUseCase,
+    history::{HistoryCommandUseCase, HistoryQueryUseCase},
     user::{UserCommandUseCase, UserQueryUseCase},
 };
 
 use super::{mutation::Mutation, query::Query};
 use async_graphql::{EmptySubscription, Schema};
 
-pub type GraphqlSchema<UQ, BQ, AQ, HQ, UC, BC, AC> =
-    Schema<Query<UQ, BQ, AQ, HQ>, Mutation<UC, BC, AC>, EmptySubscription>;
+pub type GraphqlSchema<UQ, BQ, AQ, HQ, UC, BC, AC, HC> =
+    Schema<Query<UQ, BQ, AQ, HQ>, Mutation<UC, BC, AC, HC>, EmptySubscription>;
 
-pub fn build_schema<UQ, BQ, AQ, HQ, UC, BC, AC>(
+pub fn build_schema<UQ, BQ, AQ, HQ, UC, BC, AC, HC>(
     query: Query<UQ, BQ, AQ, HQ>,
-    mutation: Mutation<UC, BC, AC>,
-) -> GraphqlSchema<UQ, BQ, AQ, HQ, UC, BC, AC>
+    mutation: Mutation<UC, BC, AC, HC>,
+) -> GraphqlSchema<UQ, BQ, AQ, HQ, UC, BC, AC, HC>
 where
     UQ: UserQueryUseCase,
     BQ: BookQueryUseCase,
@@ -23,6 +23,7 @@ where
     UC: UserCommandUseCase,
     BC: BookCommandUseCase,
     AC: AuthorCommandUseCase,
+    HC: HistoryCommandUseCase,
 {
     Schema::build(query, mutation, EmptySubscription).finish()
 }
@@ -45,7 +46,7 @@ mod tests {
             traits::{
                 author::{MockAuthorCommandUseCase, MockAuthorQueryUseCase},
                 book::{MockBookCommandUseCase, MockBookQueryUseCase},
-                history::MockHistoryQueryUseCase,
+                history::{MockHistoryCommandUseCase, MockHistoryQueryUseCase},
                 user::{MockUserCommandUseCase, MockUserQueryUseCase},
             },
         },
@@ -67,12 +68,17 @@ mod tests {
         )
     }
 
-    fn mutation()
-    -> Mutation<MockUserCommandUseCase, MockBookCommandUseCase, MockAuthorCommandUseCase> {
+    fn mutation() -> Mutation<
+        MockUserCommandUseCase,
+        MockBookCommandUseCase,
+        MockAuthorCommandUseCase,
+        MockHistoryCommandUseCase,
+    > {
         Mutation::new(
             MockUserCommandUseCase::new(),
             MockBookCommandUseCase::new(),
             MockAuthorCommandUseCase::new(),
+            MockHistoryCommandUseCase::new(),
         )
     }
 
@@ -148,6 +154,7 @@ mod tests {
                 MockUserCommandUseCase::new(),
                 MockBookCommandUseCase::new(),
                 author_command,
+                MockHistoryCommandUseCase::new(),
             ),
         );
         let claims = Claims {
@@ -171,6 +178,40 @@ mod tests {
             "e77df9d5-b7bf-47f2-8753-03f285d440e3"
         );
         assert_eq!(json["data"]["createAuthor"]["author"]["name"], "Author");
+    }
+
+    #[tokio::test]
+    async fn undo_operation_returns_the_new_operation_id() {
+        let target_id = "e77df9d5-b7bf-47f2-8753-03f285d440e3";
+        let undo_id = "79455a41-bb67-44a7-966f-2f6fdd04e8ca";
+        let mut history_command = MockHistoryCommandUseCase::new();
+        history_command
+            .expect_undo_operation()
+            .with(predicate::eq("user1"), predicate::eq(target_id))
+            .returning(move |_, _| Ok(undo_id.to_owned()));
+        let schema = build_schema(
+            query(),
+            Mutation::new(
+                MockUserCommandUseCase::new(),
+                MockBookCommandUseCase::new(),
+                MockAuthorCommandUseCase::new(),
+                history_command,
+            ),
+        );
+        let response = schema
+            .execute(
+                async_graphql::Request::from(format!(
+                    "mutation {{ undoOperation(operationId: \"{target_id}\") {{ operationId }} }}"
+                ))
+                .data(Claims {
+                    sub: "user1".to_owned(),
+                    _permissions: None,
+                }),
+            )
+            .await;
+        let json = serde_json::to_value(response).unwrap();
+
+        assert_eq!(json["data"]["undoOperation"]["operationId"], undo_id);
     }
 
     #[tokio::test]

--- a/src/use_case/error.rs
+++ b/src/use_case/error.rs
@@ -34,6 +34,7 @@ impl From<DomainError> for UseCaseError {
                 user_id,
             },
             DomainError::HasAssociatedBooks { .. } => UseCaseError::Conflict(err.to_string()),
+            DomainError::Conflict(message) => UseCaseError::Conflict(message),
             DomainError::InfrastructureError(_) => UseCaseError::Other(anyhow::Error::new(err)),
             DomainError::Unexpected(message) => UseCaseError::Unexpected(message),
         }

--- a/src/use_case/interactor/history.rs
+++ b/src/use_case/interactor/history.rs
@@ -16,13 +16,30 @@ use crate::{
             OperationDto,
         },
         error::UseCaseError,
-        traits::history::HistoryQueryUseCase,
+        traits::history::{HistoryCommandUseCase, HistoryQueryUseCase},
     },
 };
 
 #[derive(Debug, Clone)]
 pub struct HistoryQueryInteractor<HR> {
     repository: HR,
+}
+
+#[async_trait]
+impl<HR: HistoryRepository> HistoryCommandUseCase for HistoryQueryInteractor<HR> {
+    async fn undo_operation(
+        &self,
+        user_id: &str,
+        operation_id: &str,
+    ) -> Result<String, UseCaseError> {
+        let user_id = UserId::new(user_id.to_owned())?;
+        let operation_id = OperationId::try_from(operation_id).map_err(UseCaseError::Validation)?;
+        Ok(self
+            .repository
+            .undo_operation(&user_id, &operation_id)
+            .await?
+            .to_string())
+    }
 }
 
 impl<HR> HistoryQueryInteractor<HR> {
@@ -56,6 +73,19 @@ impl<HR: HistoryRepository> HistoryQueryUseCase for HistoryQueryInteractor<HR> {
             .find_operation(&user_id, &operation_id)
             .await?
             .map(Into::into))
+    }
+
+    async fn is_operation_undoable(
+        &self,
+        user_id: &str,
+        operation_id: &str,
+    ) -> Result<bool, UseCaseError> {
+        let user_id = UserId::new(user_id.to_owned())?;
+        let operation_id = OperationId::try_from(operation_id).map_err(UseCaseError::Validation)?;
+        Ok(self
+            .repository
+            .is_operation_undoable(&user_id, &operation_id)
+            .await?)
     }
 
     async fn book_revisions(
@@ -183,7 +213,8 @@ mod tests {
             entity::operation::OperationId, repository::history_repository::MockHistoryRepository,
         },
         use_case::{
-            interactor::history::HistoryQueryInteractor, traits::history::HistoryQueryUseCase,
+            interactor::history::HistoryQueryInteractor,
+            traits::history::{HistoryCommandUseCase, HistoryQueryUseCase},
         },
     };
 
@@ -194,6 +225,55 @@ mod tests {
             .operation("user1", "invalid")
             .await;
         assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn undo_eligibility_is_scoped_to_the_parsed_owner_and_operation() {
+        let operation_id = OperationId::from(Uuid::new_v4());
+        let expected_id = operation_id.clone();
+        let mut repository = MockHistoryRepository::new();
+        repository
+            .expect_is_operation_undoable()
+            .withf(move |user_id, id| user_id.as_str() == "user1" && id == &expected_id)
+            .return_once(|_, _| Ok(true));
+
+        let result = HistoryQueryInteractor::new(repository)
+            .is_operation_undoable("user1", &operation_id.to_string())
+            .await
+            .unwrap();
+
+        assert!(result);
+    }
+
+    #[tokio::test]
+    async fn undo_eligibility_rejects_invalid_id_before_repository_call() {
+        let repository = MockHistoryRepository::new();
+
+        let result = HistoryQueryInteractor::new(repository)
+            .is_operation_undoable("user1", "invalid")
+            .await;
+
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn undo_returns_the_new_operation_id() {
+        let target_id = OperationId::from(Uuid::new_v4());
+        let undo_id = OperationId::from(Uuid::new_v4());
+        let expected_target = target_id.clone();
+        let expected_undo = undo_id.clone();
+        let mut repository = MockHistoryRepository::new();
+        repository
+            .expect_undo_operation()
+            .withf(move |user_id, id| user_id.as_str() == "user1" && id == &expected_target)
+            .return_once(move |_, _| Ok(expected_undo));
+
+        let result = HistoryQueryInteractor::new(repository)
+            .undo_operation("user1", &target_id.to_string())
+            .await
+            .unwrap();
+
+        assert_eq!(result, undo_id.to_string());
     }
 
     #[tokio::test]

--- a/src/use_case/traits/history.rs
+++ b/src/use_case/traits/history.rs
@@ -20,6 +20,11 @@ pub trait HistoryQueryUseCase: Send + Sync + 'static {
         user_id: &str,
         operation_id: &str,
     ) -> Result<Option<OperationDto>, UseCaseError>;
+    async fn is_operation_undoable(
+        &self,
+        user_id: &str,
+        operation_id: &str,
+    ) -> Result<bool, UseCaseError>;
     async fn book_revisions(
         &self,
         user_id: &str,
@@ -52,4 +57,14 @@ pub trait HistoryQueryUseCase: Send + Sync + 'static {
         user_id: &str,
         operation_ids: &[String],
     ) -> Result<HashMap<String, Vec<AuthorOperationChangeDto>>, UseCaseError>;
+}
+
+#[automock]
+#[async_trait]
+pub trait HistoryCommandUseCase: Send + Sync + 'static {
+    async fn undo_operation(
+        &self,
+        user_id: &str,
+        operation_id: &str,
+    ) -> Result<String, UseCaseError>;
 }


### PR DESCRIPTION
## Summary
- add owned Operation undo with deterministic locking and transaction-time eligibility revalidation
- restore Author and Book snapshots in dependency order while recording fresh Revisions and inverse OperationChanges
- expose undoOperation in GraphQL and cover create, update, delete, import, merge, rollback, and undo-of-undo

## Validation
- cargo fmt --check
- cargo clippy --all-targets --locked -- -D warnings
- cargo test --locked
- DATABASE_URL=postgres://bookshelf:password@localhost:5433/bookshelf cargo test --locked --features test-with-database
- TEST_SERVER_URL=http://localhost:8081 cargo test --locked -p bookshelf-e2e -- --test-threads=1
- openspec validate redesign-history-model --strict

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * GraphQLから操作履歴を取り消せるようになりました。
  * 作成・更新・削除・インポート・著者統合の操作を元の状態へ復元できます。
  * 競合や対象状態の変更を検出し、安全に取り消しを拒否します。
  * 取り消し結果として新しい操作IDを返します。

* **テスト**
  * 状態復元、関連データ、競合時の拒否、原子的なロールバックを検証するテストを追加しました。

* **ドキュメント**
  * 取り消し可能性の判定方針を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->