### PR TITLE
Unify pull request CI workflows

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -2,6 +2,9 @@ name: actionlint
 
 on:
   push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   actionlint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,16 +2,9 @@ name: Continuous integration
 
 on:
   push:
-  workflow_dispatch:
-    inputs:
-      ref:
-        description: Git ref to validate
-        required: true
-        type: string
-      release_pr_head_sha:
-        description: Release pull request head SHA to receive the aggregate status
-        required: true
-        type: string
+    branches:
+      - main
+  pull_request:
 
 permissions:
   contents: read
@@ -26,7 +19,6 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-          ref: ${{ inputs.ref || github.ref }}
       - uses: ./.github/actions/setup-rust-toolchain
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       - run: sudo systemctl start postgresql.service
@@ -44,7 +36,6 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-          ref: ${{ inputs.ref || github.ref }}
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
       - name: Cache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -134,7 +125,6 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-          ref: ${{ inputs.ref || github.ref }}
       - uses: ./.github/actions/setup-rust-toolchain
         with:
           components: rustfmt
@@ -148,7 +138,6 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-          ref: ${{ inputs.ref || github.ref }}
       - uses: ./.github/actions/setup-rust-toolchain
         with:
           components: clippy
@@ -163,7 +152,6 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-          ref: ${{ inputs.ref || github.ref }}
       - run: sudo systemctl start postgresql.service
       - run: pg_isready
       - run: sudo -u postgres psql --command="CREATE USER bookshelf WITH SUPERUSER PASSWORD 'password'" postgres
@@ -181,43 +169,9 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-          ref: ${{ inputs.ref || github.ref }}
       - uses: ./.github/actions/setup-rust-toolchain
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       - name: Generate schema
         run: cargo run --bin gen_schema --locked > /tmp/schema.graphql.generated
       - name: Check schema is up to date
         run: diff schema.graphql /tmp/schema.graphql.generated
-
-  release-pr-status:
-    name: Report release PR CI status
-    if: ${{ always() && github.event_name == 'workflow_dispatch' }}
-    needs: [test, test-image-building, fmt, clippy, migration-test, check-schema]
-    runs-on: ubuntu-latest
-    permissions:
-      statuses: write
-    steps:
-      - name: Report aggregate status
-        env:
-          GH_TOKEN: ${{ github.token }}
-          HEAD_SHA: ${{ inputs.release_pr_head_sha }}
-          REPOSITORY: ${{ github.repository }}
-          RESULTS: ${{ join(needs.*.result, ',') }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: |
-          state=error
-          description="Release PR validation ended without a result"
-          if [[ "${RESULTS}" == "success,success,success,success,success,success" ]]; then
-            state=success
-            description="Release PR validation passed"
-          elif [[ ",${RESULTS}," == *,failure,* ]]; then
-            state=failure
-            description="Release PR validation failed"
-          fi
-
-          gh api --method POST \
-            "repos/${REPOSITORY}/statuses/${HEAD_SHA}" \
-            -f state="${state}" \
-            -f context=release-pr-ci \
-            -f description="${description}" \
-            -f target_url="${RUN_URL}"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -2,16 +2,9 @@ name: E2E tests
 
 on:
   push:
-  workflow_dispatch:
-    inputs:
-      ref:
-        description: Git ref to validate
-        required: true
-        type: string
-      release_pr_head_sha:
-        description: Release pull request head SHA to receive E2E statuses
-        required: true
-        type: string
+    branches:
+      - main
+  pull_request:
 
 permissions:
   contents: read
@@ -26,7 +19,6 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-          ref: ${{ inputs.ref || github.ref }}
       - uses: ./.github/actions/setup-rust-toolchain
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       - name: Start Postgres service
@@ -96,7 +88,6 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-          ref: ${{ inputs.ref || github.ref }}
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: hiterm/bookshelf
@@ -260,77 +251,3 @@ jobs:
       - name: Run e2e-integration tests
         run: pnpm run test:integration
         working-directory: bookshelf-src
-
-  release-pr-api-e2e-status:
-    name: Report release PR API E2E status
-    if: ${{ always() && github.event_name == 'workflow_dispatch' }}
-    needs: e2e
-    runs-on: ubuntu-latest
-    permissions:
-      statuses: write
-    steps:
-      - name: Report API E2E status
-        env:
-          GH_TOKEN: ${{ github.token }}
-          HEAD_SHA: ${{ inputs.release_pr_head_sha }}
-          REPOSITORY: ${{ github.repository }}
-          RESULT: ${{ needs.e2e.result }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: |
-          state=error
-          description="Release PR API E2E ended without a result"
-
-          case "${RESULT}" in
-            success)
-              state=success
-              description="Release PR API E2E passed"
-              ;;
-            failure)
-              state=failure
-              description="Release PR API E2E failed"
-              ;;
-          esac
-
-          gh api --method POST \
-            "repos/${REPOSITORY}/statuses/${HEAD_SHA}" \
-            -f state="${state}" \
-            -f context=release-pr-api-e2e \
-            -f description="${description}" \
-            -f target_url="${RUN_URL}"
-
-  release-pr-frontend-integration-status:
-    name: Report release PR frontend integration status
-    if: ${{ always() && github.event_name == 'workflow_dispatch' }}
-    needs: test-integration-bookshelf
-    runs-on: ubuntu-latest
-    permissions:
-      statuses: write
-    steps:
-      - name: Report frontend integration status
-        env:
-          GH_TOKEN: ${{ github.token }}
-          HEAD_SHA: ${{ inputs.release_pr_head_sha }}
-          REPOSITORY: ${{ github.repository }}
-          RESULT: ${{ needs.test-integration-bookshelf.result }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: |
-          state=error
-          description="Release PR frontend integration ended without a result"
-
-          case "${RESULT}" in
-            success)
-              state=success
-              description="Release PR frontend integration passed"
-              ;;
-            failure)
-              state=failure
-              description="Release PR frontend integration failed"
-              ;;
-          esac
-
-          gh api --method POST \
-            "repos/${REPOSITORY}/statuses/${HEAD_SHA}" \
-            -f state="${state}" \
-            -f context=release-pr-frontend-integration \
-            -f description="${description}" \
-            -f target_url="${RUN_URL}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,11 +16,9 @@ jobs:
     name: Update release pull request or tag release
     runs-on: ubuntu-latest
     permissions:
-      actions: write
       contents: write
       issues: read
       pull-requests: write
-      statuses: write
     outputs:
       release_tag: ${{ steps.release_tag.outputs.tag }}
     steps:
@@ -37,83 +35,6 @@ jobs:
         uses: Songmu/tagpr@d1b8138b7a31075141b6cd64103de9485ced7ac9 # v1.20.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Validate release pull request
-        if: ${{ steps.tagpr.outputs.pull_request != '' && steps.tagpr.outputs.tag == '' }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PULL_REQUEST: ${{ steps.tagpr.outputs.pull_request }}
-        run: |
-          set -euo pipefail
-
-          head_ref=$(jq -er '.head.ref' <<<"${PULL_REQUEST}")
-          pull_request_url=$(jq -er '.html_url' <<<"${PULL_REQUEST}")
-          head_sha=$(gh api \
-            "repos/${GITHUB_REPOSITORY}/git/ref/heads/${head_ref}" \
-            --jq '.object.sha')
-
-          if [[ -z "${head_sha}" ]]; then
-            echo "::error::Could not resolve current release pull request HEAD SHA"
-            exit 1
-          fi
-
-          report_status() {
-            local context=$1
-            local state=$2
-            local description=$3
-
-            gh api --method POST \
-              "repos/${GITHUB_REPOSITORY}/statuses/${head_sha}" \
-              -f state="${state}" \
-              -f context="${context}" \
-              -f description="${description}" \
-              -f target_url="${pull_request_url}"
-          }
-
-          dispatch_workflow() {
-            local workflow=$1
-
-            for attempt in {1..5}; do
-              if gh workflow run "${workflow}" \
-                --ref main \
-                -f ref="${head_sha}" \
-                -f release_pr_head_sha="${head_sha}"; then
-                return 0
-              fi
-
-              if [[ "${attempt}" -lt 5 ]]; then
-                sleep $((attempt * 2))
-              fi
-            done
-
-            return 1
-          }
-
-          report_status release-pr-ci pending "Release PR CI is queued"
-          report_status release-pr-api-e2e pending "Release PR API E2E is queued"
-          report_status release-pr-frontend-integration pending \
-            "Release PR frontend integration is queued"
-
-          dispatch_failed=0
-
-          if ! dispatch_workflow ci.yml; then
-            report_status release-pr-ci error \
-              "Could not dispatch release PR CI"
-            echo "::error::Could not dispatch release pull request CI after 5 attempts"
-            dispatch_failed=1
-          fi
-
-          if ! dispatch_workflow e2e.yml; then
-            report_status release-pr-api-e2e error \
-              "Could not dispatch release PR API E2E"
-            report_status release-pr-frontend-integration error \
-              "Could not dispatch release PR frontend integration"
-            echo "::error::Could not dispatch release pull request E2E after 5 attempts"
-            dispatch_failed=1
-          fi
-
-          if [[ "${dispatch_failed}" -ne 0 ]]; then
-            exit 1
-          fi
       - name: Determine release tag
         id: release_tag
         env:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,6 +1,10 @@
 name: zizmor
 
-on: [push]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   zizmor:

--- a/openspec/changes/archive/2026-08-31-unify-pr-ci-workflows/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-31-unify-pr-ci-workflows/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-31

--- a/openspec/changes/archive/2026-08-31-unify-pr-ci-workflows/design.md
+++ b/openspec/changes/archive/2026-08-31-unify-pr-ci-workflows/design.md
@@ -1,0 +1,46 @@
+## Context
+
+CI and E2E currently run on every push. A second path allows the release workflow to dispatch both workflows against a release PR SHA and then synthesize three commit statuses. That path exists because tagpr creates or updates its release PR with `GITHUB_TOKEN`, whose pull request workflow runs require explicit repository approval.
+
+The desired model accepts that approval boundary. Normal PRs and tagpr release PRs use the same event context, jobs, and check reporting; only the release PR may wait for human approval before those jobs start.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Give ordinary and release PRs one `pull_request`-based CI and E2E path.
+- Retain CI and E2E after pushes to `main` without running them for standalone feature-branch pushes.
+- Remove custom dispatching and commit-status orchestration from the release workflow.
+- Preserve tagpr, release tag validation, and the reusable deploy invocation unchanged apart from permissions no longer needed by the workaround.
+
+**Non-Goals:**
+
+- Avoiding or automating GitHub's approval requirement for tagpr-generated release PR workflows.
+- Introducing a PAT or GitHub App token.
+- Changing branch protection, deploy behavior, release image validation, or frontend integration behavior.
+
+## Decisions
+
+1. CI and E2E use `push` filtered to `main` plus an unfiltered `pull_request` trigger. GitHub's native event context selects the checked-out commit, so explicit ref inputs and checkout overrides are removed. Keeping an all-branch `push` trigger was rejected because it duplicates validation for open feature PRs.
+2. Release PR workflow approval is a human action. tagpr continues to use the repository `GITHUB_TOKEN`; no privileged token or dispatch bypass is added. This retains the intended trust boundary at the cost of release PR checks not starting until approved.
+3. CI and E2E rely on native workflow job conclusions. Release-specific aggregate/status jobs and `statuses: write` permissions are removed because their only consumer was the dispatch workaround.
+4. The release workflow retains only tagpr coordination, release tag discovery/validation, and conditional delegation to the existing deploy reusable workflow. `actions: write` and `statuses: write` are removed from the tagpr job, while `contents: write`, `issues: read`, and `pull-requests: write` remain for tagpr and release operations.
+
+## Risks / Trade-offs
+
+- [A release PR can remain unvalidated while approval is pending] → Document this as intentional and require a human to select `Approve workflows to run` before merge.
+- [Trigger changes could accidentally suppress validation] → Validate workflow syntax and assert that CI/E2E define both `pull_request` and `push.branches: [main]` with no `workflow_dispatch`.
+- [Permission minimization could prevent tagpr operations] → Retain tagpr's existing content, issue, and pull request permissions; only permissions exclusively used by workflow dispatch and status APIs are removed.
+- [Removing feature-branch push runs changes check timing] → Pull request validation remains comprehensive, and `main` continues to be validated after merge.
+
+## Migration Plan
+
+1. Merge the trigger and workaround removals together so the native pull request path replaces the dispatch path atomically.
+2. Confirm the PR itself receives CI and E2E through `pull_request`.
+3. On the next tagpr-generated release PR, approve the pending workflows manually and verify both native workflows run.
+
+Rollback consists of reverting this workflow-only change; no persistent data or external deployment configuration is migrated.
+
+## Open Questions
+
+None.

--- a/openspec/changes/archive/2026-08-31-unify-pr-ci-workflows/proposal.md
+++ b/openspec/changes/archive/2026-08-31-unify-pr-ci-workflows/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+Release pull requests currently bypass the repository's normal pull request validation path through explicit workflow dispatches and hand-written commit statuses. This duplicates CI orchestration inside the release workflow and obscures the intended GitHub approval boundary for workflows triggered by tagpr's `GITHUB_TOKEN`.
+
+## What Changes
+
+- Run CI and E2E on every `pull_request` event and on pushes to `main`, while no longer running them directly for feature-branch pushes.
+- Remove release-PR-only workflow dispatch inputs, checkout overrides, aggregate status jobs, and status-write permissions from CI and E2E.
+- Remove release PR validation dispatching, retries, and manual commit-status reporting from the release workflow.
+- Keep tagpr on `GITHUB_TOKEN` and intentionally require a human to approve the resulting release PR workflows before CI and E2E begin.
+- Limit the release workflow to updating or creating the release PR and, after merge, validating the release tag and invoking the existing deploy workflow.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `release-validation-pipeline`: Replace release-PR-specific dispatch and status requirements with a unified pull request validation model and explicit human approval for tagpr-generated release PR workflows, while preserving release publication validation and deployment behavior.
+
+## Impact
+
+- Affected workflows: `.github/workflows/ci.yml`, `.github/workflows/e2e.yml`, and `.github/workflows/release.yml`.
+- Affected GitHub behavior: release PR checks appear as ordinary pull request workflow runs and remain approval-required until a human selects `Approve workflows to run`.
+- No PAT or GitHub App token is introduced, branch protection is not changed, and the deploy reusable workflow is unchanged.

--- a/openspec/changes/archive/2026-08-31-unify-pr-ci-workflows/proposal.md
+++ b/openspec/changes/archive/2026-08-31-unify-pr-ci-workflows/proposal.md
@@ -4,7 +4,7 @@ Release pull requests currently bypass the repository's normal pull request vali
 
 ## What Changes
 
-- Run CI and E2E on every `pull_request` event and on pushes to `main`, while no longer running them directly for feature-branch pushes.
+- Run CI and E2E on the default `pull_request` activity types (`opened`, `synchronize`, and `reopened`) and on pushes to `main`, while no longer running them directly for feature-branch pushes.
 - Remove release-PR-only workflow dispatch inputs, checkout overrides, aggregate status jobs, and status-write permissions from CI and E2E.
 - Remove release PR validation dispatching, retries, and manual commit-status reporting from the release workflow.
 - Keep tagpr on `GITHUB_TOKEN` and intentionally require a human to approve the resulting release PR workflows before CI and E2E begin.

--- a/openspec/changes/archive/2026-08-31-unify-pr-ci-workflows/specs/release-validation-pipeline/spec.md
+++ b/openspec/changes/archive/2026-08-31-unify-pr-ci-workflows/specs/release-validation-pipeline/spec.md
@@ -1,9 +1,4 @@
-# release-validation-pipeline Specification
-
-## Purpose
-Define the unified pull request, release validation, and deployment pipeline.
-
-## Requirements
+## ADDED Requirements
 
 ### Requirement: Unified pull request validation
 The repository SHALL run the same CI and E2E workflows for ordinary pull requests and tagpr release pull requests through the `pull_request` event, without release-specific workflow dispatches or hand-written commit statuses.
@@ -45,39 +40,19 @@ The release workflow SHALL create or update the release pull request on pushes t
 - **WHEN** tagpr creates a release tag or an existing valid release tag points at the pushed commit
 - **THEN** the release workflow validates the tag and invokes the existing deploy reusable workflow with that tag
 
-### Requirement: API E2E gates release publication
-The deployment workflow MUST run API E2E against a release Docker image with PostgreSQL and the API-side JWKS server before publishing the image.
+## REMOVED Requirements
 
-#### Scenario: API E2E fails
-- **WHEN** API E2E against the release container fails
-- **THEN** the workflow does not push the image to GHCR and does not trigger Render deployment
+### Requirement: Immediate independent release PR statuses
+**Reason**: Release pull requests now use native CI and E2E workflow checks instead of synthesized status contexts.
 
-#### Scenario: API E2E succeeds
-- **WHEN** API E2E against the release container succeeds
-- **THEN** the workflow makes that validated image eligible for GHCR publication
+**Migration**: Use the job results from the `pull_request` CI and E2E workflow runs after human approval.
 
-### Requirement: Published image is the validated image
-The deployment workflow SHALL build the release image once and SHALL push the same image that passed API E2E without rebuilding it.
+### Requirement: Release PR E2E dispatch
+**Reason**: E2E now runs from the native `pull_request` event and no longer accepts a release PR SHA through `workflow_dispatch`.
 
-#### Scenario: Validated image is published
-- **WHEN** the publication job receives the validated image
-- **THEN** it verifies the image identity and pushes it without invoking another image build
-- **AND** the published image retains the release OCI labels applied before validation
+**Migration**: Approve the tagpr-generated pull request workflows and use their native event context.
 
-### Requirement: Frontend compatibility does not gate deployment
-After successful image publication, the workflow SHALL run Render deployment and `Integration tests (bookshelf frontend)` as independent jobs, and a frontend integration failure SHALL fail the workflow without stopping or cancelling deployment.
+### Requirement: Status contexts are informational
+**Reason**: The three release-specific status contexts are removed with the dispatch workaround.
 
-#### Scenario: Frontend integration fails
-- **WHEN** the published release image is incompatible with the frontend `main` branch
-- **THEN** the frontend integration job and workflow fail while the Render deployment remains eligible to complete
-
-#### Scenario: Render deployment fails
-- **WHEN** Render deployment fails
-- **THEN** the frontend integration job remains independently eligible to complete
-
-### Requirement: Release runs are serialized
-The release workflow SHALL use the `release` concurrency group and SHALL NOT cancel an in-progress release run when a newer run is queued.
-
-#### Scenario: A second release run starts
-- **WHEN** a release workflow is already in progress
-- **THEN** the newer run waits for the active run instead of cancelling it
+**Migration**: No branch protection migration is required; use native workflow checks for pull request validation.

--- a/openspec/changes/archive/2026-08-31-unify-pr-ci-workflows/tasks.md
+++ b/openspec/changes/archive/2026-08-31-unify-pr-ci-workflows/tasks.md
@@ -1,0 +1,14 @@
+## 1. Unify pull request workflows
+
+- [x] 1.1 Restrict CI to pushes on `main` and pull request events, then remove dispatch inputs, checkout ref overrides, and the release PR status job.
+- [x] 1.2 Restrict E2E to pushes on `main` and pull request events, then remove dispatch inputs, checkout ref overrides, and both release PR status jobs.
+
+## 2. Simplify release coordination
+
+- [x] 2.1 Remove release PR HEAD resolution, workflow dispatch retries, and manual commit-status reporting from the release workflow.
+- [x] 2.2 Remove the release job's `actions: write` and `statuses: write` permissions while preserving tagpr, tag validation, release, and deploy behavior.
+
+## 3. Verify the unified model
+
+- [x] 3.1 Validate workflow syntax and assert the expected event triggers, permissions, and absence of release-specific dispatch/status configuration.
+- [x] 3.2 Run the required Rust formatting, lint, and unit test checks; leave frontend integration execution to CI.

--- a/openspec/changes/archive/2026-08-31-unify-static-analysis-triggers/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-31-unify-static-analysis-triggers/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-31

--- a/openspec/changes/archive/2026-08-31-unify-static-analysis-triggers/design.md
+++ b/openspec/changes/archive/2026-08-31-unify-static-analysis-triggers/design.md
@@ -1,0 +1,33 @@
+## Context
+
+CI and E2E already run for the default pull request activities and pushes to `main`. Actionlint and zizmor still run for every push, which duplicates work on feature branches and does not present those tools through the same release PR approval path.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Apply the existing PR-centered trigger model to actionlint and zizmor.
+- Preserve checks on `main` and allow tagpr release PR checks after human approval.
+
+**Non-Goals:**
+
+- Changing either static analysis job, permission set, tool version, or command.
+- Changing Renovate configuration validation.
+- Expanding the default `pull_request` activity types.
+
+## Decisions
+
+Both workflows use the same expanded YAML trigger form as CI and E2E: `push.branches: [main]` plus `pull_request`. The compact zizmor `on: [push]` form is expanded only as needed to express the branch filter and PR trigger.
+
+## Risks / Trade-offs
+
+- [Static analysis no longer runs for an isolated feature-branch push] → The checks run when the branch opens or updates a pull request, and continue to run after merge on `main`.
+- [Trigger syntax could diverge across workflows] → Run actionlint against the complete workflow set and compare the four trigger declarations.
+
+## Migration Plan
+
+Merge the two trigger changes together. Existing PR synchronization will exercise both checks; rollback is a workflow-only revert.
+
+## Open Questions
+
+None.

--- a/openspec/changes/archive/2026-08-31-unify-static-analysis-triggers/proposal.md
+++ b/openspec/changes/archive/2026-08-31-unify-static-analysis-triggers/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+Actionlint and zizmor still run on every branch push, while CI and E2E now use the unified pull request and `main` push model. Aligning the static analysis workflows removes duplicate feature-branch runs and gives ordinary and tagpr release pull requests the same native Checks.
+
+## What Changes
+
+- Run actionlint and zizmor on the default `pull_request` activity types and on pushes to `main`.
+- Stop running either workflow directly for standalone feature-branch pushes.
+- Leave the path-limited Renovate configuration validation workflow unchanged.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `release-validation-pipeline`: Extend the unified PR and main-only push validation requirements to actionlint and zizmor.
+
+## Impact
+
+- Affected workflows: `.github/workflows/actionlint.yml` and `.github/workflows/zizmor.yml`.
+- No workflow jobs, permissions, tools, or Renovate validation behavior change.

--- a/openspec/changes/archive/2026-08-31-unify-static-analysis-triggers/specs/release-validation-pipeline/spec.md
+++ b/openspec/changes/archive/2026-08-31-unify-static-analysis-triggers/specs/release-validation-pipeline/spec.md
@@ -1,0 +1,23 @@
+## MODIFIED Requirements
+
+### Requirement: Unified pull request validation
+The repository SHALL run CI, E2E, actionlint, and zizmor for ordinary pull requests and tagpr release pull requests through the `pull_request` event, without release-specific workflow dispatches or hand-written commit statuses.
+
+#### Scenario: Ordinary pull request is opened or updated
+- **WHEN** an ordinary pull request emits a supported `pull_request` event
+- **THEN** the CI, E2E, actionlint, and zizmor workflows run using the native pull request event context
+
+#### Scenario: Release pull request is approved for workflow execution
+- **WHEN** a human approves workflow execution for a tagpr-generated release pull request
+- **THEN** the same `pull_request` CI, E2E, actionlint, and zizmor workflows used by ordinary pull requests begin
+
+### Requirement: Main-only push validation
+The repository SHALL run CI, E2E, actionlint, and zizmor for pushes to `main` and SHALL NOT directly run those workflows for a standalone push to another branch.
+
+#### Scenario: Main receives a push
+- **WHEN** a commit is pushed to `main`
+- **THEN** the CI, E2E, actionlint, and zizmor workflows run
+
+#### Scenario: Feature branch receives a push
+- **WHEN** a commit is pushed to a branch other than `main` without a pull request event
+- **THEN** CI, E2E, actionlint, and zizmor do not run directly for that push

--- a/openspec/changes/archive/2026-08-31-unify-static-analysis-triggers/tasks.md
+++ b/openspec/changes/archive/2026-08-31-unify-static-analysis-triggers/tasks.md
@@ -1,0 +1,9 @@
+## 1. Unify static analysis triggers
+
+- [x] 1.1 Change actionlint to run for pushes to `main` and pull request events.
+- [x] 1.2 Change zizmor to run for pushes to `main` and pull request events.
+
+## 2. Verify workflows
+
+- [x] 2.1 Run actionlint and confirm all four general validation workflows use the same trigger model.
+- [x] 2.2 Confirm Renovate configuration validation is unchanged and validate the OpenSpec change.

--- a/openspec/specs/release-validation-pipeline/spec.md
+++ b/openspec/specs/release-validation-pipeline/spec.md
@@ -6,26 +6,26 @@ Define the unified pull request, release validation, and deployment pipeline.
 ## Requirements
 
 ### Requirement: Unified pull request validation
-The repository SHALL run the same CI and E2E workflows for ordinary pull requests and tagpr release pull requests through the `pull_request` event, without release-specific workflow dispatches or hand-written commit statuses.
+The repository SHALL run CI, E2E, actionlint, and zizmor for ordinary pull requests and tagpr release pull requests through the `pull_request` event, without release-specific workflow dispatches or hand-written commit statuses.
 
 #### Scenario: Ordinary pull request is opened or updated
 - **WHEN** an ordinary pull request emits a supported `pull_request` event
-- **THEN** the CI and E2E workflows run using the native pull request event context
+- **THEN** the CI, E2E, actionlint, and zizmor workflows run using the native pull request event context
 
 #### Scenario: Release pull request is approved for workflow execution
 - **WHEN** a human approves workflow execution for a tagpr-generated release pull request
-- **THEN** the same `pull_request` CI and E2E workflows used by ordinary pull requests begin
+- **THEN** the same `pull_request` CI, E2E, actionlint, and zizmor workflows used by ordinary pull requests begin
 
 ### Requirement: Main-only push validation
-The repository SHALL run CI and E2E for pushes to `main` and SHALL NOT directly run those workflows for a standalone push to another branch.
+The repository SHALL run CI, E2E, actionlint, and zizmor for pushes to `main` and SHALL NOT directly run those workflows for a standalone push to another branch.
 
 #### Scenario: Main receives a push
 - **WHEN** a commit is pushed to `main`
-- **THEN** both CI and E2E workflows run
+- **THEN** the CI, E2E, actionlint, and zizmor workflows run
 
 #### Scenario: Feature branch receives a push
 - **WHEN** a commit is pushed to a branch other than `main` without a pull request event
-- **THEN** neither CI nor E2E runs directly for that push
+- **THEN** CI, E2E, actionlint, and zizmor do not run directly for that push
 
 ### Requirement: Human-approved tagpr validation
 Tagpr SHALL continue to use `GITHUB_TOKEN`, and the release process SHALL accept GitHub's approval requirement for pull request workflows generated or updated by that token. The repository MUST NOT use a PAT, GitHub App token, automatic workflow dispatch, or manual commit-status bypass for release pull request validation.


### PR DESCRIPTION
## Summary

- run CI and E2E from `pull_request` for ordinary and tagpr release PRs, plus pushes to `main`
- remove release-PR-only workflow dispatch inputs, checkout overrides, synthesized statuses, retries, and permissions
- keep tagpr on `GITHUB_TOKEN` and intentionally require human approval before release PR workflows run
- preserve release tag validation and the existing reusable deploy flow
- sync and archive the OpenSpec change `unify-pr-ci-workflows`

## Validation

- `actionlint` 1.7.12
- `openspec validate --all --strict`
- `cargo fmt --check`
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo test --locked` (142 passed)

Frontend integration tests were not run locally and are delegated to this PR's E2E workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **CI/CD**
  * プルリクエストと `main` ブランチへの変更で、CI・E2Eテスト・静的解析を自動実行するよう統一しました。
  * リリース用プルリクエストも通常の検証フローで確認されるようになりました。
  * リリース処理を簡素化し、不要な手動実行や個別ステータス報告を廃止しました。
  * リリース後のタグ検証とデプロイ処理は従来どおり維持されています。

* **ドキュメント**
  * 新しいリリース検証フローと移行方針を仕様書・設計書に反映しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->