### PR TITLE
Add Vercel Dockerfile

### DIFF
--- a/Dockerfile.vercel
+++ b/Dockerfile.vercel
@@ -1,0 +1,1 @@
+FROM ghcr.io/hiterm/bookshelf-api:2.16.0


### PR DESCRIPTION
## Summary

- add a root-level Dockerfile.vercel for Vercel container deployments
- reuse the same published image as the Render deployment

## Testing

- cargo fmt --check
- cargo clippy --all-targets --locked -- -D warnings
- cargo test --locked